### PR TITLE
Add: 大会名（tournament_id）でのフィルタリング機能を追加

### DIFF
--- a/app/controllers/api/v2/dashboards_controller.rb
+++ b/app/controllers/api/v2/dashboards_controller.rb
@@ -16,11 +16,12 @@ module Api
         year = params[:year]
         match_type = convert_match_type(params[:match_type])
         season_id = params[:season_id]
+        tournament_id = params[:tournament_id]
 
         render json: {
           recent_game_results: build_recent_game_results(user),
-          batting_stats: build_batting_stats(user, year:, match_type:, season_id:),
-          pitching_stats: build_pitching_stats(user, year:, match_type:, season_id:),
+          batting_stats: build_batting_stats(user, year:, match_type:, season_id:, tournament_id:),
+          pitching_stats: build_pitching_stats(user, year:, match_type:, season_id:, tournament_id:),
           group_rankings: build_group_rankings(user),
           available_years: build_available_years(user)
         }
@@ -31,7 +32,7 @@ module Api
         user = params[:user_id].present? ? User.find(params[:user_id]) : current_api_v1_user
         render json: build_batting_stats(
           user, year: params[:year], match_type: convert_match_type(params[:match_type]),
-                season_id: params[:season_id]
+                season_id: params[:season_id], tournament_id: params[:tournament_id]
         )
       end
 
@@ -40,7 +41,7 @@ module Api
         user = params[:user_id].present? ? User.find(params[:user_id]) : current_api_v1_user
         render json: build_pitching_stats(
           user, year: params[:year], match_type: convert_match_type(params[:match_type]),
-                season_id: params[:season_id]
+                season_id: params[:season_id], tournament_id: params[:tournament_id]
         )
       end
 
@@ -77,9 +78,9 @@ module Api
           earned_run: pitching.earned_run, strikeouts: pitching.strikeouts }
       end
 
-      def build_batting_stats(user, year: nil, match_type: nil, season_id: nil)
-        aggregate = BattingAverage.filtered_aggregate_for_user(user.id, year:, match_type:, season_id:).take
-        calculated = BattingAverage.filtered_stats_for_user(user.id, year:, match_type:, season_id:)
+      def build_batting_stats(user, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+        aggregate = BattingAverage.filtered_aggregate_for_user(user.id, year:, match_type:, season_id:, tournament_id:).take
+        calculated = BattingAverage.filtered_stats_for_user(user.id, year:, match_type:, season_id:, tournament_id:)
 
         return { aggregate: nil, calculated: nil } unless aggregate && calculated
         return { aggregate: nil, calculated: nil } if batting_all_zero?(aggregate)
@@ -111,9 +112,9 @@ module Api
           iso: calc[:iso], bb_per_k: calc[:bb_per_k], isod: calc[:isod] }
       end
 
-      def build_pitching_stats(user, year: nil, match_type: nil, season_id: nil)
-        aggregate = PitchingResult.filtered_pitching_aggregate_for_user(user.id, year:, match_type:, season_id:).take
-        calculated = PitchingResult.filtered_pitching_stats_for_user(user.id, year:, match_type:, season_id:)
+      def build_pitching_stats(user, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+        aggregate = PitchingResult.filtered_pitching_aggregate_for_user(user.id, year:, match_type:, season_id:, tournament_id:).take
+        calculated = PitchingResult.filtered_pitching_stats_for_user(user.id, year:, match_type:, season_id:, tournament_id:)
 
         return { aggregate: nil, calculated: nil } unless aggregate && calculated
         return { aggregate: nil, calculated: nil } if pitching_all_zero?(aggregate)

--- a/app/controllers/api/v2/game_results_controller.rb
+++ b/app/controllers/api/v2/game_results_controller.rb
@@ -35,7 +35,8 @@ module Api
         year = params[:year]
         match_type = convert_match_type(params[:match_type])
         season_id = params[:season_id]
-        game_results = GameResult.v2_filtered_game_associated_data_user(current_api_v1_user, year, match_type, season_id)
+        tournament_id = params[:tournament_id]
+        game_results = GameResult.v2_filtered_game_associated_data_user(current_api_v1_user, year, match_type, season_id, tournament_id:)
         game_results = game_results.search_by_opponent(params[:search]) if params[:search].present?
         game_results = game_results.reorder(nil).apply_sort(params[:sort_by], params[:sort_order]) if params[:sort_by].present?
         game_results = game_results.page(params[:page]).per(params[:per_page])
@@ -66,7 +67,8 @@ module Api
         year = params[:year]
         match_type = convert_match_type(params[:match_type])
         season_id = params[:season_id]
-        game_results = GameResult.v2_filtered_game_associated_data_user(user, year, match_type, season_id)
+        tournament_id = params[:tournament_id]
+        game_results = GameResult.v2_filtered_game_associated_data_user(user, year, match_type, season_id, tournament_id:)
         game_results = game_results.search_by_opponent(params[:search]) if params[:search].present?
         game_results = game_results.reorder(nil).apply_sort(params[:sort_by], params[:sort_order]) if params[:sort_by].present?
         game_results = game_results.page(params[:page]).per(params[:per_page])

--- a/app/controllers/api/v2/stats_controller.rb
+++ b/app/controllers/api/v2/stats_controller.rb
@@ -9,7 +9,8 @@ module Api
           user_id: target_user_id,
           year: params[:year],
           match_type: convert_match_type(params[:match_type]),
-          season_id: params[:season_id]
+          season_id: params[:season_id],
+          tournament_id: params[:tournament_id]
         ).call
         render json: result
       end
