### PR TITLE
Fix: 打撃・投手成績が未記入時にレコード作成を拒否するバリデーションを追加

### DIFF
--- a/app/models/batting_average.rb
+++ b/app/models/batting_average.rb
@@ -153,7 +153,7 @@ class BattingAverage < ApplicationRecord
       hit_by_pitch, sacrifice_hit, sacrifice_fly, stealing_base,
       caught_stealing, error
     ]
-    return unless stat_fields.all? { |v| v.nil? || v.zero? }
+    return unless stat_fields.all? { |v| v.nil? || v.to_f.zero? }
 
     errors.add(:base, '打撃成績が未入力です')
   end

--- a/app/models/batting_average.rb
+++ b/app/models/batting_average.rb
@@ -3,6 +3,7 @@ class BattingAverage < ApplicationRecord
   belongs_to :user
 
   validates :game_result_id, uniqueness: true
+  validate :must_have_any_stats
 
   ZERO = 0
 
@@ -141,5 +142,19 @@ class BattingAverage < ApplicationRecord
     total_bases = stats['hit'].to_i + (stats['two_base_hit'].to_i * 2) +
                   (stats['three_base_hit'].to_i * 3) + (stats['home_run'].to_i * 4)
     at_bats.zero? ? ZERO : total_bases.to_f / at_bats
+  end
+
+  private
+
+  def must_have_any_stats
+    stat_fields = [
+      times_at_bat, at_bats, hit, two_base_hit, three_base_hit, home_run,
+      total_bases, runs_batted_in, run, strike_out, base_on_balls,
+      hit_by_pitch, sacrifice_hit, sacrifice_fly, stealing_base,
+      caught_stealing, error
+    ]
+    return unless stat_fields.all? { |v| v.nil? || v.zero? }
+
+    errors.add(:base, '打撃成績が未入力です')
   end
 end

--- a/app/models/pitching_result.rb
+++ b/app/models/pitching_result.rb
@@ -2,6 +2,8 @@ class PitchingResult < ApplicationRecord
   belongs_to :game_result
   belongs_to :user
 
+  validate :must_have_any_stats
+
   INNINGS_PER_GAME = 9
   ZERO = 0
 
@@ -97,5 +99,18 @@ class PitchingResult < ApplicationRecord
 
   def self.safe_divide_round(numerator, denominator, precision)
     denominator.zero? ? ZERO : (numerator / denominator).round(precision)
+  end
+
+  private
+
+  def must_have_any_stats
+    stat_fields = [
+      win, loss, hold, saves, innings_pitched, number_of_pitches,
+      run_allowed, earned_run, hits_allowed, home_runs_hit,
+      strikeouts, base_on_balls, hit_by_pitch
+    ]
+    return unless stat_fields.all? { |v| v.nil? || v.to_f.zero? } && !got_to_the_distance
+
+    errors.add(:base, '投手成績が未入力です')
   end
 end

--- a/spec/models/batting_average_spec.rb
+++ b/spec/models/batting_average_spec.rb
@@ -101,12 +101,45 @@ RSpec.describe BattingAverage, type: :model do
       gr = create(:game_result, user:)
       gr.match_result.update!(date_and_time: Time.zone.local(2025, 1, 10))
       create(:batting_average, game_result: gr, user:,
-                               hit: 0, at_bats: 0, times_at_bat: 0, base_on_balls: 0, strike_out: 0,
+                               hit: 0, at_bats: 0, times_at_bat: 0, base_on_balls: 1, strike_out: 0,
                                two_base_hit: 0, three_base_hit: 0, home_run: 0)
 
       result = described_class.filtered_stats_for_user(user.id, year: '2025')
       expect(result[:batting_average]).to eq(0)
-      expect(result[:on_base_percentage]).to eq(0)
+      expect(result[:on_base_percentage]).to eq(1.0)
+    end
+  end
+
+  describe 'must_have_any_stats validation' do
+    let(:game_result) { create(:game_result, user:) }
+
+    it 'is invalid when all stat fields are zero' do
+      ba = described_class.new(
+        game_result:, user:,
+        times_at_bat: 0, at_bats: 0, hit: 0, two_base_hit: 0, three_base_hit: 0,
+        home_run: 0, total_bases: 0, runs_batted_in: 0, run: 0, strike_out: 0,
+        base_on_balls: 0, hit_by_pitch: 0, sacrifice_hit: 0, sacrifice_fly: 0,
+        stealing_base: 0, caught_stealing: 0, error: 0
+      )
+      expect(ba).not_to be_valid
+      expect(ba.errors[:base]).to include('打撃成績が未入力です')
+    end
+
+    it 'is invalid when all stat fields are nil' do
+      ba = described_class.new(game_result:, user:)
+      expect(ba).not_to be_valid
+      expect(ba.errors[:base]).to include('打撃成績が未入力です')
+    end
+
+    it 'is valid when at least one stat field is non-zero' do
+      ba = described_class.new(
+        game_result:, user:,
+        times_at_bat: 0, at_bats: 0, hit: 0, two_base_hit: 0, three_base_hit: 0,
+        home_run: 0, total_bases: 0, runs_batted_in: 1, run: 0, strike_out: 0,
+        base_on_balls: 0, hit_by_pitch: 0, sacrifice_hit: 0, sacrifice_fly: 0,
+        stealing_base: 0, caught_stealing: 0, error: 0
+      )
+      expect(ba).to be_valid
     end
   end
 end

