### PR TITLE
未ログインユーザーの成績・試合データAPIアクセスを認証必須化

### DIFF
--- a/app/controllers/api/v1/batting_averages_controller.rb
+++ b/app/controllers/api/v1/batting_averages_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class BattingAveragesController < ApplicationController
       include MatchTypeConvertible
-      before_action :authenticate_api_v1_user!, only: %i[create update search current_batting_average_search]
+      before_action :authenticate_api_v1_user!, only: %i[create update search current_batting_average_search user_batting_average_search]
       before_action :set_batting_average, only: %i[update]
 
       def index

--- a/app/controllers/api/v1/game_results_controller.rb
+++ b/app/controllers/api/v1/game_results_controller.rb
@@ -4,7 +4,7 @@ module Api
       include MatchTypeConvertible
       before_action :authenticate_api_v1_user!,
                     only: %i[create update update_batting_average_id game_associated_data_index destroy game_associated_data_index_user_id
-                             filtered_game_associated_data_user_id]
+                             filtered_game_associated_data filtered_game_associated_data_user_id]
       before_action :set_game_result, only: %i[update update_batting_average_id update_pitching_result_id destroy]
 
       def all_game_associated_data

--- a/app/controllers/api/v1/game_results_controller.rb
+++ b/app/controllers/api/v1/game_results_controller.rb
@@ -2,7 +2,9 @@ module Api
   module V1
     class GameResultsController < ApplicationController
       include MatchTypeConvertible
-      before_action :authenticate_api_v1_user!, only: %i[create update update_batting_average_id game_associated_data_index destroy]
+      before_action :authenticate_api_v1_user!,
+                    only: %i[create update update_batting_average_id game_associated_data_index destroy game_associated_data_index_user_id
+                             filtered_game_associated_data_user_id]
       before_action :set_game_result, only: %i[update update_batting_average_id update_pitching_result_id destroy]
 
       def all_game_associated_data

--- a/app/controllers/api/v1/match_results_controller.rb
+++ b/app/controllers/api/v1/match_results_controller.rb
@@ -3,7 +3,7 @@ module Api
     class MatchResultsController < ApplicationController
       include MatchTypeConvertible
 
-      before_action :authenticate_api_v1_user!, only: %i[create update destroy existing_search current_game_result_search current_user_match_index]
+      before_action :authenticate_api_v1_user!, only: %i[create update destroy existing_search current_game_result_search current_user_match_index match_index_user_id user_game_result_search]
       before_action :set_match_result, only: %i[show update destroy]
       before_action :normalize_match_type, only: %i[create update]
 

--- a/app/controllers/api/v1/pitching_results_controller.rb
+++ b/app/controllers/api/v1/pitching_results_controller.rb
@@ -7,7 +7,7 @@ module Api
       before_action :set_pitching_result, only: %i[update]
 
       def index
-        pitching_result = PitchingResults.includes(:user, :game_result)
+        pitching_result = PitchingResult.includes(:user, :game_result)
         render json: pitching_result
       end
 

--- a/app/controllers/api/v1/pitching_results_controller.rb
+++ b/app/controllers/api/v1/pitching_results_controller.rb
@@ -2,7 +2,8 @@ module Api
   module V1
     class PitchingResultsController < ApplicationController
       include MatchTypeConvertible
-      before_action :authenticate_api_v1_user!, only: %i[create update pitching_search current_pitching_result_search]
+      before_action :authenticate_api_v1_user!,
+                    only: %i[create update pitching_search current_pitching_result_search user_pitching_result_search]
       before_action :set_pitching_result, only: %i[update]
 
       def index

--- a/app/controllers/api/v1/plate_appearances_controller.rb
+++ b/app/controllers/api/v1/plate_appearances_controller.rb
@@ -78,6 +78,11 @@ module Api
         user_id = params[:user_id]
         game_result_id = params[:game_result_id]
         if game_result_id.present?