@@ -19,7 +20,8 @@ module Api
           user_id: target_user_id,
           year: params[:year],
           match_type: convert_match_type(params[:match_type]),
-          season_id: params[:season_id]
+          season_id: params[:season_id],
+          tournament_id: params[:tournament_id]
         ).call
         render json: { breakdown: result }
       end
@@ -29,7 +31,8 @@ module Api
           user_id: target_user_id,
           mode: params[:period] || 'yearly',
           year: params[:year],
-          season_id: params[:season_id]
+          season_id: params[:season_id],
+          tournament_id: params[:tournament_id]
         ).call
         render json: { rows: result }
       end
@@ -39,7 +42,8 @@ module Api
           user_id: target_user_id,
           mode: params[:period] || 'yearly',
           year: params[:year],
-          season_id: params[:season_id]
+          season_id: params[:season_id],
+          tournament_id: params[:tournament_id]
         ).call
         render json: { rows: result }
       end
@@ -48,7 +52,8 @@ module Api
         result = Stats::EraTrendService.new(
           user_id: target_user_id,
           year: params[:year],
-          season_id: params[:season_id]
+          season_id: params[:season_id],
+          tournament_id: params[:tournament_id]
         ).call
         render json: { trend: result }
       end
@@ -58,7 +63,8 @@ module Api
           user_id: target_user_id,
           year: params[:year],
           match_type: convert_match_type(params[:match_type]),
-          season_id: params[:season_id]
+          season_id: params[:season_id],
+          tournament_id: params[:tournament_id]
         ).call
         render json: result
       end

--- a/app/models/batting_average.rb
+++ b/app/models/batting_average.rb
@@ -41,15 +41,15 @@ class BattingAverage < ApplicationRecord
      'SUM(error) AS error']
   end
 
