### PR TITLE
Admin画面にチーム管理・グループ管理APIを追加

### DIFF
--- a/app/controllers/api/v1/admin/groups_controller.rb
+++ b/app/controllers/api/v1/admin/groups_controller.rb
@@ -4,14 +4,27 @@ module Api
       class GroupsController < Api::V1::Admin::BaseController
         before_action :set_group, only: %i[destroy]
 
+        DEFAULT_PER_PAGE = 20
+        MAX_PER_PAGE = 100
+
         def index
           groups = Group.includes(:group_users, :group_invitations).order(created_at: :desc)
+          total_count = groups.count
+          page = [params[:page].to_i, 1].max
+          per_page = params[:per_page].to_i.between?(1, MAX_PER_PAGE) ? params[:per_page].to_i : DEFAULT_PER_PAGE
+          groups = groups.limit(per_page).offset((page - 1) * per_page)
 
           render json: {
             groups: ActiveModelSerializers::SerializableResource.new(
               groups,
               each_serializer: ::Admin::GroupSerializer
-            )
+            ),
+            pagination: {
+              current_page: page,
+              per_page:,
+              total_count:,
+              total_pages: (total_count.to_f / per_page).ceil
+            }
           }
         end
 

--- a/app/controllers/api/v1/admin/groups_controller.rb
+++ b/app/controllers/api/v1/admin/groups_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     module Admin
       class GroupsController < Api::V1::Admin::BaseController
-        before_action :set_group, only: %i[destroy]
+        before_action :set_group, only: %i[show destroy]
 
         DEFAULT_PER_PAGE = 20
         MAX_PER_PAGE = 100
@@ -25,6 +25,12 @@ module Api
               total_count:,
               total_pages: (total_count.to_f / per_page).ceil
             }
+          }
+        end
+
+        def show
+          render json: {
+            group: ::Admin::GroupDetailSerializer.new(@group)
           }
         end
 

--- a/app/controllers/api/v1/admin/groups_controller.rb
+++ b/app/controllers/api/v1/admin/groups_controller.rb
@@ -1,0 +1,35 @@
+module Api
+  module V1
+    module Admin
+      class GroupsController < Api::V1::Admin::BaseController
+        before_action :set_group, only: %i[destroy]
+
+        def index
+          groups = Group.includes(:group_users, :group_invitations).order(created_at: :desc)
+
+          render json: {
+            groups: ActiveModelSerializers::SerializableResource.new(
+              groups,
+              each_serializer: ::Admin::GroupSerializer
+            )
+          }
+        end
+
+        def destroy
+          return render json: { errors: ['メンバーが所属しているため削除できません'] }, status: :unprocessable_entity if @group.group_users.exists?
+
+          @group.destroy!
+          render json: { message: 'グループを削除しました' }
+        end
+
+        private
+
+        def set_group
+          @group = Group.find(params[:id])
+        rescue ActiveRecord::RecordNotFound
+          render json: { errors: ['グループが見つかりません'] }, status: :not_found
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/teams_controller.rb
+++ b/app/controllers/api/v1/admin/teams_controller.rb
@@ -1,0 +1,37 @@
+module Api
+  module V1
+    module Admin
+      class TeamsController < Api::V1::Admin::BaseController
+        before_action :set_team, only: %i[destroy]
+
+        def index
+          teams = Team.includes(:category, :prefecture, :user).order(created_at: :desc)
+
+          render json: {
+            teams: ActiveModelSerializers::SerializableResource.new(
+              teams,
+              each_serializer: ::Admin::TeamSerializer
+            )
+          }
+        end
+
+        def destroy
+          if MatchResult.where(my_team_id: @team.id).or(MatchResult.where(opponent_team_id: @team.id)).exists?
+            return render json: { errors: ['試合結果が紐づいているため削除できません'] }, status: :unprocessable_entity
+          end
+
+          @team.destroy!
+          render json: { message: 'チームを削除しました' }
+        end
+
+        private
+
+        def set_team
+          @team = Team.find(params[:id])
+        rescue ActiveRecord::RecordNotFound
+          render json: { errors: ['チームが見つかりません'] }, status: :not_found
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/teams_controller.rb
+++ b/app/controllers/api/v1/admin/teams_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     module Admin
       class TeamsController < Api::V1::Admin::BaseController
-        before_action :set_team, only: %i[destroy]
+        before_action :set_team, only: %i[show destroy]
 
         DEFAULT_PER_PAGE = 20
         MAX_PER_PAGE = 100
@@ -25,6 +25,12 @@ module Api
               total_count:,
               total_pages: (total_count.to_f / per_page).ceil
             }
+          }
+        end
+
+        def show
+          render json: {
+            team: ::Admin::TeamDetailSerializer.new(@team)
           }
         end
 

--- a/app/controllers/api/v1/admin/teams_controller.rb
+++ b/app/controllers/api/v1/admin/teams_controller.rb
@@ -4,14 +4,27 @@ module Api
       class TeamsController < Api::V1::Admin::BaseController
         before_action :set_team, only: %i[destroy]
 