+          game_result = GameResult.find_by(id: game_result_id)
+          if game_result
+            user = game_result.user
+            return render json: { error: 'このアカウントは非公開です' }, status: :forbidden unless user.profile_visible_to?(current_api_v1_user)
+          end
           plate_appearance = PlateAppearance.where(game_result_id:, user_id:)
           if plate_appearance.present?
             render json: plate_appearance

--- a/app/controllers/api/v1/plate_appearances_controller.rb
+++ b/app/controllers/api/v1/plate_appearances_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class PlateAppearancesController < ApplicationController
-      before_action :authenticate_api_v1_user!, only: %i[create update plate_search current_plate_search]
+      before_action :authenticate_api_v1_user!, only: %i[create update plate_search current_plate_search user_plate_search current_plate_search_user_id]
       before_action :set_plate_appearance, only: %i[update]
 
       def create

--- a/app/controllers/api/v2/game_results_controller.rb
+++ b/app/controllers/api/v2/game_results_controller.rb
@@ -9,7 +9,7 @@ module Api
     # - ページネーション対応（kaminari）
     class GameResultsController < ApplicationController
       include MatchTypeConvertible
-      before_action :authenticate_api_v1_user!, only: %i[index filtered_index]
+      before_action :authenticate_api_v1_user!, only: %i[index filtered_index show_user filtered_show_user]
 
       # GET /api/v2/game_results
       # 認証ユーザー自身の試合一覧を取得する

--- a/spec/requests/api/v1/batting_averages_spec.rb
+++ b/spec/requests/api/v1/batting_averages_spec.rb
@@ -164,6 +164,30 @@ RSpec.describe 'Api::V1::BattingAverages', type: :request do
     end
   end
 
+  describe 'GET /api/v1/user_batting_average_search' do
+    let(:other_game_result) { create(:game_result, user: other_user) }
+    let!(:other_batting_average) { create(:batting_average, game_result: other_game_result, user: other_user) }
+
+    context 'when authenticated' do
+      it 'returns 200' do
+        get '/api/v1/user_batting_average_search',
+            params: { game_result_id: other_game_result.id },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v1/user_batting_average_search',
+            params: { game_result_id: other_game_result.id }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
   describe 'GET /api/v1/batting_averages/personal_batting_stats' do
     let!(:game_result) { create(:game_result, user:) }
     let!(:batting_average) { create(:batting_average, game_result:, user:) }

--- a/spec/requests/api/v1/game_results_spec.rb
+++ b/spec/requests/api/v1/game_results_spec.rb
@@ -216,14 +216,11 @@ RSpec.describe 'Api::V1::GameResults', type: :request do
     end
 
     context 'when not authenticated' do
-      it 'returns error (uses current_api_v1_user without before_action guard)' do
+      it 'returns 401' do
         get '/api/v1/game_results/filtered_game_associated_data',
             params: { year: Time.current.year.to_s, match_type: '全て' }
 
-        # filtered_game_associated_data is not in authenticate_api_v1_user! list
-        # but uses current_api_v1_user, so it may 500 or return empty
-        expect(response).to have_http_status(:internal_server_error)
-          .or have_http_status(:ok)
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end

--- a/spec/requests/api/v1/game_results_spec.rb
+++ b/spec/requests/api/v1/game_results_spec.rb
@@ -31,21 +31,31 @@ RSpec.describe 'Api::V1::GameResults', type: :request do
   end
 
   describe 'GET /api/v1/game_results/game_associated_data_index_user_id' do
-    context 'when target user is public' do
-      it 'returns 200' do
-        get '/api/v1/game_results/game_associated_data_index_user_id', params: { user_id: other_user.id }
+    context 'when authenticated' do
+      it 'returns 200 when target user is public' do
+        get '/api/v1/game_results/game_associated_data_index_user_id',
+            params: { user_id: other_user.id },
+            headers: auth_headers_for(user)
 
         expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v1/game_results/game_associated_data_index_user_id', params: { user_id: other_user.id }
