### PR TITLE
Change: 野球ノート一覧のソート順を作成日時降順に変更

### DIFF
--- a/app/controllers/api/v1/baseball_notes_controller.rb
+++ b/app/controllers/api/v1/baseball_notes_controller.rb
@@ -5,7 +5,7 @@ module Api
       before_action :set_baseball_note, only: %i[show update destroy]
 
       def index
-        @baseball_notes = current_api_v1_user.baseball_notes.order(date: :desc)
+        @baseball_notes = current_api_v1_user.baseball_notes.order(created_at: :desc)
 
         modified_notes = @baseball_notes.map do |note|
           memo_text = note.extract_and_truncate_memo

--- a/spec/requests/api/v1/baseball_notes_spec.rb
+++ b/spec/requests/api/v1/baseball_notes_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::BaseballNotes', type: :request do
+  let(:user) { create(:user) }
+
+  describe 'GET /api/v1/baseball_notes' do
+    context 'when authenticated' do
+      # 試合日付と作成日時の前後関係を意図的にずらす
+      let!(:old_created_recent_game) do
+        create(:baseball_note, user:, date: Date.new(2026, 5, 1),
+                               created_at: 3.days.ago, updated_at: 3.days.ago)
+      end
+      let!(:middle) do
+        create(:baseball_note, user:, date: Date.new(2026, 3, 15),
+                               created_at: 1.day.ago, updated_at: 1.day.ago)
+      end
+      let!(:new_created_old_game) do
+        create(:baseball_note, user:, date: Date.new(2025, 1, 1),
+                               created_at: 1.minute.ago, updated_at: 1.minute.ago)
+      end
+
+      it 'ノートを作成日時の降順で返す' do
+        get '/api/v1/baseball_notes', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        ids = response.parsed_body.pluck('id')
+        expect(ids).to eq([new_created_old_game.id, middle.id, old_created_recent_game.id])
+      end
+    end
+
+    context 'when authenticated with multiple users' do
+      it '他ユーザーのノートは含めない' do
+        own = create(:baseball_note, user:)
+        create(:baseball_note, user: create(:user))
+
+        get '/api/v1/baseball_notes', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        ids = response.parsed_body.pluck('id')
+        expect(ids).to eq([own.id])
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v1/baseball_notes'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## issue
（#258 関連 — App Hang対応中に発見した別件のため、issue#258内で扱う）

## 実装概要
\`Api::V1::BaseballNotesController#index\` のソート順を \`order(date: :desc)\` から \`order(created_at: :desc)\` に変更。

## 背景
これまで一覧は試合日付（\`date\`）降順でソートしていたが、過去の試合について後からノートを書いたケースで「さっき書いたノートが下に埋もれて見つけにくい」という問題があった。野球ノートは記録の習慣化を支援する機能であり、最近の活動が一覧トップに来たほうがユーザーが書いたコンテンツを見失わない。

最も新しく作成したノートが一番上に来るよう変更する。

## やらなかったこと
- \`updated_at\` 降順との併用（編集時にもトップに上げる）→ 今回は作成順のみ
- 多段ソート（\`date\` 降順と \`created_at\` 降順の組合せ）→ シンプルに \`created_at\` 単体
- フロントエンド側の対応 → 一覧表示はバックエンドの順序をそのまま表示しているため変更不要

## 受入基準
- [ ] 一覧APIが \`created_at\` 降順で返却される
- [ ] 他ユーザーのノートは含まれない
- [ ] 未認証時は401を返す
- [ ] 既存のRSpec（modelスペック）に影響がない

## 実装詳細

### 修正ファイル
- \`app/controllers/api/v1/baseball_notes_controller.rb\`
  - \`order(date: :desc)\` → \`order(created_at: :desc)\` の1行変更

### 新規ファイル
- \`spec/requests/api/v1/baseball_notes_spec.rb\` — 一覧APIのリクエストスペック（既存に未存在のため新規作成）
  - 「ノートを作成日時の降順で返す」: 試合日付と作成日時の前後関係を意図的にずらしたデータで、APIレスポンスの順序が \`created_at\` 順になることを検証
  - 「他ユーザーのノートは含めない」: スコープ \`current_api_v1_user.baseball_notes\` の動作確認
  - 「returns 401」: 未認証時の動作確認

## スクリーンショット
なし（APIレスポンスのソート順のみ変更）

## 確認手順
\`\`\`bash
# テスト実行
docker compose exec back bundle exec rspec spec/requests/api/v1/baseball_notes_spec.rb spec/models/baseball_note_spec.rb

# 期待: 8 examples, 0 failures
\`\`\`

実機/モバイル側での確認:
1. ノート一覧画面を開く
2. 過去日付の試合に対して新たにノートを作成
3. 一覧に戻る → **作ったばかりのノートが一番上に表示される**
4. 既存ノートを開いて保存（編集）→ 順番は変わらない（updated_atは使っていないため）

## 影響範囲
- モバイルアプリのノート一覧画面（\`mobile/app/(tabs)/(profile)/notes/index.tsx\`）の表示順序
- フロントエンド側のコード変更は不要

## コード上の懸念点
- 既存ユーザーのデータでは \`created_at\` がインポート時刻に集中しているケースも考えられるが、今後作成されるノートから自然に \`created_at\` 降順が機能する
- 順序のtie-breakは指定していないが、\`created_at\` は ms粒度なので衝突はほぼ起きない想定

## その他
issue#258（iOS App Hang）の対応中に「ノート一覧の並びが直感的でない」という別件として上がったため、同じissue番号の傘下で進めている。本PRはバックエンドのみの変更で、mobile側の#258 PR（[buzzbase_mobile#53](https://github.com/ippei-shimizu/buzzbase_mobile/pull/53)）とは独立してマージ可能。