### PR TITLE
Fix: ユーザーID重複時のRecordNotUnique 500エラーを防止 (#245)

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -78,6 +78,8 @@ module Api
         else
           render json: { errors: current_api_v1_user.errors.full_messages }, status: :unprocessable_entity
         end
+      rescue ActiveRecord::RecordNotUnique
+        render json: { errors: ['このユーザーIDは既に使われています'] }, status: :unprocessable_entity
       end
 
       def following_users

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,7 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :validatable, :confirmable
   include DeviseTokenAuth::Concerns::User
 
+  before_validation :normalize_user_id
   after_commit :notify_slack_new_user, on: :create
 
   validates :password, custom_password: true, on: :create, unless: -> { provider.in?(%w[google apple]) }
@@ -133,6 +134,10 @@ class User < ActiveRecord::Base
   delegate :count, to: :followers, prefix: true
 
   private
+
+  def normalize_user_id
+    self.user_id = nil if user_id.blank?
+  end
 
   def notify_slack_new_user
     SlackNotificationService.notify_new_user(self)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -20,6 +20,22 @@ RSpec.describe User, type: :model do
         user = build(:user, user_id: '')
         expect(user.errors[:user_id]).to be_empty
       end
+
+      it 'normalizes empty string user_id to nil on save' do
+        user = create(:user, user_id: '')
+        expect(user.reload.user_id).to be_nil
+      end
+
+      it 'normalizes whitespace-only user_id to nil on save' do
+        user = create(:user, user_id: '   ')
+        expect(user.reload.user_id).to be_nil
+      end
+
+      it 'allows multiple users with blank user_id (BUZZBASE-BACKEND-P regression)' do
+        create(:user, user_id: '')
+        expect { create(:user, user_id: '') }.not_to raise_error
+        expect(described_class.where(user_id: nil).count).to be >= 2
+      end
     end
 
     describe 'format' do

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Users', type: :request do
+  describe 'PUT /api/v1/user' do
+    let(:user) { create(:user, user_id: 'original_id') }
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        put '/api/v1/user', params: { user: { user_id: 'whatever' } }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'with a valid new user_id' do
+      it 'updates and returns success' do
+        put '/api/v1/user',
+            params: { user: { user_id: 'new_player' } },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to eq('success' => true)
+        expect(user.reload.user_id).to eq('new_player')
+      end
+    end
+
+    context 'when user_id is empty string (BUZZBASE-BACKEND-P regression)' do
+      it 'normalizes to nil and returns success' do
+        put '/api/v1/user',
+            params: { user: { user_id: '' } },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(user.reload.user_id).to be_nil
+      end
+
+      it 'allows multiple users to clear their user_id without DB conflict' do
+        another = create(:user, user_id: 'another_id')
+
+        put '/api/v1/user', params: { user: { user_id: '' } }, headers: auth_headers_for(user)
+        expect(response).to have_http_status(:ok)
+
+        put '/api/v1/user', params: { user: { user_id: '' } }, headers: auth_headers_for(another)
+        expect(response).to have_http_status(:ok)
+
+        expect(user.reload.user_id).to be_nil
+        expect(another.reload.user_id).to be_nil
+      end
+    end
+
+    context 'when user_id is already taken by another user' do
+      it 'returns 422 with the localized error message' do
+        create(:user, user_id: 'taken_id')
+
+        put '/api/v1/user',
+            params: { user: { user_id: 'taken_id' } },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['errors']).to include(a_string_including('このユーザーIDは既に使われています'))
+      end
+    end
+
+    context 'when ActiveRecord::RecordNotUnique is raised at the DB layer (race condition)' do
+      it 'rescues to 422 instead of leaking 500' do
+        # Devise が返す current_api_v1_user のインスタンスを直接掴めないため any_instance を許可
+        allow_any_instance_of(User).to receive(:update).and_raise(ActiveRecord::RecordNotUnique) # rubocop:disable RSpec/AnyInstance
+
+        put '/api/v1/user',
+            params: { user: { user_id: 'racing_id' } },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['errors']).to include('このユーザーIDは既に使われています')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## issue
close #245