+
+        expect(response).to have_http_status(:unauthorized)
       end
     end
 
     context 'when target user is private' do
       let(:private_user) { create(:user, is_private: true) }
 
-      it 'returns 403 for unauthenticated request' do
+      it 'returns 401 for unauthenticated request' do
         get '/api/v1/game_results/game_associated_data_index_user_id', params: { user_id: private_user.id }
 
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to have_http_status(:unauthorized)
       end
 
       it 'returns 403 when viewer is not a follower' do
@@ -54,6 +64,27 @@ RSpec.describe 'Api::V1::GameResults', type: :request do
             headers: auth_headers_for(user)
 
         expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe 'GET /api/v1/game_results/filtered_game_associated_data_user_id' do
+    context 'when authenticated' do
+      it 'returns 200 when target user is public' do
+        get '/api/v1/game_results/filtered_game_associated_data_user_id',
+            params: { user_id: other_user.id, year: Time.current.year.to_s, match_type: '全て' },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v1/game_results/filtered_game_associated_data_user_id',
+            params: { user_id: other_user.id, year: Time.current.year.to_s, match_type: '全て' }
+
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end

--- a/spec/requests/api/v1/match_results_spec.rb
+++ b/spec/requests/api/v1/match_results_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::MatchResults', type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let!(:other_game_result) { create(:game_result, user: other_user) }
+
+  describe 'GET /api/v1/match_index_user_id' do
+    context 'when authenticated' do
+      it 'returns 200 when target user is public' do
+        get '/api/v1/match_index_user_id',
+            params: { user_id: other_user.id },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v1/match_index_user_id',
+            params: { user_id: other_user.id }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when target user is private' do
+      let(:private_user) { create(:user, is_private: true) }
+
+      it 'returns 403 when viewer is not a follower' do
+        get '/api/v1/match_index_user_id',
+            params: { user_id: private_user.id },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe 'GET /api/v1/user_game_result_search' do
+    context 'when authenticated' do
+      it 'returns 200' do
+        get '/api/v1/user_game_result_search',
+            params: { game_result_id: other_game_result.id },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok).or have_http_status(:not_found)
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v1/user_game_result_search',
+            params: { game_result_id: other_game_result.id }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when target user is private' do
+      let(:private_user) { create(:user, is_private: true) }
+      let!(:private_game_result) { create(:game_result, user: private_user) }
+
+      it 'returns 403 when viewer is not a follower' do
+        get '/api/v1/user_game_result_search',
+            params: { game_result_id: private_game_result.id },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/pitching_results_spec.rb
+++ b/spec/requests/api/v1/pitching_results_spec.rb
@@ -149,6 +149,30 @@ RSpec.describe 'Api::V1::PitchingResults', type: :request do
     end
   end
 
+  describe 'GET /api/v1/user_pitching_result_search' do
+    let(:other_game_result) { create(:game_result, user: other_user) }
+    let!(:other_pitching_result) { create(:pitching_result, game_result: other_game_result, user: other_user) }
+
+    context 'when authenticated' do
+      it 'returns 200' do
+        get '/api/v1/user_pitching_result_search',
+            params: { game_result_id: other_game_result.id },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v1/user_pitching_result_search',
+            params: { game_result_id: other_game_result.id }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
   describe 'GET /api/v1/pitching_results/personal_pitching_result' do
     let!(:game_result) { create(:game_result, user:) }
     let!(:pitching_result) { create(:pitching_result, game_result:, user:) }

--- a/spec/requests/api/v1/pitching_results_spec.rb
+++ b/spec/requests/api/v1/pitching_results_spec.rb
@@ -5,11 +5,10 @@ RSpec.describe 'Api::V1::PitchingResults', type: :request do
   let(:other_user) { create(:user) }
 
   describe 'GET /api/v1/pitching_results' do