-  def self.filtered_aggregate_for_user(user_id, year: nil, match_type: nil, season_id: nil)
+  def self.filtered_aggregate_for_user(user_id, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
     scope = joins(game_result: :match_result).select(*aggregate_columns)
-    scope = apply_filters(scope, year, match_type, season_id:)
+    scope = apply_filters(scope, year, match_type, season_id:, tournament_id:)
     scope.where(batting_averages: { user_id: }).group('batting_averages.user_id')
   end
 
-  def self.stats_for_user(user_id, year: nil, match_type: nil, season_id: nil)
-    if year.present? || match_type.present? || season_id.present?
-      scope = apply_filters(unscoped.joins(game_result: :match_result), year, match_type, season_id:)
+  def self.stats_for_user(user_id, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+    if year.present? || match_type.present? || season_id.present? || tournament_id.present?
+      scope = apply_filters(unscoped.joins(game_result: :match_result), year, match_type, season_id:, tournament_id:)
       result = scope.where(batting_averages: { user_id: }).select(*stats_columns).reorder(nil).take
     else
       result = unscoped.where(user_id:).select(*stats_columns).reorder(nil).take
@@ -75,10 +75,11 @@ class BattingAverage < ApplicationRecord
     alias filtered_stats_for_user stats_for_user
   end
 
-  def self.apply_filters(scope, year, match_type, season_id: nil)
+  def self.apply_filters(scope, year, match_type, season_id: nil, tournament_id: nil)
     scope = scope.where(match_results: { date_and_time: Date.new(year.to_i, 1, 1)..Date.new(year.to_i, 12, 31) }) if year.present? && year.to_s != '通算'
     scope = scope.where(match_results: { match_type: }) if match_type.present? && match_type != '全て'
     scope = scope.where(game_results: { season_id: }) if season_id.present?
+    scope = scope.where(match_results: { tournament_id: }) if tournament_id.present?
     scope
   end
 

--- a/app/models/game_result.rb
+++ b/app/models/game_result.rb
@@ -44,11 +44,12 @@ class GameResult < ApplicationRecord
     end
   end
 
-  def self.filtered_game_associated_data_user(user, year, match_type, season_id = nil)
+  def self.filtered_game_associated_data_user(user, year, match_type, season_id = nil, tournament_id: nil)
     game_results = base_query(user)
     game_results = filter_by_year(game_results, year) if year_filter_applicable?(year)
     game_results = filter_by_match_type(game_results, match_type) if match_type_filter_applicable?(match_type)
     game_results = filter_by_season(game_results, season_id) if season_id.present?
+    game_results = filter_by_tournament(game_results, tournament_id) if tournament_id.present?
 
     map_game_results(game_results)
   end
@@ -78,6 +79,10 @@ class GameResult < ApplicationRecord
 
   def self.filter_by_season(game_results, season_id)
     game_results.where(season_id:)
+  end
+
+  def self.filter_by_tournament(game_results, tournament_id)
+    game_results.where(match_results: { tournament_id: })
   end
 
   def self.map_game_results(game_results)
@@ -138,11 +143,12 @@ class GameResult < ApplicationRecord
   # @param year [String, nil] フィルタ対象の年度（"通算"の場合はフィルタなし）
   # @param match_type [String, nil] フィルタ対象の試合種別（"全て"の場合はフィルタなし）
   # @return [ActiveRecord::Relation<GameResult>] フィルタ済みの試合結果リレーション
-  def self.v2_filtered_game_associated_data_user(user, year, match_type, season_id = nil)
+  def self.v2_filtered_game_associated_data_user(user, year, match_type, season_id = nil, tournament_id: nil)
     game_results = v2_game_associated_data_user(user)
     game_results = filter_by_year(game_results, year) if year_filter_applicable?(year)
     game_results = filter_by_match_type(game_results, match_type) if match_type_filter_applicable?(match_type)
     game_results = filter_by_season(game_results, season_id) if season_id.present?
+    game_results = filter_by_tournament(game_results, tournament_id) if tournament_id.present?
     game_results
   end
 

--- a/app/models/pitching_result.rb
+++ b/app/models/pitching_result.rb
@@ -38,15 +38,15 @@ class PitchingResult < ApplicationRecord
      'SUM(earned_run) AS earned_run']
   end
 
-  def self.filtered_pitching_aggregate_for_user(user_id, year: nil, match_type: nil, season_id: nil)
+  def self.filtered_pitching_aggregate_for_user(user_id, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
     scope = joins(game_result: :match_result).select(*pitching_aggregate_columns)
-    scope = apply_filters(scope, year, match_type, season_id:)
+    scope = apply_filters(scope, year, match_type, season_id:, tournament_id:)
     scope.where(pitching_results: { user_id: }).group('pitching_results.user_id')
   end
 
-  def self.pitching_stats_for_user(user_id, year: nil, match_type: nil, season_id: nil)
-    if year.present? || match_type.present? || season_id.present?
-      scope = apply_filters(joins(game_result: :match_result), year, match_type, season_id:)
+  def self.pitching_stats_for_user(user_id, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+    if year.present? || match_type.present? || season_id.present? || tournament_id.present?
+      scope = apply_filters(joins(game_result: :match_result), year, match_type, season_id:, tournament_id:)
       result = scope.select(*pitching_aggregate_columns)
                     .where(pitching_results: { user_id: })
                     .group('pitching_results.user_id').take
@@ -72,10 +72,11 @@ class PitchingResult < ApplicationRecord
     alias filtered_pitching_stats_for_user pitching_stats_for_user
   end
 
-  def self.apply_filters(scope, year, match_type, season_id: nil)
+  def self.apply_filters(scope, year, match_type, season_id: nil, tournament_id: nil)
     scope = scope.where(match_results: { date_and_time: Date.new(year.to_i, 1, 1)..Date.new(year.to_i, 12, 31) }) if year.present? && year.to_s != '通算'
     scope = scope.where(match_results: { match_type: }) if match_type.present? && match_type != '全て'
     scope = scope.where(game_results: { season_id: }) if season_id.present?
+    scope = scope.where(match_results: { tournament_id: }) if tournament_id.present?
     scope
   end
 

--- a/app/services/stats/batting_stats_table_service.rb
+++ b/app/services/stats/batting_stats_table_service.rb
@@ -14,11 +14,12 @@ module Stats
 
     # mode: :yearly, :monthly, :daily
     # year: required for :monthly and :daily
-    def initialize(user_id:, mode: :yearly, year: nil, season_id: nil)
+    def initialize(user_id:, mode: :yearly, year: nil, season_id: nil, tournament_id: nil)
       @user_id = user_id
       @mode = mode.to_sym
       @year = year
       @season_id = season_id
+      @tournament_id = tournament_id
     end
 
     def call
@@ -36,6 +37,7 @@ module Stats
       scope = BattingAverage.joins(game_result: :match_result)
                             .where(batting_averages: { user_id: @user_id })
       scope = scope.where(game_results: { season_id: @season_id }) if @season_id.present?
+      scope = scope.where(match_results: { tournament_id: @tournament_id }) if @tournament_id.present?
       scope
     end
 

--- a/app/services/stats/era_trend_service.rb
+++ b/app/services/stats/era_trend_service.rb
@@ -4,10 +4,11 @@ module Stats
   class EraTrendService
     INNINGS_PER_GAME = 9
 
-    def initialize(user_id:, year: nil, season_id: nil)
+    def initialize(user_id:, year: nil, season_id: nil, tournament_id: nil)
       @user_id = user_id
       @year = year
       @season_id = season_id
+      @tournament_id = tournament_id
     end
 
     def call
@@ -47,6 +48,7 @@ module Stats
       end
 
       scope = scope.where(game_results: { season_id: @season_id }) if @season_id.present?
+      scope = scope.where(match_results: { tournament_id: @tournament_id }) if @tournament_id.present?
       scope
     end
   end

--- a/app/services/stats/game_summary_service.rb
+++ b/app/services/stats/game_summary_service.rb
@@ -2,11 +2,12 @@
 
 module Stats
   class GameSummaryService
-    def initialize(user_id:, year: nil, match_type: nil, season_id: nil)
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
       @user_id = user_id
       @year = year
       @match_type = match_type
       @season_id = season_id
+      @tournament_id = tournament_id
     end
 
     def call
@@ -30,7 +31,8 @@ module Stats
                         .where(user_id: @user_id)
       scope = apply_year_filter(scope)
       scope = apply_match_type_filter(scope)
-      apply_season_filter(scope)
+      scope = apply_season_filter(scope)
+      apply_tournament_filter(scope)
     end
 
     def apply_year_filter(scope)
@@ -51,6 +53,12 @@ module Stats
       return scope if @season_id.blank?
 
       scope.where(game_results: { season_id: @season_id })
+    end
+
+    def apply_tournament_filter(scope)
+      return scope if @tournament_id.blank?
+
+      scope.where(match_results: { tournament_id: @tournament_id })
     end
 
     # --- win/loss summary ---

--- a/app/services/stats/hit_direction_aggregator.rb
+++ b/app/services/stats/hit_direction_aggregator.rb
@@ -26,11 +26,12 @@ module Stats
 
     HR_RESULT_ID = 10
 
-    def initialize(user_id:, year: nil, match_type: nil, season_id: nil)
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
       @user_id = user_id
       @year = year
       @match_type = match_type
       @season_id = season_id
+      @tournament_id = tournament_id
     end
 
     def call
@@ -94,7 +95,8 @@ module Stats
                              .where(user_id: @user_id)
       scope = apply_year_filter(scope)
       scope = apply_match_type_filter(scope)
-      apply_season_filter(scope)
+      scope = apply_season_filter(scope)
+      apply_tournament_filter(scope)
     end
 
     def apply_year_filter(scope)
@@ -115,6 +117,12 @@ module Stats
       return scope if @season_id.blank?
 
       scope.where(game_results: { season_id: @season_id })
+    end
+
+    def apply_tournament_filter(scope)
+      return scope if @tournament_id.blank?
+
+      scope.where(match_results: { tournament_id: @tournament_id })
     end
   end
 end

--- a/app/services/stats/pitching_stats_table_service.rb
+++ b/app/services/stats/pitching_stats_table_service.rb
@@ -15,11 +15,12 @@ module Stats
 
     # mode: :yearly, :monthly, :daily
     # year: required for :monthly and :daily
-    def initialize(user_id:, mode: :yearly, year: nil, season_id: nil)
+    def initialize(user_id:, mode: :yearly, year: nil, season_id: nil, tournament_id: nil)
       @user_id = user_id
       @mode = mode.to_sym
       @year = year
       @season_id = season_id
+      @tournament_id = tournament_id
     end
 
     def call
@@ -38,6 +39,7 @@ module Stats
                             .where(pitching_results: { user_id: @user_id })
                             .where('pitching_results.innings_pitched > 0')
       scope = scope.where(game_results: { season_id: @season_id }) if @season_id.present?
+      scope = scope.where(match_results: { tournament_id: @tournament_id }) if @tournament_id.present?
       scope
     end
 

--- a/app/services/stats/plate_appearance_breakdown_service.rb
+++ b/app/services/stats/plate_appearance_breakdown_service.rb
@@ -13,11 +13,12 @@ module Stats
       'その他' => [5, 6, 11, 12, 17, 18, 19]
     }.freeze
 
-    def initialize(user_id:, year: nil, match_type: nil, season_id: nil)
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
       @user_id = user_id
       @year = year
       @match_type = match_type
       @season_id = season_id
+      @tournament_id = tournament_id
     end
 
     def call
@@ -42,7 +43,8 @@ module Stats
                              .where(user_id: @user_id)
       scope = apply_year_filter(scope)
       scope = apply_match_type_filter(scope)
-      apply_season_filter(scope)
+      scope = apply_season_filter(scope)
+      apply_tournament_filter(scope)
     end
 
     def apply_year_filter(scope)
@@ -63,6 +65,12 @@ module Stats
       return scope if @season_id.blank?
 
       scope.where(game_results: { season_id: @season_id })
+    end
+
+    def apply_tournament_filter(scope)
+      return scope if @tournament_id.blank?
+
+      scope.where(match_results: { tournament_id: @tournament_id })
     end
   end
 end


### PR DESCRIPTION
## issue
close ippei-shimizu/buzzbase#212

## 実装概要
試合結果・成績の絞り込みに大会名（tournament_id）フィルターを追加した。既存の `apply_filters` パターンを踏襲し、各モデル・サービス・コントローラーに `tournament_id` パラメータを透過的に追加した。

## 背景
`match_results` テーブルには `tournament_id` カラムが既に存在していたが、フィルタリングには使われていなかった。ユーザーが大会単位で自分の成績を確認できるようにするため実装が必要だった。

## やらなかったこと
- フロントエンド（Web）への対応（モバイルアプリのみ対応）

## 受入基準
- [ ] `tournament_id` パラメータを渡すと試合結果が大会でフィルタリングされる
- [ ] 打撃・投球成績が大会でフィルタリングされる
- [ ] スプレーチャート・ドーナツグラフ・ERA推移グラフが大会でフィルタリングされる
- [ ] ダッシュボード（batting_stats / pitching_stats）が大会でフィルタリングされる

## 実装詳細

### モデル層
- `GameResult`: `filter_by_tournament` クラスメソッドを追加。`v2_filtered_game_associated_data_user` / `filtered_game_associated_data_user` に `tournament_id:` 引数を追加
- `BattingAverage#apply_filters`: `tournament_id:` キーワード引数を追加し、`match_results.tournament_id` でスコープ絞り込み
- `PitchingResult#apply_filters`: 同上

### コントローラー層
- `Api::V2::GameResultsController`: `filtered_index` / `filtered_show_user` に `params[:tournament_id]` を追加
- `Api::V2::StatsController`: 全6アクション（hit_directions, plate_appearance_breakdown, batting, pitching, era_trend, game_summary）に `tournament_id:` を追加
- `Api::V2::DashboardsController`: `batting_stats` / `pitching_stats` / `show` に `tournament_id:` を追加

### サービス層
- `Stats::HitDirectionAggregator`, `Stats::PlateAppearanceBreakdownService`, `Stats::BattingStatsTableService`, `Stats::PitchingStatsTableService`, `Stats::EraTrendService`, `Stats::GameSummaryService` の `initialize` に `tournament_id: nil` を追加し、`apply_filters` に渡す

## スクリーンショット
なし（API変更のみ）

## 確認手順
1. `docker compose up` で開発環境起動
2. API に `tournament_id` パラメータを付けてリクエストし、該当大会の試合のみが返ることを確認
   - `GET /api/v2/game_results/filtered_index?tournament_id=<id>`
   - `GET /api/v2/stats/batting?tournament_id=<id>`

## 影響範囲
- 試合結果一覧・詳細フィルタリング
- 成績集計（打撃・投球）
- ダッシュボード成績表示

## コード上の懸念点
特になし

## その他
特になし