### PR TITLE
Fix: チーム作成時のForeignKeyViolationを防止 (#244)

### DIFF
--- a/app/controllers/api/v1/teams_controller.rb
+++ b/app/controllers/api/v1/teams_controller.rb
@@ -11,8 +11,8 @@ module Api
       end
 
       def create
-        team = Team.find_or_create_by(team_params)
-        if team.persisted?
+        team = Team.find_or_initialize_by(team_params)
+        if team.persisted? || team.save
           render json: team, status: :created
         else
           render json: team.errors, status: :unprocessable_entity

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -4,4 +4,6 @@ class Team < ApplicationRecord
   has_one :user, foreign_key: 'user_id', primary_key: 'id', dependent: :destroy, inverse_of: :team
 
   validates :name, presence: true
+  validates :category_id, numericality: { only_integer: true, greater_than: 0, allow_nil: true }
+  validates :prefecture_id, numericality: { only_integer: true, greater_than: 0, allow_nil: true }
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -8,6 +8,36 @@ RSpec.describe Team, type: :model do
   end
 
   describe 'validations' do
+    let(:prefecture) { Prefecture.create!(name: '東京都') }
+    let(:category) { BaseballCategory.create!(name: '高校生') }
+
     it { should validate_presence_of(:name) }
+
+    it 'is valid with name only (master ids nil)' do
+      team = described_class.new(name: 'テストチーム')
+      expect(team).to be_valid
+    end
+
+    it 'is valid with name and existing master ids' do
+      team = described_class.new(name: 'テストチーム', category_id: category.id, prefecture_id: prefecture.id)
+      expect(team).to be_valid
+    end
+
+    it 'is invalid with prefecture_id = 0' do
+      team = described_class.new(name: 'テスト', prefecture_id: 0)
+      expect(team).not_to be_valid
+      expect(team.errors[:prefecture_id]).to be_present
+    end
+
+    it 'is invalid with category_id = 0' do
+      team = described_class.new(name: 'テスト', category_id: 0)
+      expect(team).not_to be_valid
+      expect(team.errors[:category_id]).to be_present
+    end
+
+    it 'is invalid with negative prefecture_id' do
+      team = described_class.new(name: 'テスト', prefecture_id: -1)
+      expect(team).not_to be_valid
+    end
   end
 end

--- a/spec/requests/api/v1/teams_spec.rb
+++ b/spec/requests/api/v1/teams_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Teams', type: :request do
+  let(:user) { create(:user) }
+  let(:prefecture) { Prefecture.create!(name: '東京都') }
+  let(:category) { BaseballCategory.create!(name: '高校生') }
+
+  describe 'POST /api/v1/teams' do
+    context 'when not authenticated' do
+      it 'returns 401' do
+        post '/api/v1/teams', params: { team: { name: 'テストチーム' } }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'with valid name and master ids' do
+      it 'creates the team and returns 201' do
+        post '/api/v1/teams',
+             params: { team: { name: 'テストチーム', category_id: category.id, prefecture_id: prefecture.id } },
+             headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:created)
+        json = response.parsed_body
+        expect(json['name']).to eq('テストチーム')
+        expect(json['category_id']).to eq(category.id)
+        expect(json['prefecture_id']).to eq(prefecture.id)
+      end
+    end
+
+    context 'with name only (master ids omitted)' do
+      it 'creates the team and returns 201' do
+        post '/api/v1/teams',
+             params: { team: { name: 'チーム名のみ' } },
+             headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:created)
+        json = response.parsed_body
+        expect(json['name']).to eq('チーム名のみ')
+        expect(json['category_id']).to be_nil
+        expect(json['prefecture_id']).to be_nil
+      end
+    end
+
+    context 'when prefecture_id is 0 (BUZZBASE-BACKEND-N regression)' do
+      it 'returns 422 instead of raising ForeignKeyViolation' do
+        post '/api/v1/teams',
+             params: { team: { name: '不正なチーム', category_id: category.id, prefecture_id: 0 } },
+             headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(Team.where(name: '不正なチーム')).to be_empty
+      end
+    end
+
+    context 'when category_id is 0' do
+      it 'returns 422 instead of raising ForeignKeyViolation' do
+        post '/api/v1/teams',
+             params: { team: { name: '不正なチーム2', category_id: 0, prefecture_id: prefecture.id } },
+             headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(Team.where(name: '不正なチーム2')).to be_empty
+      end
+    end
+
+    context 'when both master ids are 0' do
+      it 'returns 422' do
+        post '/api/v1/teams',
+             params: { team: { name: '不正なチーム3', category_id: 0, prefecture_id: 0 } },
+             headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'when prefecture_id is empty string' do
+      it 'creates the team treating it as nil' do
+        post '/api/v1/teams',
+             params: { team: { name: '空文字チーム', category_id: category.id, prefecture_id: '' } },
+             headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:created)
+        json = response.parsed_body
+        expect(json['prefecture_id']).to be_nil
+      end
+    end
+
+    context 'when name is blank' do
+      it 'returns 422' do
+        post '/api/v1/teams',
+             params: { team: { name: '', category_id: category.id, prefecture_id: prefecture.id } },
+             headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## issue
close #244