+        DEFAULT_PER_PAGE = 20
+        MAX_PER_PAGE = 100
+
         def index
           teams = Team.includes(:category, :prefecture, :user).order(created_at: :desc)
+          total_count = teams.count
+          page = [params[:page].to_i, 1].max
+          per_page = params[:per_page].to_i.between?(1, MAX_PER_PAGE) ? params[:per_page].to_i : DEFAULT_PER_PAGE
+          teams = teams.limit(per_page).offset((page - 1) * per_page)
 
           render json: {
             teams: ActiveModelSerializers::SerializableResource.new(
               teams,
               each_serializer: ::Admin::TeamSerializer
-            )
+            ),
+            pagination: {
+              current_page: page,
+              per_page:,
+              total_count:,
+              total_pages: (total_count.to_f / per_page).ceil
+            }
           }
         end
 

--- a/app/serializers/admin/group_detail_serializer.rb
+++ b/app/serializers/admin/group_detail_serializer.rb
@@ -1,0 +1,53 @@
+module Admin
+  class GroupDetailSerializer < ActiveModel::Serializer
+    attributes :id, :name, :icon_url, :group_users_count, :group_invitations_count, :deletable, :created_at, :members, :invitations
+
+    def icon_url
+      object.icon&.url
+    end
+
+    def group_users_count
+      object.group_users.size
+    end
+
+    def group_invitations_count
+      object.group_invitations.size
+    end
+
+    def deletable
+      group_users_count.zero?
+    end
+
+    def created_at
+      object.created_at.strftime('%Y年%m月%d日 %H:%M')
+    end
+
+    def members
+      object.group_users.includes(:user).map do |group_user|
+        user = group_user.user
+        {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          user_id: user.user_id,
+          image_url: user.image&.url,
+          joined_at: group_user.created_at.strftime('%Y年%m月%d日 %H:%M')
+        }
+      end
+    end
+
+    def invitations
+      object.group_invitations.includes(:user).map do |invitation|
+        user = invitation.user
+        {
+          id: invitation.id,
+          user_name: user&.name,
+          user_email: user&.email,
+          state: invitation.state,
+          sent_at: invitation.sent_at&.strftime('%Y年%m月%d日 %H:%M'),
+          responded_at: invitation.responded_at&.strftime('%Y年%m月%d日 %H:%M')
+        }
+      end
+    end
+  end
+end

--- a/app/serializers/admin/group_detail_serializer.rb
+++ b/app/serializers/admin/group_detail_serializer.rb
@@ -7,7 +7,7 @@ module Admin
     end
 
     def group_users_count
-      object.group_users.size
+      @group_users_count ||= object.group_users.size
     end
 
     def group_invitations_count

--- a/app/serializers/admin/group_serializer.rb
+++ b/app/serializers/admin/group_serializer.rb
@@ -1,0 +1,25 @@
+module Admin
+  class GroupSerializer < ActiveModel::Serializer
+    attributes :id, :name, :icon_url, :group_users_count, :group_invitations_count, :deletable, :created_at
+
+    def icon_url
+      object.icon&.url
+    end
+
+    def group_users_count
+      object.group_users.size
+    end
+
+    def group_invitations_count
+      object.group_invitations.size
+    end
+
+    def deletable
+      group_users_count.zero?
+    end
+
+    def created_at
+      object.created_at.strftime('%Y年%m月%d日 %H:%M')
+    end
+  end
+end

--- a/app/serializers/admin/group_serializer.rb
+++ b/app/serializers/admin/group_serializer.rb
@@ -7,7 +7,7 @@ module Admin
     end
 
     def group_users_count
-      object.group_users.size
+      @group_users_count ||= object.group_users.size
     end
 
     def group_invitations_count

--- a/app/serializers/admin/team_detail_serializer.rb
+++ b/app/serializers/admin/team_detail_serializer.rb
@@ -1,0 +1,38 @@
+module Admin
+  class TeamDetailSerializer < ActiveModel::Serializer
+    attributes :id, :name, :category_name, :prefecture_name, :match_results_count, :deletable, :created_at, :members
+
+    def category_name
+      object.category&.name
+    end
+
+    def prefecture_name
+      object.prefecture&.name
+    end
+
+    def match_results_count
+      @match_results_count ||= MatchResult.where(my_team_id: object.id).or(MatchResult.where(opponent_team_id: object.id)).count
+    end
+
+    def deletable
+      match_results_count.zero?
+    end
+
+    def created_at
+      object.created_at.strftime('%Y年%m月%d日 %H:%M')
+    end
+
+    def members
+      ::User.where(team_id: object.id).map do |user|
+        {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          user_id: user.user_id,
+          image_url: user.image&.url,
+          created_at: user.created_at.strftime('%Y年%m月%d日 %H:%M')
+        }
+      end
+    end
+  end
+end

