### PR TITLE
Admin グループメンバー一覧を承認済みユーザーに修正

### DIFF
--- a/app/serializers/admin/group_detail_serializer.rb
+++ b/app/serializers/admin/group_detail_serializer.rb
@@ -23,15 +23,20 @@ module Admin
     end
 
     def members
-      object.group_users.includes(:user).map do |group_user|
-        user = group_user.user
+      creator_user_id = object.group_users.order(:created_at).first&.user_id
+
+      object.group_invitations.includes(:user).where(state: 'accepted').filter_map do |invitation|
+        user = invitation.user
+        next unless user
+
         {
           id: user.id,
           name: user.name,
           email: user.email,
           user_id: user.user_id,
           image_url: user.image&.url,
-          joined_at: group_user.created_at.strftime('%Y年%m月%d日 %H:%M')
+          is_creator: user.id == creator_user_id,
+          joined_at: invitation.sent_at&.strftime('%Y年%m月%d日 %H:%M')
         }
       end
     end


### PR DESCRIPTION
## issue
close ippei-shimizu/buzzbase#240

## 実装概要
Admin画面のグループ詳細ページで、メンバー一覧のデータソースを `group_users`（作成者のみ）から `group_invitations.where(state: 'accepted')`（承認済みメンバー全員）に修正。グループ作成者には `is_creator` フラグを付与。

## 背景
`group_users` テーブルはグループ作成時に作成者1人だけが追加されるテーブルであり、招待を承認して参加したメンバーは `group_invitations` テーブルで管理されている。そのため、Admin画面のメンバー一覧に作成者しか表示されない不具合があった。

## やらなかったこと
特になし

## 受入基準
- [ ] グループ詳細画面で承認済み（accepted）の全メンバーが表示される
- [ ] グループ作成者の名前に「作成者」バッジが表示される
- [ ] 招待が保留中（pending）や辞退（declined）のユーザーはメンバー一覧に表示されない

## 実装詳細

### バックエンド (`app/serializers/admin/group_detail_serializer.rb`)
- `members` メソッドのデータソースを `object.group_users` → `object.group_invitations.where(state: 'accepted')` に変更
- `group_users` テーブルの最初のレコードから作成者IDを取得し、各メンバーに `is_creator` フラグを付与
- `map + compact` → `filter_map` に変更（RuboCop Performance/MapCompact対応）

## スクリーンショット
なし

## 確認手順
1. Admin画面にログイン
2. グループ管理 → 任意のグループの「詳細」をクリック
3. メンバー一覧に招待承認済みの全ユーザーが表示されることを確認
4. グループ作成者のユーザー名の横に「作成者」バッジが表示されることを確認

## 影響範囲
- Admin画面のグループ詳細ページのメンバー一覧のみ

## コード上の懸念点
特になし

## その他
- フロントエンドPR: ippei-shimizu/buzzbase_front（同ブランチ）