### PR TITLE
ログイン機能実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::API
   include DeviseTokenAuth::Concerns::SetUserByToken
+  include DeviseHackFakeSession
   before_action do
     I18n.locale = :ja
   end

--- a/app/controllers/concerns/devise_hack_fake_session.rb
+++ b/app/controllers/concerns/devise_hack_fake_session.rb
@@ -1,0 +1,23 @@
+module DeviseHackFakeSession
+  extend ActiveSupport::Concern
+
+  class FakeSession < Hash
+    def enabled?
+      false
+    end
+
+    def destroy; end
+  end
+
+  included do
+    before_action :set_fake_session
+
+    private
+
+    def set_fake_session
+      return unless Rails.configuration.respond_to?(:api_only) && Rails.configuration.api_only
+
+      request.env['rack.session'] ||= ::DeviseHackFakeSession::FakeSession.new
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,5 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :validatable, :confirmable
   include DeviseTokenAuth::Concerns::User
 
-  VALID_PASSWORD_REGEX = /\A[a-zA-Z\d]+\z/
-  validates :password, format: { with: VALID_PASSWORD_REGEX }
+  validates :password, custom_password: true, on: :create
 end

--- a/app/validators/custom_password_validator.rb
+++ b/app/validators/custom_password_validator.rb
@@ -2,9 +2,8 @@ class CustomPasswordValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if value.blank?
 
-    unless value =~ /\A[a-zA-Z0-9]+\z/
-      record.errors.add(attribute, :invalid, message: 'は半角英数字のみ使用できます')
-    end
-    
+    return if value =~ /\A[a-zA-Z0-9]+\z/
+
+    record.errors.add(attribute, :invalid, message: 'は半角英数字のみ使用できます')
   end
 end

--- a/app/validators/custom_password_validator.rb
+++ b/app/validators/custom_password_validator.rb
@@ -1,0 +1,10 @@
+class CustomPasswordValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    unless value =~ /\A[a-zA-Z0-9]+\z/
+      record.errors.add(attribute, :invalid, message: 'は半角英数字のみ使用できます')
+    end
+    
+  end
+end

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -1,0 +1,3 @@
+ActiveSupport.on_load(:action_controller) do
+  wrap_parameters false 
+end

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -1,3 +1,3 @@
 ActiveSupport.on_load(:action_controller) do
-  wrap_parameters false 
+  wrap_parameters false
 end

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -146,3 +146,4 @@ ja:
       too_short: "は%{count}文字以上で入力してください"
       confirmation: "が一致しません"
       invalid: "は半角英数字のみ使用可能です"
+      record_invalid: "バリデーションに失敗しました: %{errors}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      mount_devise_token_auth_for 'User', at: 'auth', controllers: {
-        registrations: 'api/v1/auth/registrations'
-      }
+      mount_devise_token_auth_for 'User', at: 'auth', controllers: {}
 
       namespace :auth do
         resources :sessions, only: [:index]


### PR DESCRIPTION
## 概要

ログイン機能実装に伴い、「リクエストパラメーターの変更」と「バリデーションの設定変更」を行いました。

### リクエストパラメーターの変更
ログイン時のリクエストが、`{"session"=>{"email"=>"test3@example.com", "password"=>"[FILTERED]"}}`という形式になっており、`Unpermitted parameter: :session. Context:`というエラーが発生して、ログインが失敗していました。エラーの原因を調べたところ、Rails側のコントローラーで`session`パラメーターが許可されていないことが原因でしたので、session_controller.rbでストロングパラーメーターを指定してみましたが、エラーは解消しませんでした。
ですが、`config/initializers/wrap_parameters.rb`を作成して、リクエストの形式を`{"email"=>"test8@example.com", "password"=>"[FILTERED]"}`という形に変更して、エラーを回避することができました。
もし、わかったらで大丈夫なのですが、このエラーの解決方法が適切だったかどうかも確認していただけると幸いです。

### バリデーションの設定変更
`user.rb`に、passwordに対して「半角英数字のみ使用可能」というバリデーションを設定していましたが、ログイン時のpasswordにも適用されてしまい、バリデーションエラーが発生してしまっていたので、カスタムバリデーションを作成し、対応しました。

## 確認方法

エラーハンドリングが適切に行われているかの確認をお願いいたします。

1. 新規会員登録フォームのバリデーション・エラーメッセージの確認をします。
2. ログイン時のエラーメッセージを確認します。

## 影響範囲

SignUpとSignInのバリデーションとエラーメッセージについて。

## チェックリスト

### /signupのバリデーション・エラーメッセージ確認
- [ ] フォーム未入力 → 「パスワードを入力してください」「メールアドレスを入力してください」

[![Image from Gyazo](https://i.gyazo.com/87ba39d65001ff8ebf04b5afa375c0c0.gif)](https://gyazo.com/87ba39d65001ff8ebf04b5afa375c0c0)

- [ ]　パスワード6文字以下　→   「パスワード は6文字以上で入力してください」

[![Image from Gyazo](https://i.gyazo.com/4ae49de3727da305712f12433438bb02.gif)](https://gyazo.com/4ae49de3727da305712f12433438bb02) 

- [ ] パスワードで半角英数字以外を入力　→   「パスワード は半角英数字のみ使用できます」

[![Image from Gyazo](https://i.gyazo.com/06da99bcabeb906e4ec5b63cc817b3e5.gif)](https://gyazo.com/06da99bcabeb906e4ec5b63cc817b3e5)

- [ ] メールアドレス未入力　→   「メールアドレス を入力してください」

[![Image from Gyazo](https://i.gyazo.com/75ba76e1645f8f268f274ca44c662191.gif)](https://gyazo.com/75ba76e1645f8f268f274ca44c662191)

### /signinのエラーメッセージ

- [ ] ログイン情報に間違いがあった場合は、「ログイン用の認証情報が正しくありません。再度お試しください。」と表示。

[![Image from Gyazo](https://i.gyazo.com/270f3de1e94135571b96805e6f75fac3.gif)](https://gyazo.com/270f3de1e94135571b96805e6f75fac3)


## コメント

バリデーションの設定やエラーメッセージに不備や漏れ・改善点などがありましたら、ご指摘いただけると幸いです。
