### PR TITLE
Fix: 存在しないリソースへのアクセスで500を返す問題を修正 (#254)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,10 @@ class ApplicationController < ActionController::API
     render json: { errors: [exception.message] }, status: :bad_request
   end
 
+  rescue_from ActiveRecord::RecordNotFound do
+    render json: { errors: ['リソースが見つかりません'] }, status: :not_found unless performed?
+  end
+
   rescue_from ActiveRecord::RecordInvalid do |exception|
     if Sentry.initialized?
       Sentry.capture_message(

--- a/spec/requests/api/v1/match_results_spec.rb
+++ b/spec/requests/api/v1/match_results_spec.rb
@@ -38,6 +38,29 @@ RSpec.describe 'Api::V1::MatchResults', type: :request do
     end
   end
 
+  # Bug #254 (mobile Sentry BUZZBASE-MOBILE-1) リグレッション
+  # ApplicationController に rescue_from RecordNotFound が無く、
+  # 存在しない id への PUT が 500 を返していた。404 にする。
+  describe 'PUT /api/v1/match_results/:id (non-existent id)' do
+    context 'when the match_result does not exist' do
+      it 'returns 404 with a Japanese error message' do
+        put '/api/v1/match_results/999999',
+            params: { match_result: { my_team_score: 5 } },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:not_found)
+        expect(response.parsed_body['errors']).to include('リソースが見つかりません')
+      end
+    end
+
+    context 'when the match_result does not exist (DELETE)' do
+      it 'returns 404 instead of 500' do
+        delete '/api/v1/match_results/999999', headers: auth_headers_for(user)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
   describe 'GET /api/v1/user_game_result_search' do
     context 'when authenticated' do
       it 'returns 200' do


### PR DESCRIPTION
## issue
close #254

## 実装概要
\`ApplicationController\` に \`ActiveRecord::RecordNotFound\` 専用の \`rescue_from\` を追加し、\`find(params[:id])\` で対象が見つからないときに **404 + 日本語エラーメッセージ** を返すよう修正する。これまでは専用 rescue が無く \`rescue_from StandardError\` が catch して 500 を返していた。

## 背景
mobile Sentry \`BUZZBASE-MOBILE-1\`（8件 / 2ユーザー / 2026-04-28〜継続中）として観測:
- \`PUT /api/v1/match_results/4031\` で \`AxiosError: Request failed with status code 500\`
- backend Sentry には対応エラーなし → \`RecordNotFound\` が \`config.excluded_exceptions\` に含まれているため Sentry でキャプチャされないが、レスポンスとしては 500 を返してしまっていた
- 推定: 削除済み or 存在しない match_result id を mobile から PUT してしまっている（楽観的UI / 状態同期ずれ）

\`ApplicationController\` を継承する **全コントローラー** で同種の構造的バグが起きうるため、グローバル rescue で一括対応する。

## やらなかったこと
- mobile / front 側のエラーハンドリング改善（404 受信時のリフェッチや一覧復帰）— UX 改善は別 issue / 別 PR にて対応
- 既存の inline \`rescue ActiveRecord::RecordNotFound\`（admin / groups コントローラーなど）の整理 — 個別 rescue が先に評価されるため挙動は維持され、本 PR では触らない

## 受入基準
- [x] \`bundle exec rspec spec/\` が全件パス（505 examples, 0 failures）
- [x] \`bundle exec rubocop\` が変更ファイルでオフェンスなし
- [x] 存在しない id で \`PUT /api/v1/match_results/:id\` を叩くと **404 + \`{ errors: ['リソースが見つかりません'] }\`** が返る
- [x] 存在しない id で \`DELETE /api/v1/match_results/:id\` も同様に 404
- [x] 既存の \`CustomConfirmationsController#show\`（redirect 後の after_action 経路で RecordNotFound が出るパス）でテストが落ちないこと（\`unless performed?\` ガードで二重 render を防止）

## 実装詳細

### \`app/controllers/application_controller.rb\`
\`rescue_from ActionController::ParameterMissing\` と \`rescue_from ActiveRecord::RecordInvalid\` の間に下記を追加:
\`\`\`ruby
rescue_from ActiveRecord::RecordNotFound do
  render json: { errors: ['リソースが見つかりません'] }, status: :not_found unless performed?
end
\`\`\`

ポイント:
- \`rescue_from\` は **後に登録された具象的なハンドラが優先**されるため、既存の \`rescue_from StandardError\` よりも \`RecordNotFound\` が先に評価される
- \`unless performed?\` ガードを入れることで、すでに \`redirect_to\` または \`render\` 済みのレスポンス（\`CustomConfirmationsController#show\` の after_action 経路など）に対して二重 render が発生するのを防ぐ
- 既存の \`rescue_from StandardError\` も同じパターンなので、本ファイル内で挙動の整合性が取れる

### \`spec/requests/api/v1/match_results_spec.rb\`
2 ケース追加:
- \`PUT /api/v1/match_results/999999\`（存在しない id） → 404 + \`'リソースが見つかりません'\` メッセージ（Bug #254 直接リグレッション）
- \`DELETE /api/v1/match_results/999999\` → 500 ではなく 404

修正前: 両ケースが 500 を返すことを確認済み。修正後: green。

## スクリーンショット
なし（API 内部のステータスコード修正）

## 確認手順
1. \`docker compose exec back bundle exec rspec spec/requests/api/v1/match_results_spec.rb\` を実行し全件 green を確認
2. \`docker compose exec back bundle exec rspec spec/\` で全件（505 examples）通ることを回帰確認（\`CustomConfirmationsController\` 含む）
3. 手動: 認証ヘッダー付きで存在しない id に PUT/DELETE を叩いて 404 + JSON が返ることを確認
4. マージ後、mobile Sentry \`BUZZBASE-MOBILE-1\` の発生が止まることを確認

## 影響範囲
- \`ApplicationController\` を継承する **全コントローラー** で、find 失敗時のレスポンスが **500 → 404** に変更される
- 既存の inline \`rescue ActiveRecord::RecordNotFound\`（admin / groups 系）はそのまま動作（個別 rescue が先に評価される）
- mobile / front のエラーハンドリングは正しいステータスコードに反応できるようになる（破壊変更ではないが、404 を機にする実装があれば挙動改善になる）
- DB スキーマ・マイグレーションなし

## コード上の懸念点
- \`rescue_from\` の評価順は **後に登録されたものが優先**という Rails 仕様に依存する。本ファイル内の登録順序を将来書き換える場合は要注意（ただし今回は既存の \`rescue_from ActiveRecord::RecordInvalid\` と同じ場所に置いており、慣習に沿う）
- レスポンスメッセージは Issue 本文の指定（"リソースが見つかりません"）通り。種別ごとに「ユーザーが見つかりません」等と細かく出し分けるのは個別 controller 側で個別 rescue する設計を維持できる

## その他
- 既存の \`rescue_from StandardError\` の \`unless performed?\` パターンと整合
- 本 PR は #244, #245, #246, #247 と同じ Sentry エラー一掃シリーズの 5 件目