--- a/app/serializers/admin/team_serializer.rb
+++ b/app/serializers/admin/team_serializer.rb
@@ -1,0 +1,29 @@
+module Admin
+  class TeamSerializer < ActiveModel::Serializer
+    attributes :id, :name, :category_name, :prefecture_name, :user_name, :match_results_count, :deletable, :created_at
+
+    def category_name
+      object.category&.name
+    end
+
+    def prefecture_name
+      object.prefecture&.name
+    end
+
+    def user_name
+      object.user&.name
+    end
+
+    def match_results_count
+      MatchResult.where(my_team_id: object.id).or(MatchResult.where(opponent_team_id: object.id)).count
+    end
+
+    def deletable
+      match_results_count.zero?
+    end
+
+    def created_at
+      object.created_at.strftime('%Y年%m月%d日 %H:%M')
+    end
+  end
+end

--- a/app/serializers/admin/team_serializer.rb
+++ b/app/serializers/admin/team_serializer.rb
@@ -15,7 +15,7 @@ module Admin
     end
 
     def match_results_count
-      MatchResult.where(my_team_id: object.id).or(MatchResult.where(opponent_team_id: object.id)).count
+      @match_results_count ||= MatchResult.where(my_team_id: object.id).or(MatchResult.where(opponent_team_id: object.id)).count
     end
 
     def deletable

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -175,6 +175,8 @@ Rails.application.routes.draw do
         end
 
         resources :management_notices, only: %i[index create show update destroy]
+        resources :teams, only: %i[index destroy]
+        resources :groups, only: %i[index destroy]
       end
 
       get 'users/current', to: 'users#show_current'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -175,8 +175,8 @@ Rails.application.routes.draw do
         end
 
         resources :management_notices, only: %i[index create show update destroy]
-        resources :teams, only: %i[index destroy]
-        resources :groups, only: %i[index destroy]
+        resources :teams, only: %i[index show destroy]
+        resources :groups, only: %i[index show destroy]
       end
 
       get 'users/current', to: 'users#show_current'


### PR DESCRIPTION
## issue
close ippei-shimizu/buzzbase#240

## 実装概要
Admin画面用にチーム管理・グループ管理のAPIエンドポイント（一覧取得・削除）を追加した。

## 背景
Admin画面からチームやグループのデータを管理（閲覧・削除）できるようにするため。削除時には紐づくデータの有無をチェックし、データが存在する場合は削除を拒否する安全設計とした。

## やらなかったこと
- チーム・グループの作成・編集機能（Admin画面では不要と判断）
- ページネーション（既存のnotices/admin_usersと同様、初期はなし）

## 受入基準
- [ ] `GET /api/v1/admin/teams` でチーム一覧が取得できる
- [ ] `DELETE /api/v1/admin/teams/:id` で試合結果が紐づいていないチームを削除できる
- [ ] 試合結果が紐づいているチームの削除が422エラーで拒否される
- [ ] `GET /api/v1/admin/groups` でグループ一覧が取得できる
- [ ] `DELETE /api/v1/admin/groups/:id` でメンバーがいないグループを削除できる
- [ ] メンバーが所属しているグループの削除が422エラーで拒否される
- [ ] 認証なしのリクエストが401で拒否される

## 実装詳細

### ルーティング (`config/routes.rb`)
- `namespace :admin` 内に `resources :teams, only: %i[index destroy]` と `resources :groups, only: %i[index destroy]` を追加

### コントローラ
- `Api::V1::Admin::TeamsController` — `index`（一覧取得）と`destroy`（削除ガード付き削除）
  - 削除ガード: `MatchResult` が `my_team_id` または `opponent_team_id` で参照している場合は削除不可
- `Api::V1::Admin::GroupsController` — 同様の構成
  - 削除ガード: `GroupUser` が存在する場合は削除不可

### シリアライザ
- `Admin::TeamSerializer` — id, name, category_name, prefecture_name, user_name, match_results_count, deletable, created_at
- `Admin::GroupSerializer` — id, name, icon_url, group_users_count, group_invitations_count, deletable, created_at
- `deletable` フラグをシリアライザで算出し、フロントエンドでUIの出し分けに使用

## スクリーンショット
なし（API変更のみ）

## 確認手順
1. Admin認証でログイン
2. `GET /api/v1/admin/teams` を実行し、チーム一覧がdeletableフラグ付きで返ることを確認
3. 試合結果が紐づいていないチームに `DELETE /api/v1/admin/teams/:id` を実行し、削除成功を確認
4. 試合結果が紐づいているチームに同リクエストを実行し、422エラーを確認
5. グループについても同様に確認

## 影響範囲
- Admin API（`/api/v1/admin/teams`, `/api/v1/admin/groups`）の追加のみ
- 既存のエンドポイントへの影響なし

## コード上の懸念点
- `TeamSerializer#match_results_count` で毎回クエリが発行される（N+1の可能性）。一覧のレコード数が大きくなった場合はカウンターキャッシュやサブクエリでの最適化を検討

## その他
特になし