### PR TITLE
🐛 Add x86_64-linux platform to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.15.5-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.15.5-x86_64-linux)
+      racc (~> 1.4)
     omniauth (2.1.1)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
@@ -262,6 +264,7 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
## 概要

fly.ioへのデプロイエラーの原因を修正しました。
原因は、プロジェクトの Gemfile.lock がリモートビルダーで使用されているもの（この場合は x86_64-linux）とは異なるプラットフォームの依存関係を指定していることだと思われます。