### PR TITLE
Fix: ログイン時のRecordInvalid 500エラーを防止 (#247)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,10 +39,10 @@ class User < ActiveRecord::Base
   after_commit :notify_slack_new_user, on: :create
 
   validates :password, custom_password: true, on: :create, unless: -> { provider.in?(%w[google apple]) }
-  validates :user_id, uniqueness: true, allow_blank: true
-  validates :user_id, format: { with: /\A[A-Za-z0-9_-]+\z/ }, allow_blank: true
-  validates :user_id, length: { minimum: 3, maximum: 30 }, allow_blank: true
-  validates :introduction, length: { maximum: 100 }
+  validates :user_id, uniqueness: true, allow_blank: true, if: :user_id_changed?
+  validates :user_id, format: { with: /\A[A-Za-z0-9_-]+\z/ }, allow_blank: true, if: :user_id_changed?
+  validates :user_id, length: { minimum: 3, maximum: 30 }, allow_blank: true, if: :user_id_changed?
+  validates :introduction, length: { maximum: 100 }, if: :introduction_changed?
 
   def password_required?
     return false if provider.in?(%w[google apple])

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -113,6 +113,52 @@ RSpec.describe User, type: :model do
         expect(user.reload.id).to eq(original_id)
       end
     end
+
+    # Bug #247 (BUZZBASE-BACKEND-M) リグレッション
+    # ログイン時の save! でレガシー値（バリデーション追加前の short user_id）が
+    # RecordInvalid を発火させて500になっていた。user_id を変更しない save では
+    # バリデーションを走らせないことで grandfather する。
+    describe 'legacy user_id (BUZZBASE-BACKEND-M regression)' do
+      it 'allows save! when legacy user_id is shorter than 3 chars and unchanged' do
+        user = create(:user, user_id: 'valid_id')
+        user.update_column(:user_id, 'ab') # rubocop:disable Rails/SkipsModelValidations
+
+        user.reload
+        expect { user.save! }.not_to raise_error
+      end
+
+      it 'allows save! when legacy user_id is longer than 30 chars and unchanged' do
+        user = create(:user, user_id: 'valid_id')
+        user.update_column(:user_id, 'a' * 35) # rubocop:disable Rails/SkipsModelValidations
+
+        user.reload
+        expect { user.save! }.not_to raise_error
+      end
+
+      it 'still rejects when user_id is being changed to an invalid value' do
+        user = create(:user, user_id: 'valid_id')
+        user.user_id = 'ab'
+        expect(user).not_to be_valid
+        expect(user.errors[:user_id]).to be_present
+      end
+    end
+  end
+
+  describe 'introduction validations' do
+    it 'allows save! when legacy introduction exceeds 100 chars and unchanged' do
+      user = create(:user)
+      user.update_column(:introduction, 'a' * 200) # rubocop:disable Rails/SkipsModelValidations
+
+      user.reload
+      expect { user.save! }.not_to raise_error
+    end
+
+    it 'still rejects when introduction is being changed to over 100 chars' do
+      user = create(:user)
+      user.introduction = 'a' * 101
+      expect(user).not_to be_valid
+      expect(user.errors[:introduction]).to be_present
+    end
   end
 
   describe 'scopes' do


### PR DESCRIPTION
## issue
close #247

## 実装概要
DTA \`SessionsController#create_and_assign_token\` がログイン時に \`@resource.save!\` を呼ぶと、User の user_id length バリデーション（2026-04-02 追加）以前に登録されたレガシーアカウント（user_id が 1〜2 文字 / 31 文字以上）で \`ActiveRecord::RecordInvalid\` が発火しログイン不可になっていた。user_id・introduction バリデーションを \`_changed?\` でスコープし、属性を変更した時だけ走るようにする。

## 背景
Sentry \`BUZZBASE-BACKEND-M\`（0ユーザー / 10イベント / 2026-04-05〜）として観測。**該当ユーザーはアプリへログイン不可**になっており、本案件の中で **唯一ユーザー実害が発生しているバグ**。

### タイムライン（決定的な裏付け）
| 日時 | イベント |
| --- | --- |
| 2026-04-02 22:48 | コミット \`db59f87\` で user_id format/length バリデーション追加 |
| 2026-04-05 08:51 | Sentry First Seen（約2.5日後） |
| 2026-04-11 12:17 | Last Seen（10件） |

### 発生フロー
1. レガシーユーザーが \`POST /api/v1/auth/sign_in\` でログイン試行（メール/パスワードは正しい）
2. DTA \`create_and_assign_token\` が \`with_lock\` 内で \`@resource.save!\` を呼ぶ（トークン保存のため）
3. **既存の user_id（例: 2文字）が length バリデーションに違反** → \`RecordInvalid\` raise
4. ログイン失敗 → ユーザーはアプリを使えない

「0 ユーザー / 10 イベント」表示は、Sentry がログイン途中で \`current_user.id\` を捕捉できずユーザー紐付けされないため。実際は同じ少数ユーザーがリトライしている可能性が高い。

## やらなかったこと
- **既存レガシーデータの一括クリーンアップマイグレーション** — 短すぎる user_id を nil 化、長すぎる user_id を切り詰め等の DB 一括変更は実施しない。本修正の grandfather パターンで、レガシー値を保ったまま使えるようにするほうが UX 的に無難（勝手に user_id を変更される体験を避ける）。
- **mobile / front の変更** — バックエンドのみで完結する修正

## 受入基準
- [x] \`bundle exec rspec spec/\` が全件パス（503 examples, 0 failures）
- [x] \`bundle exec rubocop\` が変更ファイルでオフェンスなし
- [x] レガシーな短い/長い user_id を持つユーザーの \`save!\` が落ちない
- [x] レガシーで 100 字超の introduction を持つユーザーの \`save!\` が落ちない
- [x] 新規登録・プロフィール編集での user_id / introduction バリデーションは従来通り効く
- [ ] 本番デプロイ後、Sentry \`BUZZBASE-BACKEND-M\` の発生が止まり、対象ユーザーがログイン可能になることを確認

## 実装詳細

### \`app/models/user.rb\`
\`user_id\` 関連 3 つの validates と \`introduction\` の validates に \`if: :*_changed?\` を追加:
\`\`\`ruby
validates :user_id, uniqueness: true, allow_blank: true, if: :user_id_changed?
validates :user_id, format: { with: /\A[A-Za-z0-9_-]+\z/ }, allow_blank: true, if: :user_id_changed?
validates :user_id, length: { minimum: 3, maximum: 30 }, allow_blank: true, if: :user_id_changed?
validates :introduction, length: { maximum: 100 }, if: :introduction_changed?
\`\`\`

これで:
- 新規登録 / 値の変更時 → \`*_changed?\` true → 検証 ✅
- ログイン時の \`save!\` （user_id / introduction 変更なし） → false → スキップ ✅（バグ解消）
- 他のカラム更新時 → スキップ ✅

introduction も同じ仕組みで、レガシーで 100 字超の自己紹介を持つユーザーが落ちる潜在バグを併せて防御する。

### \`spec/models/user_spec.rb\`
5 ケース追加:
- レガシー短い user_id（2 文字） + 変更なし → \`save!\` が落ちない（Bug #247 直接リグレッション）
- レガシー長い user_id（35 文字） + 変更なし → \`save!\` が落ちない
- user_id を新たに無効値に変更 → 従来通り invalid（バリデーションは正しく走る）
- レガシー長い introduction（200 字） + 変更なし → \`save!\` が落ちない
- introduction を新たに 101 字に変更 → 従来通り invalid

修正前: 該当 3 ケースが \`RecordInvalid\` で失敗することを確認済み。修正後: 全 52 件 green。

## スクリーンショット
なし（API 内部のバリデーション挙動修正）

## 確認手順
1. \`docker compose exec back bundle exec rspec spec/models/user_spec.rb\` を実行し全件 green を確認
2. \`docker compose exec back bundle exec rspec spec/\` で全件 (503 examples) 通ることを回帰確認
3. 本番デプロイ後、レガシー user_id を持つユーザーがログインできることを動作確認
4. Sentry \`BUZZBASE-BACKEND-M\` の発生が止まる/resolved になることを確認

## 影響範囲
- \`User\` モデルのバリデーション挙動（変更時のみ走るようになる）
- すべての save 経路（ログイン / 登録 / プロフィール編集 / 他アクション）
- DB スキーマ・マイグレーションなし
- mobile / front 変更不要

## コード上の懸念点
- バリデーションを \`_changed?\` でスコープする副作用として、**直接 SQL や \`update_column\` でレガシー値が DB に書き込まれた場合、その値はモデル経由のバリデーションを通過してしまう**。ただしこれは Rails の通常仕様であり、データ整合性は DB 制約 + アプリケーション層の責任分担で担保するのが筋。今回はアプリ層で過去に作られた合法的なデータを grandfather する方針として妥当と判断。
- introduction バリデーションの \`_changed?\` スコープは Sentry には現れていない予防的な追加。レガシー超過データが今後同様にログインを止めるのを防ぐ位置付け。

## その他
本案件は #244, #245, #246 と並ぶ Sentry 一括対応の中で、**唯一ユーザー実害が発生していたバグ**。優先的にマージしてプロダクションへ反映するのが望ましい。