### PR TITLE
Add: Claude Code用のコーディングルールを追加

### DIFF
--- a/.claude/rules/controller-design.md
+++ b/.claude/rules/controller-design.md
@@ -1,0 +1,40 @@
+# コントローラー設計ルール
+
+## 基本方針: CRUDに帰着させる
+
+- 7アクションのみ: `index`, `show`, `new`, `edit`, `create`, `update`, `destroy`
+- カスタムアクションが欲しくなったら**新しいコントローラーを切る**
+- 例: `POST /cards/:id/close` ではなく `Cards::ClosuresController#create`
+
+## 認証とリソース取得
+
+- `before_action :authenticate_api_v1_user!, only: %i[create update destroy]`
+- リソース取得はスコープを絞る: `current_api_v1_user.game_results.find(params[:id])`
+- **非公開アカウントガード必須**: 他ユーザーのデータを返す前に `user.profile_visible_to?(current_api_v1_user)` をチェック
+
+## レスポンス形式（v2パターンで統一）
+
+```ruby
+# 成功
+render json: resource, serializer: V2::XxxSerializer, status: :ok
+render json: resource, serializer: V2::XxxSerializer, status: :created
+
+# エラー
+render json: { errors: resource.errors.full_messages }, status: :unprocessable_entity
+
+# 削除
+render json: { message: '削除しました' }, status: :ok
+
+# 非公開
+render json: { error: 'このアカウントは非公開です' }, status: :forbidden
+
+# ページネーション
+paginated_response(resources, V2::XxxSerializer)
+```
+
+## 新機能の実装
+
+- **v2パターン**で実装する（シリアライザ使用、N+1回避）
+- v1のモデル`.map`でハッシュ変換するパターンは使わない
+- エラーメッセージは日本語
+- ルーティングは`resources`に`only:`を明示して不要なルートを生やさない

--- a/.claude/rules/general.md
+++ b/.claude/rules/general.md
@@ -1,0 +1,33 @@
+# Ruby / Rails 全般ルール
+
+## 設計原則
+
+- **Rails標準機能を最大限活用する** — 外部gemの追加は最後の手段。Rails本体で解決できないか先に検討する
+- メタプログラミングを避ける — 2-3ケースなら`case`文で十分
+- 明示的なコードを書く — マジックより可読性を優先
+
+## パフォーマンス
+
+- `pluck(:field)` を `.map(&:field)` より優先
+- N+1クエリを避ける — `includes` / `preload` を使う
+- 大量レコードは `find_each` / `in_batches` で処理
+
+## コーディングスタイル
+
+- RuboCop準拠（`Layout/LineLength: 140`, `Metrics/MethodLength: 30`）
+- クラスコメント不要（`Style/Documentation: Disabled`）
+- `frozen_string_literal`コメントは既存ファイルに合わせる（強制しない）
+- 定数は`FREEZE`する（`SORTABLE_COLUMNS = {...}.freeze`）
+
+## セキュリティ
+
+- SQLインジェクション対策: 許可リスト方式 + `Arel.sql`で安全な生SQL
+- パラメータは`Strong Parameters`で絞る
+- ユーザー入力を直接SQLに渡さない
+
+## 開発環境
+
+- コマンドはDocker経由: `docker compose exec back bundle exec ...`
+- マイグレーション: `docker compose exec back bundle exec rails db:migrate`
+- テスト: `docker compose exec back bundle exec rspec`
+- Lint: `docker compose exec back bundle exec rubocop`

--- a/.claude/rules/model-design.md
+++ b/.claude/rules/model-design.md
@@ -1,0 +1,38 @@
+# モデル設計ルール
+
+## 基本方針: Fat Model / Thin Controller
+
+- ビジネスロジックはモデルに集約する
+- コントローラーにドメインロジックを書かない
+- モデルに表現的なメソッドを持たせる（`user.follow(other)`, `user.profile_visible_to?(viewer)`）
+
+## Concerns
+
+- **「has trait / acts as」のセマンティクスがある場合のみ**使う
+- 任意のコード分割コンテナとして使わない
+- `extend ActiveSupport::Concern` + `included`ブロックで定義
+- 配置: `app/models/concerns/`
+
+## バリデーション
+
+- 標準バリデーションマクロを優先（`validates :name, presence: true, length: { maximum: 50 }`）
+- カスタムバリデーションは`validate :method_name`で独立メソッドに切り出す
+- 再利用可能なバリデータは`app/validators/`にクラスとして分離
+- エラーメッセージは日本語（`errors.add(:base, '打撃成績が未入力です')`）
+
+## enum / scope / delegate
+
+- enumは整数マッピング: `enum status: { pending: 0, accepted: 1 }`
+- scopeはラムダ形式: `scope :active, -> { where(active: true) }`
+- `delegate :count, to: :following, prefix: true` で委譲パターンを活用
+
+## コールバック
+
+- **最小限に抑える** — 暗黙の副作用はバグの温床
+- 外部サービス呼び出しは`after_commit`でサービスに委譲: `after_commit :notify_slack, on: :create`
+- コールバック内に複雑なロジックを書かない
+
+## クエリ
+
+- 複雑なクエリはクラスメソッド（`self.aggregate_for_user`）で管理
+- ソート可能カラムは`SORTABLE_COLUMNS`定数で許可リスト管理