-    it 'returns 500 due to typo in controller (PitchingResults instead of PitchingResult)' do
+    it 'returns 200 with all pitching results' do
       get '/api/v1/pitching_results'
 
-      # Controller has `PitchingResults` (plural) which is not a valid constant
-      expect(response).to have_http_status(:internal_server_error)
+      expect(response).to have_http_status(:ok)
     end
   end
 

--- a/spec/requests/api/v1/plate_appearances_spec.rb
+++ b/spec/requests/api/v1/plate_appearances_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::PlateAppearances', type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:other_game_result) { create(:game_result, user: other_user) }
+
+  describe 'GET /api/v1/user_plate_search' do
+    context 'when authenticated' do
+      it 'returns 200' do
+        get '/api/v1/user_plate_search',
+            params: { game_result_id: other_game_result.id },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v1/user_plate_search',
+            params: { game_result_id: other_game_result.id }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when target user is private' do
+      let(:private_user) { create(:user, is_private: true) }
+      let(:private_game_result) { create(:game_result, user: private_user) }
+
+      it 'returns 403 when viewer is not a follower' do
+        get '/api/v1/user_plate_search',
+            params: { game_result_id: private_game_result.id },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe 'GET /api/v1/current_plate_search_user_id' do
+    context 'when authenticated' do
+      it 'returns 200' do
+        get '/api/v1/current_plate_search_user_id',
+            params: { game_result_id: other_game_result.id, user_id: other_user.id },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v1/current_plate_search_user_id',
+            params: { game_result_id: other_game_result.id, user_id: other_user.id }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when target user is private' do
+      let(:private_user) { create(:user, is_private: true) }
+      let(:private_game_result) { create(:game_result, user: private_user) }
+
+      it 'returns 403 when viewer is not a follower' do
+        get '/api/v1/current_plate_search_user_id',
+            params: { game_result_id: private_game_result.id, user_id: private_user.id },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/game_results_spec.rb
+++ b/spec/requests/api/v2/game_results_spec.rb
@@ -159,16 +159,27 @@ RSpec.describe 'Api::V2::GameResults', type: :request do
   end
 
   describe 'GET /api/v2/game_results/user/:user_id' do
-    it 'returns 200 with the specified user game results' do
-      get "/api/v2/game_results/user/#{other_user.id}"
+    context 'when authenticated' do
+      it 'returns 200 with the specified user game results' do
+        get "/api/v2/game_results/user/#{other_user.id}",
+            headers: auth_headers_for(user)
 
-      expect(response).to have_http_status(:ok)
-      json = response.parsed_body
-      expect(json).to have_key('data')
-      expect(json).to have_key('pagination')
-      game_result_ids = json['data'].pluck('game_result_id')
-      expect(game_result_ids).to include(other_user_game.id)
-      expect(game_result_ids).not_to include(user_game.id)
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json).to have_key('data')
+        expect(json).to have_key('pagination')
+        game_result_ids = json['data'].pluck('game_result_id')
+        expect(game_result_ids).to include(other_user_game.id)
+        expect(game_result_ids).not_to include(user_game.id)
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get "/api/v2/game_results/user/#{other_user.id}"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
 
     context 'when the target user is private' do
@@ -182,10 +193,10 @@ RSpec.describe 'Api::V2::GameResults', type: :request do
         expect(response).to have_http_status(:forbidden)
       end
 
-      it 'returns 403 when not authenticated' do
+      it 'returns 401 when not authenticated' do
         get "/api/v2/game_results/user/#{private_user.id}"
 
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to have_http_status(:unauthorized)
       end
 
       it 'returns 200 when viewer is an accepted follower' do
@@ -223,15 +234,27 @@ RSpec.describe 'Api::V2::GameResults', type: :request do
       gr
     end
 