## 実装概要
`POST /api/v1/teams` で `prefecture_id=0` / `category_id=0` が送られたときに `PG::ForeignKeyViolation`（`fk_rails_61b55c7fe1`）で500エラーになっていた問題を修正する。Rails 層で 0 や負数を弾き、422 を返すようにする。

## 背景
Sentry `BUZZBASE-BACKEND-N`（4ユーザー / 15発生 / 2026-04-07〜継続中）として観測されたバグ。発火元はモバイルアプリのプロフィール編集画面で、ユーザーがチーム名を自由入力した上でカテゴリーまたは都道府県を未選択のまま保存した際、mobile側の `?? 0` フォールバックで `0` が送信されていた。

`Team` モデルは `belongs_to :prefecture, optional: true` で `nil` のみ許容し `0` は素通り → DB の FK 制約で500になる流れだった。多層防御として、mobile側の修正に加えてバックエンドでも 0 を Rails 層で弾く。

## やらなかったこと
- `find_or_create_by` の意味論を見直して `find_or_initialize_by` + 明示的 `save` に切り替えたが、応答ステータス（既存ヒット時も `:created` を返す挙動）はAPI互換のため変更していない
- `update` アクションも `team_params` を受け取るため同じ脆弱性があるが、今回のSentryには現れていないので影響範囲を限定して `create` のみ対象にした（モデルバリデーションは update でも効くため、結果的に update でも 422 が返る）

## 受入基準
- [x] `bundle exec rspec` が全件パス
- [x] `bundle exec rubocop` が変更ファイルでオフェンスなし
- [x] `prefecture_id=0` / `category_id=0` の POST で 500 ではなく 422 が返る
- [x] `prefecture_id`/`category_id` が `nil`（未指定）でも 201 でチームが作成される
- [x] 正常系（実在する master id）で 201 が返る

## 実装詳細

### `app/models/team.rb`
- `category_id` / `prefecture_id` に `numericality: { only_integer: true, greater_than: 0, allow_nil: true }` を追加。`belongs_to optional: true` で `nil` は許容しつつ、`0` や負数は ActiveRecord のバリデーションで弾く。

### `app/controllers/api/v1/teams_controller.rb`
- `create` を `Team.find_or_create_by(team_params)` から `find_or_initialize_by(team_params)` + `save` に変更。バリデーション失敗時に例外を投げず、`team.errors` を 422 で返す。

### `spec/models/team_spec.rb`
- 既存の `validate_presence_of(:name)` に加え、`prefecture_id=0`、`category_id=0`、負数の3ケースで invalid になることを検証。

### `spec/requests/api/v1/teams_spec.rb`（新規）
- 認証 / 正常系 / `prefecture_id=0` / `category_id=0` / 両方=0 / 空文字 / `name` ブランクの 8 ケースをカバー。リグレッションが起きないようコメントに `BUZZBASE-BACKEND-N` を残してある。

## 確認手順
1. \`docker compose exec back bundle exec rspec spec/requests/api/v1/teams_spec.rb spec/models/team_spec.rb\` を実行し、全件グリーンになることを確認する
2. 手動確認: \`POST /api/v1/teams\` に \`{ team: { name: \"X\", prefecture_id: 0 } }\` を投げて 422 が返ること
3. 手動確認: \`{ team: { name: \"X\" } }\` のみ（master id 省略）で 201 が返ること

## 影響範囲
- Rails API: `POST /api/v1/teams` のレスポンスコードのみ変更（500 → 422、正常系は変更なし）
- DB: マイグレーションなし（バリデーション層のみの変更）
- 既存データへの影響なし（既存の Team レコードはすべて valid な master id か nil）

## コード上の懸念点
- `find_or_initialize_by` への変更で「既存ヒット時に 201 を返す」挙動が残っているが、これは旧 `find_or_create_by` と同じで意図的に互換維持している。本来は `:ok` の方が正確だが、API破壊変更を避けるため据え置き。
- `belongs_to :prefecture, optional: true` のままにしている。これを `optional: false` にすると nil も弾かれるが、既存データに nil がある可能性とフロントエンドの挙動を考慮して維持。

## その他
mobile側の修正PRと併せてマージすることで、根本対策（モバイル側の事前バリデーション）と多層防御（バックエンドの Rails バリデーション）が揃う。