--- a/spec/models/pitching_result_spec.rb
+++ b/spec/models/pitching_result_spec.rb
@@ -117,12 +117,56 @@ RSpec.describe PitchingResult, type: :model do
       gr = create(:game_result, user:)
       gr.match_result.update!(date_and_time: Time.zone.local(2025, 1, 10))
       create(:pitching_result, game_result: gr, user:,
-                               win: 0, loss: 0, innings_pitched: 0.0, earned_run: 0, strikeouts: 0,
+                               win: 0, loss: 0, innings_pitched: 0.0, earned_run: 0, strikeouts: 1,
                                base_on_balls: 0, hits_allowed: 0)
 
       result = described_class.filtered_pitching_stats_for_user(user.id, year: '2025')
       expect(result[:era]).to eq(0)
       expect(result[:whip]).to eq(0)
+    end
+  end
+
+  describe 'must_have_any_stats validation' do
+    let(:game_result) { create(:game_result, user:) }
+
+    it 'is invalid when all stat fields are zero and got_to_the_distance is false' do
+      pr = described_class.new(
+        game_result:, user:,
+        win: 0, loss: 0, hold: 0, saves: 0, innings_pitched: 0.0,
+        number_of_pitches: 0, got_to_the_distance: false,
+        run_allowed: 0, earned_run: 0, hits_allowed: 0, home_runs_hit: 0,
+        strikeouts: 0, base_on_balls: 0, hit_by_pitch: 0
+      )
+      expect(pr).not_to be_valid
+      expect(pr.errors[:base]).to include('投手成績が未入力です')
+    end
+
+    it 'is invalid when all stat fields are nil' do
+      pr = described_class.new(game_result:, user:)
+      expect(pr).not_to be_valid
+      expect(pr.errors[:base]).to include('投手成績が未入力です')
+    end
+
+    it 'is valid when at least one stat field is non-zero' do
+      pr = described_class.new(
+        game_result:, user:,
+        win: 0, loss: 0, hold: 0, saves: 0, innings_pitched: 3.0,
+        number_of_pitches: 0, got_to_the_distance: false,
+        run_allowed: 0, earned_run: 0, hits_allowed: 0, home_runs_hit: 0,
+        strikeouts: 0, base_on_balls: 0, hit_by_pitch: 0
+      )
+      expect(pr).to be_valid
+    end
+
+    it 'is valid when got_to_the_distance is true even if all numbers are zero' do
+      pr = described_class.new(
+        game_result:, user:,
+        win: 0, loss: 0, hold: 0, saves: 0, innings_pitched: 0.0,
+        number_of_pitches: 0, got_to_the_distance: true,
+        run_allowed: 0, earned_run: 0, hits_allowed: 0, home_runs_hit: 0,
+        strikeouts: 0, base_on_balls: 0, hit_by_pitch: 0
+      )
+      expect(pr).to be_valid
     end
   end
 end


### PR DESCRIPTION
## issue
close ippei-shimizu/buzzbase#224

## 実装概要
BattingAverageとPitchingResultモデルに、全フィールドが0/nilの場合に保存を拒否するカスタムバリデーション(`must_have_any_stats`)を追加。

## 背景
試合結果登録フローで、打撃成績・投手成績が未記入（全項目nil/0）のままでもレコードが作成されてしまい、ランキング汚染や不要データ蓄積の原因になっていた。バックエンドのバリデーションは最終防衛線として機能する。

## やらなかったこと
- 編集モードで既存レコードを全て0にした場合のレコード削除（別issueで対応）

## 受入基準
- [ ] 全フィールド0/nilのBattingAverageが保存拒否される（422）
- [ ] 全フィールド0/nilのPitchingResultが保存拒否される（422）
- [ ] 1つでも非0フィールドがあれば保存できる
- [ ] PitchingResultでgot_to_the_distanceがtrueなら数値が全て0でも保存できる
- [ ] 既存テストが全てパスする

## 実装詳細
### `app/models/batting_average.rb`
- `must_have_any_stats` カスタムバリデーション追加
- 成績フィールド17項目が全てnil/0なら `:base` にエラー追加

### `app/models/pitching_result.rb`
- `must_have_any_stats` カスタムバリデーション追加
- 数値フィールド13項目が全てnil/0 かつ `got_to_the_distance` がfalseならエラー追加
- `innings_pitched` はfloatのため `.to_f.zero?` で判定

### テスト
- `spec/models/batting_average_spec.rb` — バリデーションテスト3件追加、既存の全0テストを修正
- `spec/models/pitching_result_spec.rb` — バリデーションテスト4件追加、既存の全0テストを修正

## スクリーンショット
なし

## 確認手順
1. `docker compose exec back bundle exec rspec spec/models/batting_average_spec.rb spec/models/pitching_result_spec.rb` でテスト実行
2. `docker compose exec back bundle exec rspec` で全テストがパスすることを確認
3. Rails consoleで `BattingAverage.new(game_result_id: 1, user_id: 1).valid?` → `false` を確認

## 影響範囲
- BattingAverageのcreate/update
- PitchingResultのcreate/update

## コード上の懸念点
特になし

## その他
全429テストがパスすることを確認済み。