### PR TITLE
Fix: 新規登録時のActiveRecordError 'cannot update a new record' を防止 (#246)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,7 +41,7 @@ class ApplicationController < ActionController::API
   private
 
   def update_last_login_at
-    return unless current_user
+    return unless current_user&.persisted?
     return if current_user.last_login_at&.> 1.hour.ago
 
     current_user.update_column(:last_login_at, Time.current) # rubocop:disable Rails/SkipsModelValidations

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+# Bug #246 (BUZZBASE-BACKEND-G) のリグレッション検証
+# update_last_login_at が new_record? の current_user で呼ばれても落ちないことを担保する
+RSpec.describe ApplicationController, type: :controller do
+  controller(described_class) do
+    def index
+      head :ok
+    end
+  end
+
+  describe '#update_last_login_at (after_action)' do
+    let(:controller_instance) { controller }
+
+    context 'when current_user is nil' do
+      before { allow(controller_instance).to receive(:current_user).and_return(nil) }
+
+      it 'returns early without raising' do
+        expect { controller_instance.send(:update_last_login_at) }.not_to raise_error
+      end
+    end
+
+    context 'when current_user is a new (unsaved) record' do
+      before { allow(controller_instance).to receive(:current_user).and_return(User.new(email: 'unsaved@example.com')) }
+
+      it 'returns early without raising ActiveRecord::ActiveRecordError' do
+        expect { controller_instance.send(:update_last_login_at) }.not_to raise_error
+      end
+
+      it 'does not attempt update_column on the unsaved record' do
+        allow(controller_instance.current_user).to receive(:update_column)
+        controller_instance.send(:update_last_login_at)
+        expect(controller_instance.current_user).not_to have_received(:update_column)
+      end
+    end
+
+    context 'when current_user is persisted with a recent last_login_at' do
+      let(:user) { create(:user, last_login_at: 30.minutes.ago) }
+
+      before { allow(controller_instance).to receive(:current_user).and_return(user) }
+
+      it 'does not update last_login_at again' do
+        expect { controller_instance.send(:update_last_login_at) }
+          .not_to(change { user.reload.last_login_at })
+      end
+    end
+
+    context 'when current_user is persisted with an old last_login_at' do
+      let(:user) { create(:user, last_login_at: 2.hours.ago) }
+
+      before { allow(controller_instance).to receive(:current_user).and_return(user) }
+
+      it 'updates last_login_at to the current time' do
+        expect { controller_instance.send(:update_last_login_at) }
+          .to(change { user.reload.last_login_at })
+      end
+    end
+
+    context 'when current_user is persisted with no last_login_at' do
+      let(:user) { create(:user, last_login_at: nil) }
+
+      before { allow(controller_instance).to receive(:current_user).and_return(user) }
+
+      it 'sets last_login_at for the first time' do
+        controller_instance.send(:update_last_login_at)
+        expect(user.reload.last_login_at).to be_present
+      end
+    end
+  end
+end


### PR DESCRIPTION
## issue
close #246

## 実装概要
\`ApplicationController#update_last_login_at\` の after_action で、\`current_user\` が new_record? のインスタンスを返す稀なケースで \`update_column\` が \`ActiveRecord::ActiveRecordError: cannot update a new record\` を発火させ、Sentry にノイズを積んでいた問題を修正する。\`current_user&.persisted?\` ガードに変更して、nil・未保存レコード両方を弾く。

## 背景
Sentry \`BUZZBASE-BACKEND-G\`（0ユーザー / 39イベント / 2026-03-18〜継続中）として観測されたバグ。発火経路:

1. POST /api/v1/auth（登録 API）リクエスト到着
2. \`create\` アクションが 422（重複等）または 200（成功）を render
3. **\`after_action :update_last_login_at, if: :user_signed_in?\` 実行**
4. 何らかの経路で \`current_user\` が **new_record? のまま** 返り、\`update_column\` が落ちる
5. \`rescue_from StandardError\` がキャッチしてログ + Sentry へ送信、\`unless performed?\` で再 render しない

正確な \`current_user\` が new_record になる上流経路（DTA / Warden の状態）は完全には解明できていないが、\`update_last_login_at\` 側で \`persisted?\` を確認すれば確実に防げる多層防御の修正。

### ユーザー影響
- HTTP レスポンスは想定通り返る（影響なし）
- 登録の成否やデータ整合性は影響なし
- \`last_login_at\` の該当リクエスト時の更新だけがスキップされる（軽微）
- 主な実害は **Sentry に 39 件のノイズ**で、本当の問題が埋もれるリスク

「0 ユーザー」表示は \`Sentry.set_user(id: current_user.id)\` の id が nil（new_record）で紐付けされないため。実害ゼロを意味するわけではない。

## やらなかったこと
- \`current_user\` が new_record になる上流経路（DTA / Warden の状態解明）の追跡 — 修正には不要なため別作業に切り出し
- ユーザーへの可視メッセージや UX 変更 — 元々サイレント失敗のため、修正前後でユーザーから見える挙動は同じ

## 受入基準
- [x] \`bundle exec rspec spec/\` が全件パス（498 examples, 0 failures）
- [x] \`bundle exec rubocop\` が変更ファイルでオフェンスなし
- [x] new_record の current_user で \`update_last_login_at\` を呼んでも例外を起こさない
- [x] persisted な current_user では従来どおり last_login_at が更新される（1時間以内ならスキップ、それ以降なら更新、nil なら初期化）

## 実装詳細

### \`app/controllers/application_controller.rb\`
- \`update_last_login_at\` の guard を \`return unless current_user\` から \`return unless current_user&.persisted?\` に変更
- 1 行のみの最小差分。残りのロジック（last_login_at 1時間ガード、update_column 呼び出し）は変更なし

### \`spec/controllers/application_controller_spec.rb\`（新規）
- \`update_last_login_at\` の private メソッドを \`send\` で直接呼ぶ controller spec を追加
- 6 ケース網羅:
  - current_user が nil → 早期 return
  - current_user が new_record → **raise しない**（Bug #246 直接リグレッション）
  - current_user が new_record → \`update_column\` が呼ばれない
  - 永続化済み + last_login_at が直近 1 時間以内 → 更新しない
  - 永続化済み + last_login_at が古い → 現在時刻に更新する
  - 永続化済み + last_login_at が nil → 初めて設定する

修正前: 該当 2 ケースが \`ActiveRecord::ActiveRecordError: cannot update a new record\` で失敗することを確認済み。修正後: 全 6 件 green。

## スクリーンショット
なし（API 内部の挙動修正）

## 確認手順
1. \`docker compose exec back bundle exec rspec spec/controllers/application_controller_spec.rb\` を実行し全件 green を確認
2. \`docker compose exec back bundle exec rspec spec/\` で全件 (498 examples) 通ることを回帰確認
3. マージ後、Sentry \`BUZZBASE-BACKEND-G\` の発生が止まる/resolved になることを確認

## 影響範囲
- \`ApplicationController#update_last_login_at\` のガード 1 行のみ
- 全エンドポイントの after_action に影響するが、ロジック変更は「nil または new_record の場合に何もしない」だけで、persisted ユーザーへの挙動は完全に同一
- DB スキーマ・マイグレーションなし
- mobile/front 変更不要

## コード上の懸念点
- \`current_user\` が new_record を返す上流経路は今回の修正では追跡しきれていない。発火頻度（39件）と現在のユーザー影響（実害ゼロ）から、本質的に Devise/Warden 側の挙動の可能性が高く、ライブラリレベルの追跡には別タスクが必要。本 PR は防御層を入れる位置付け。

## その他
特になし