## 実装概要
\`PUT /api/v1/user\` で \`user_id\` が空文字の場合に \`ActiveRecord::RecordNotUnique\`（\`PG::UniqueViolation: index_users_on_user_id\`）が発生して500エラーになっていた問題を修正する。空文字を内部的に \`nil\` に正規化し、DB レイヤーでも衝突した場合は 422 で「このユーザーIDは既に使われています」を返す。

## 背景
Sentry \`BUZZBASE-BACKEND-P\`（4ユーザー / 28発生 / 2026-04-17〜継続中）として観測されたバグ。Sentry全28件の DETAIL は \`Key (user_id)=()\` で **すべて空文字列の重複** が原因だった。

レイヤー間の不整合:

| レイヤー | \`user_id = ''\` の扱い |
| --- | --- |
| Rails \`validates :user_id, uniqueness: true, allow_blank: true\` | 空文字でバリデーションを **スキップ**（素通し） |
| PostgreSQL unique index | 空文字 \`''\` 同士は **重複と判定**（NULLは複数許容） |

ユーザーがプロフィール編集で user_id をクリアして送信すると、\`allow_blank: true\` により Rails 検証は素通しされるが、DB の unique index に空文字が既に存在すると衝突して500になる。

issueタイトルは「他人に使われている場合」だが、実データはすべて空文字の重複。理論上は非空文字での TOCTOU レース（同じuser_idを同時に取りに行く）も起こり得るため、修正は両方カバーする。

## やらなかったこと
- **既存空文字データの一括クリーンアップマイグレーション** — \`User.where(user_id: '').update_all(user_id: nil)\` は別PRに分離。本修正だけでも、該当ユーザーが次回保存時に \`before_validation\` により自動的に nil 化されるため、新規発生は止まる。プロダクションDBの一括変更は影響範囲が広いため切り出した。
- **mobile 側の変更** — 空文字を送信しないようにする最適化は UX 改善であって、本バグの根治には不要（バックエンドが堅牢であれば足りる）。

## 受入基準
- [x] \`bundle exec rspec spec/models/ spec/requests/api/v1/\` が全件パス（352 examples, 0 failures）
- [x] \`bundle exec rubocop\` が変更ファイルでオフェンスなし
- [x] 空文字 user_id を送信しても 200 が返り、DB は NULL になる
- [x] 複数ユーザーが連続で user_id をクリアしても全員 200 を受け取る
- [x] 他ユーザーが使用中の非空文字 user_id を送信した場合は 422 + 日本語メッセージ
- [x] DB レイヤーで \`RecordNotUnique\` が発火した場合（race condition）も 422 + 日本語メッセージ

## 実装詳細

### \`app/models/user.rb\`
- \`before_validation :normalize_user_id\` を追加
- \`private\` の \`normalize_user_id\` メソッドで \`user_id.blank?\` のとき \`self.user_id = nil\` する
- 既存の \`validates :user_id, uniqueness: true, allow_blank: true\` などはそのまま維持（nil でも \`allow_blank\` が効く）
- 既存の \`group_invite_link.rb\` の \`before_validation :set_code\` パターンを踏襲

### \`app/controllers/api/v1/users_controller.rb\`
- \`update\` アクションに \`rescue ActiveRecord::RecordNotUnique\` を追加
- 422 + \`{ errors: ['このユーザーIDは既に使われています'] }\` を返す
- 既存の \`auth/registrations_controller.rb\` の rescue パターンを踏襲

### \`spec/models/user_spec.rb\`
- 既存の \`describe 'uniqueness'\` ブロックに3ケース追加（空文字 → nil、空白 → nil、複数ユーザー共存）

### \`spec/requests/api/v1/users_spec.rb\`（新規）
- \`PUT /api/v1/user\` の user_id 更新ケースを 6 ケース網羅
  - 認証なし → 401
  - 正常系（valid user_id）→ 200
  - 空文字 → 200 + DB は nil（BUZZBASE-BACKEND-P 直接検証）
  - 複数ユーザー連続クリア → 全員 200
  - 既に他者が使用中の user_id → 422
  - DB レイヤー race（\`RecordNotUnique\` スタブ） → 422

## スクリーンショット
なし（API 修正のみ）

## 確認手順
1. \`docker compose exec back bundle exec rspec spec/models/user_spec.rb spec/requests/api/v1/users_spec.rb\` を実行し全件グリーンを確認
2. 手動確認 (Rails console):
   \`\`\`ruby
   u = User.first
   u.update(user_id: '')
   u.reload.user_id  # => nil
   \`\`\`
3. 手動確認 (curl/Postman):
   - \`PUT /api/v1/user\` に \`{ user: { user_id: '' } }\` で 200 が返り、DB が NULL になること
   - 別ユーザーで同じく空文字を送って 200 が返り共存できること
   - 既に他者が使っている user_id を送って 422 が返ること

## 影響範囲
- Rails API: \`PUT /api/v1/user\` のレスポンスコード（500 → 200/422、正常系は変更なし）
- DB: マイグレーションなし
- 既存データへの影響: \`User\` を再保存したタイミングで空文字が NULL に正規化される（破壊的ではない、空文字に意味は持たせていなかった）
- 既存テストへの影響: なし（352 examples すべて通過）

## コード上の懸念点
- \`spec/requests/api/v1/users_spec.rb\` の race condition テストで \`allow_any_instance_of\` を使っている。Devise の \`current_api_v1_user\` インスタンスを直接掴めないため止むを得ず使用しており、当該行のみ \`# rubocop:disable RSpec/AnyInstance\` でインライン無効化している。
- \`before_validation\` を追加したことで、Devise の \`uid\` などほかの user_id とは別のカラムには影響しない（\`user_id\` のみ操作）。

## その他
本PRをマージ後、Sentry \`BUZZBASE-BACKEND-P\` の発生が止まることを確認する。既存の空文字行のクリーンアップマイグレーションは必要に応じて別PRで対応する。