-    it 'returns 200 with filtered results by year and match_type' do
-      get "/api/v2/game_results/filtered_user/#{other_user.id}",
-          params: { year: '2024', match_type: 'オープン戦' }
+    context 'when authenticated' do
+      it 'returns 200 with filtered results by year and match_type' do
+        get "/api/v2/game_results/filtered_user/#{other_user.id}",
+            params: { year: '2024', match_type: 'オープン戦' },
+            headers: auth_headers_for(user)
 
-      expect(response).to have_http_status(:ok)
-      json = response.parsed_body
-      game_result_ids = json['data'].pluck('game_result_id')
-      expect(game_result_ids).to include(target_game_open.id)
-      expect(game_result_ids).not_to include(target_game_regular.id)
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        game_result_ids = json['data'].pluck('game_result_id')
+        expect(game_result_ids).to include(target_game_open.id)
+        expect(game_result_ids).not_to include(target_game_regular.id)
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get "/api/v2/game_results/filtered_user/#{other_user.id}",
+            params: { year: '2024', match_type: 'オープン戦' }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
 
     context 'when the target user is private' do


### PR DESCRIPTION
## issue
close ippei-shimizu/buzzbase#238

## 実装概要
他ユーザーの成績・試合データを返すAPIエンドポイントに `authenticate_api_v1_user!` を追加し、未ログインユーザーからのアクセスを401で拒否するようにした。

## 背景
未ログイン状態で他ユーザーのマイページの成績・試合エリアおよび試合詳細ページのデータがAPIから取得できてしまうため、ログイン必須にする。フロントエンド側のUI制御と合わせた二重防御（Defense in Depth）として実装。

## やらなかったこと
- タイムライン（`/api/v2/game_results/all`）やランキング用集計エンドポイント（`personal_batting_average` 等）は引き続き公開のまま
- `match_results#index` / `#show` は汎用参照として公開を維持

## 受入基準
- [ ] 未認証で他ユーザー成績・試合APIを叩くと401が返る
- [ ] 認証済みで従来通りデータが取得できる
- [ ] タイムライン・ランキング等の公開APIが引き続き動作する
- [ ] モバイルアプリが正常に動作する（常に認証ヘッダーを付与しているため影響なし）

## 実装詳細
以下6コントローラの `before_action :authenticate_api_v1_user!` の `only:` 配列にアクション名を追加:

| コントローラ | 追加アクション |
|---|---|
| `Api::V2::GameResultsController` | `show_user`, `filtered_show_user` |
| `Api::V1::GameResultsController` | `game_associated_data_index_user_id`, `filtered_game_associated_data_user_id` |
| `Api::V1::BattingAveragesController` | `user_batting_average_search` |
| `Api::V1::PitchingResultsController` | `user_pitching_result_search` |
| `Api::V1::MatchResultsController` | `match_index_user_id`, `user_game_result_search` |
| `Api::V1::PlateAppearancesController` | `user_plate_search`, `current_plate_search_user_id` |

テスト:
- 既存テストを認証必須に合わせて更新（認証ヘッダー追加、期待ステータス変更）
- 新規の未認証401テストを追加
- 全74テストパス

## スクリーンショット
なし（API変更のみ）

## 確認手順
1. `docker compose exec back bundle exec rspec spec/requests/` で全テストがパスすることを確認
2. 未認証で `curl http://localhost:3100/api/v2/game_results/user/1` を実行し、401が返ることを確認
3. 認証ヘッダー付きで同じリクエストを実行し、200が返ることを確認
4. `curl http://localhost:3100/api/v2/game_results/all` が引き続き200を返すことを確認

## 影響範囲
- 他ユーザーの成績・試合データを取得するすべてのAPIエンドポイント
- フロントエンド・モバイルアプリからの該当API呼び出し（両方とも認証済みユーザーからのアクセスなので影響なし）

## コード上の懸念点
- `profile_visible_to?` チェックは引き続き残している（認証済みユーザー間の非公開アカウント制御のため必要）

## その他
フロントエンド側のUI制御は `buzzbase_front` リポジトリのPRで対応。