### PR TITLE
10 ユーザー新規登録時のバリデーションとエラーメッセージの設定

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,6 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
 
-  VALID_PASSWORD_REGEX = /\A[a-zA-Z\d]+\z/.freeze
+  VALID_PASSWORD_REGEX = /\A[a-zA-Z\d]+\z/
   validates :password, format: { with: VALID_PASSWORD_REGEX }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,7 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
+
+  VALID_PASSWORD_REGEX = /\A[a-zA-Z\d]+\z/.freeze
+  validates :password, format: { with: VALID_PASSWORD_REGEX }
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,7 @@ module App
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
     config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
     config.session_store :cookie_store, key: '_interslice_session'
     config.middleware.use ActionDispatch::Cookies
     config.middleware.use config.session_store, config.session_options

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,7 @@ module App
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
     config.i18n.default_locale = :ja
-    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
+    config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}')]
     config.session_store :cookie_store, key: '_interslice_session'
     config.middleware.use ActionDispatch::Cookies
     config.middleware.use config.session_store, config.session_options

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -145,3 +145,4 @@ ja:
       taken: "は既に存在します"
       too_short: "%{count}文字以上で入力してください"
       confirmation: "が一致しません"
+      invalid: "は半角英数字のみ使用可能です"

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -142,6 +142,6 @@ ja:
         one: エラーが発生したため %{resource} は保存されませんでした。
         other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"
       blank: "を入力してください"
-      taken: "はすでに存在します"
+      taken: "は既に存在します"
       too_short: "%{count}文字以上で入力してください"
       confirmation: "が一致しません"

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -9,7 +9,7 @@ ja:
         current_password: 現在のパスワード
         current_sign_in_at: 現在のログイン時刻
         current_sign_in_ip: 現在のログインIPアドレス
-        email: Eメール
+        email: メールアドレス
         encrypted_password: 暗号化パスワード
         failed_attempts: 失敗したログイン試行回数
         last_sign_in_at: 最終ログイン時刻
@@ -141,3 +141,7 @@ ja:
       not_saved:
         one: エラーが発生したため %{resource} は保存されませんでした。
         other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"
+      blank: "を入力してください"
+      taken: "はすでに存在します"
+      too_short: "%{count}文字以上で入力してください"
+      confirmation: "が一致しません"

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -143,6 +143,6 @@ ja:
         other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"
       blank: "を入力してください"
       taken: "は既に存在します"
-      too_short: "%{count}文字以上で入力してください"
+      too_short: "は%{count}文字以上で入力してください"
       confirmation: "が一致しません"
       invalid: "は半角英数字のみ使用可能です"


### PR DESCRIPTION
Closes #10 

フロントエンド作業ブランチ → 13-error-message-settings
バックエンド作業ブランチ → 10-error-message-settings

## 概要

- 会員登録フォームで表示させるエラーメッセージを日本語で設定しました。
- パスワードのバリデーションを「半角英数字」のみ可能にしました。（文字数はdeviseのデフォルトで6文字に設定されています）

## 確認方法
/signup画面で、メールアドレスとパスワードを間違えて入力した際の挙動を確認します。

## チェックリスト

【メールアドレス入力時のエラーメッセージ表示チェック】

- [ ] 未入力時　→   「メールアドレスを入力してください」
- [ ] 既に登録済み   →   「メールアドレス は既に存在します」
- [ ] 有効でないフォーマット　→　「メールアドレス は有効ではありません」
    - 「test8@example」などのフォーマット

【パスワード入力時のエラーメッセージ表示チェック】

- [ ] 未入力   →   「パスワード を入力してください」
- [ ] 6文字以下   →   「パスワード 6文字以上で入力してください」
- [ ] 半角英数字以外  →   「パスワード は半角英数字のみ使用可能です」
- [ ] パスワードと確認用に差異がある  →  「パスワード（確認用） が一致しません」

## コメント

バリデーションとエラー表示の設定を行いましたが、設定漏れなどがあればご教授いただきたいです。