--- a/.claude/rules/service-and-serializer.md
+++ b/.claude/rules/service-and-serializer.md
@@ -1,0 +1,44 @@
+# サービスオブジェクト / シリアライザ ルール
+
+## サービスオブジェクト
+
+### 状態を持つサービス — `initialize` + `call` パターン
+
+```ruby
+class Stats::BattingAggregator
+  def initialize(user:, year: nil)
+    @user = user
+    @year = year
+  end
+
+  def call
+    # 処理
+  end
+end
+```
+
+### 状態を持たないサービス — クラスメソッド
+
+```ruby
+class PushNotificationService
+  class << self
+    def send_to_user(user, title:, body:)
+      # 処理
+    end
+  end
+end
+```
+
+### 規約
+
+- Stats系は`Stats::`名前空間 + `TableServiceConcern`で共通ロジック（`safe_divide`, `scope_for_year`）を共有
+- エラーハンドリング: カスタム例外クラスを内部定義（`class InvalidToken < StandardError; end`）
+- ビジネスロジックがモデルに収まるならサービスに切り出さない（Fat Model優先）
+
+## シリアライザ
+
+- `ActiveModel::Serializer`を継承
+- v2は`V2::`名前空間、Adminは`Admin::`名前空間
+- ネストしたリソースは`has_one` / `has_many`で定義してN+1を回避
+- 日付フォーマットはシリアライザ内で変換: `object.published_at&.strftime('%Y-%m-%d')`
+- v1のas_json直接返却パターンは新機能では使わない

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,53 @@
+# テスト規約
+
+## スタック
+
+- RSpec + FactoryBot + Faker + shoulda-matchers
+
+## リクエストスペック
+
+```ruby
+RSpec.describe 'Api::V1::GameResults', type: :request do
+  let(:user) { create(:user) }
+
+  context 'when authenticated' do
+    it 'returns game results' do
+      get '/api/v1/game_results', headers: auth_headers_for(user)
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json.size).to eq(3)
+    end
+  end
+
+  context 'when not authenticated' do
+    it 'returns unauthorized' do
+      get '/api/v1/game_results'
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end
+```
+
+- 認証/未認証の2分岐を基本構造とする
+- 認証ヘッダーは`auth_headers_for(user)`ヘルパー使用
+- JSONの検証は`response.parsed_body`で取得
+
+## モデルスペック
+
+- `describe '#instance_method'` / `describe '.class_method'`で階層化
+- `let!`でテストデータセットアップ
+- `described_class`を使用
+- バリデーション: `expect(record).to be_valid` / `expect(record.errors[:field]).to include('...')`
+
+## FactoryBot
+
+- `sequence`でユニーク値生成
+- `trait`で変形パターン定義
+- `association`で関連オブジェクト自動生成
+- `after(:create)`で関連データ生成が必要な場合のみコールバック使用
+
+## 配置
+
+- 非公開アカウント関連テストは専用ファイルに分離
+- サービススペックは`spec/services/`に配置
+- シリアライザスペックは`spec/serializers/`に`type: :serializer`を明示

--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,5 @@
 
 .serena
 
-# Claude Code settings
-.claude/
-
 # Ruby LSP cache
 .ruby-lsp/


### PR DESCRIPTION
## issue
なし

## 実装概要
Claude Codeがバックエンドのコードを書く際に参照するコーディングルール（`.claude/rules/`）を追加。

## 背景
Claude Codeでコード生成する際に、プロジェクト固有の設計パターンや規約に沿ったコードが生成されるよう、ルールファイルを整備する。Basecamp/37signalsのRails設計思想、Ruby/Railsベストプラクティス、既存コードベースのパターンを融合して作成。

## やらなかったこと
- skillsの追加（rulesとは異なり常時読み込みではないため別対応）

## 受入基準
- [ ] `.claude/rules/`配下に5ファイルが存在する
- [ ] 既存のコードパターンと矛盾するルールがない
- [ ] `.gitignore`の変更で`.claude/`ディレクトリのrulesが追跡可能になっている

## 実装詳細
### 新規ファイル（`.claude/rules/`）
- `model-design.md` — Fat Model、Concerns、バリデーション、enum/scope/delegate、コールバック最小限
- `controller-design.md` — CRUD帰着、認証、非公開アカウントガード、v2レスポンス形式統一
- `service-and-serializer.md` — initialize+callパターン、Stats名前空間、ActiveModel::Serializer規約
- `testing.md` — RSpec構造（認証/未認証の2分岐）、FactoryBot規約、認証ヘルパー
- `general.md` — Rails標準優先、パフォーマンス（pluck/includes）、RuboCop設定、Docker経由コマンド

### 変更ファイル
- `.gitignore` — `.claude/`の除外を削除し、rulesファイルをgit管理対象に変更

## スクリーンショット
なし

## 確認手順
1. `.claude/rules/`配下の各ファイルの内容を確認
2. 既存のCLAUDE.mdと矛盾がないことを確認

## 影響範囲
Claude Codeの動作のみ。アプリケーションコードへの影響なし。

## コード上の懸念点
- `.gitignore`から`.claude/`の除外を完全に削除している。settings.json等のClaude Code設定ファイルもgit管理対象になるが、現時点では問題なし。必要に応じて個別ファイルを`.gitignore`に追加する。

## その他
特になし