### PR TITLE
Update: ユーザー検索結果を登録日が新しい順にソート

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -114,6 +114,7 @@ module Api
       def search
         query = params[:query]
         users = User.where('name LIKE ? OR user_id LIKE ?', "%#{query}%", "%#{query}%")
+                    .order(created_at: :desc)
         render json: users.map { |user|
           user.as_json.merge(is_private: user.is_private?)
         }


### PR DESCRIPTION
## issue
close ippei-shimizu/buzzbase#225

## 実装概要
ユーザー検索API（`GET /api/v1/users/search`）のクエリに `.order(created_at: :desc)` を追加し、検索結果を登録日が新しい順で返すようにした。

## 背景
これまで `User.where(...)` に ORDER 句がなく、DB のデフォルト順（ID 昇順）で返されていた。新規ユーザーが検索結果の先頭に表示されるよう、登録日降順でソートする必要があった。

## やらなかったこと
特になし

## 受入基準
- [ ] `GET /api/v1/users/search?query=<任意>` のレスポンスが `created_at` 降順になっている
- [ ] 既存テスト（`spec/requests/api/v1/users_private_account_spec.rb`）が通る

## 実装詳細
`back/app/controllers/api/v1/users_controller.rb` の `search` メソッドに `.order(created_at: :desc)` を追加した。

```ruby
users = User.where('name LIKE ? OR user_id LIKE ?', "%#{query}%", "%#{query}%")
            .order(created_at: :desc)
```

フロントエンド・モバイルは API の返却順をそのままレンダリングするため、変更不要。

## スクリーンショット
なし

## 確認手順
1. `docker compose up` で開発環境起動
2. `GET /api/v1/users/search?query=test` を呼び出す
3. レスポンスの `created_at` が降順になっていることを確認
4. `docker compose exec back bundle exec rspec spec/requests/api/v1/users_private_account_spec.rb` でテスト通過を確認

## 影響範囲
- ユーザー検索機能（Web フロントエンド・モバイルアプリ共通）

## コード上の懸念点
特になし

## その他
特になし