### PR TITLE
鍵アカウントのフォローリクエスト承諾・却下機能（API側）

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -32,6 +32,7 @@ module Api
 
         follow_status = current_api_v1_user ? current_api_v1_user.follow_status(user) : 'none'
         is_following = follow_status == 'following'
+        incoming_request_id = current_api_v1_user&.incoming_follow_request_id_from(user)
 
         if user.profile_visible_to?(current_api_v1_user)
           render json: {
@@ -40,7 +41,8 @@ module Api
             follow_status:,
             following_count: user.following_count,
             followers_count: user.followers_count,
-            is_private: user.is_private?
+            is_private: user.is_private?,
+            incoming_follow_request_id: incoming_request_id
           }
         else
           render json: {
@@ -49,7 +51,8 @@ module Api
             follow_status:,
             following_count: nil,
             followers_count: nil,
-            is_private: user.is_private?
+            is_private: user.is_private?,
+            incoming_follow_request_id: incoming_request_id
           }
         end
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -118,6 +118,10 @@ class User < ActiveRecord::Base
     followers.include?(viewer)
   end
 
+  def incoming_follow_request_id_from(other_user)
+    pending_follow_requests.find_by(follower_id: other_user.id)&.id
+  end
+
   def approve_all_pending_requests!
     pending_follow_requests.update_all(status: :accepted) # rubocop:disable Rails/SkipsModelValidations
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,6 +119,8 @@ class User < ActiveRecord::Base
   end
 
   def incoming_follow_request_id_from(other_user)
+    return nil unless other_user
+
     pending_follow_requests.find_by(follower_id: other_user.id)&.id
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -275,6 +275,23 @@ RSpec.describe User, type: :model do
       end
     end
 
+    describe '#incoming_follow_request_id_from' do
+      it 'returns the relationship id when a pending request exists from the other user' do
+        requester = create(:user)
+        relationship = Relationship.create!(follower: requester, followed: private_user, status: :pending)
+
+        expect(private_user.incoming_follow_request_id_from(requester)).to eq(relationship.id)
+      end
+
+      it 'returns nil when no pending request exists from the other user' do
+        expect(private_user.incoming_follow_request_id_from(non_follower)).to be_nil
+      end
+
+      it 'returns nil when the relationship is already accepted' do
+        expect(private_user.incoming_follow_request_id_from(follower)).to be_nil
+      end
+    end
+
     describe '#approve_all_pending_requests!' do
       it 'accepts all pending follow requests' do
         requester1 = create(:user)

--- a/spec/requests/api/v1/users_private_account_spec.rb
+++ b/spec/requests/api/v1/users_private_account_spec.rb
@@ -53,6 +53,34 @@ RSpec.describe 'Api::V1::Users - Private Account', type: :request do
       end
     end
 
+    context 'when the viewed user has sent a pending follow request to the current user' do
+      let(:requester) { create(:user, user_id: 'requester') }
+      let(:receiver) { create(:user, user_id: 'receiver', is_private: true) }
+      let!(:pending_request) { Relationship.create!(follower: requester, followed: receiver, status: :pending) }
+
+      it 'returns the incoming_follow_request_id' do
+        get '/api/v1/users/show_user_id_data',
+            params: { user_id: requester.user_id },
+            headers: auth_headers_for(receiver)
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json['incoming_follow_request_id']).to eq(pending_request.id)
+      end
+    end
+
+    context 'when there is no pending follow request from the viewed user' do
+      it 'returns null for incoming_follow_request_id' do
+        get '/api/v1/users/show_user_id_data',
+            params: { user_id: public_user.user_id },
+            headers: auth_headers_for(non_follower)
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json['incoming_follow_request_id']).to be_nil
+      end
+    end
+
     context 'when viewing a private user without authentication' do
       it 'returns minimal profile data' do
         get '/api/v1/users/show_user_id_data',

--- a/spec/requests/api/v1/users_private_account_spec.rb
+++ b/spec/requests/api/v1/users_private_account_spec.rb
@@ -91,6 +91,7 @@ RSpec.describe 'Api::V1::Users - Private Account', type: :request do
         expect(json['is_private']).to be true
         expect(json['following_count']).to be_nil
         expect(json['followers_count']).to be_nil
+        expect(json['incoming_follow_request_id']).to be_nil
       end
     end
   end


### PR DESCRIPTION
## issue
close ippei-shimizu/buzzbase#236

## 実装概要
プロフィール詳細APIのレスポンスに `incoming_follow_request_id` フィールドを追加。閲覧対象ユーザーから自分へのペンディング中フォローリクエストがある場合、そのrelationship IDを返す。

## 背景
モバイルアプリで鍵アカウントにフォローリクエストが来た際に承諾・却下する動線がなかった。モバイル側で承認・拒否UIを実装するために、プロフィールAPI側で「この人から自分へのフォローリクエストが来ているか」を判定できるフィールドが必要だった。

## やらなかったこと
特になし

## 受入基準
- [ ] 相手から自分への保留中リクエストがある場合、`incoming_follow_request_id` にrelationship IDが返る
- [ ] リクエストがない場合は `null` が返る
- [ ] 承認済みの場合は `null` が返る
- [ ] 未認証の場合は `null` が返る
- [ ] 既存テスト・新規テストがすべてパスする

## 実装詳細
### User モデル (`app/models/user.rb`)
- `incoming_follow_request_id_from(other_user)` メソッドを追加
- `pending_follow_requests` アソシエーション（既存）から `follower_id` で検索し、IDを返す

### Users コントローラ (`app/controllers/api/v1/users_controller.rb`)
- `show_user_id_data` アクションのレスポンスに `incoming_follow_request_id` を追加
- 公開・非公開プロフィール両方のレスポンスに含む

### テスト
- モデルスペック: 3ケース（pending存在/なし/accepted済み）
- リクエストスペック: 2ケース（pending存在/なし）

## スクリーンショット
なし（API変更のみ）

## 確認手順
1. 鍵アカウントAにユーザーBからフォローリクエストを送る
2. ユーザーAの認証で `GET /api/v1/users/show_user_id_data?user_id=<B>` を呼ぶ
3. レスポンスに `incoming_follow_request_id` が含まれることを確認
4. フォローリクエストがないユーザーに対しては `null` が返ることを確認

## 影響範囲
- `GET /api/v1/users/show_user_id_data` エンドポイントのレスポンス

## コード上の懸念点
特になし

## その他
モバイル側のPR: ippei-shimizu/buzzbase_mobile で同ブランチのPRと合わせて確認