### PR TITLE
Fix: TeamsController#createのForeignKey違反を事前バリデーションとrescueで防止

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,6 +38,15 @@ class ApplicationController < ActionController::API
     render json: { errors: exception.record.errors.full_messages }, status: :unprocessable_entity
   end
 
+  # ActiveRecord 層のバリデーションをすり抜けた外部キー違反 (例: 並列削除によるレース、
+  # 新たに追加されたカラムでバリデーション漏れ等) は 500 ではなく 422 として扱い、
+  # ユーザーに「不正な入力」であることが伝わる形で返す。後続調査用に Sentry にも記録。
+  rescue_from ActiveRecord::InvalidForeignKey do |exception|
+    Rails.logger.warn("InvalidForeignKey: #{exception.message}")
+    Sentry.capture_exception(exception) if Sentry.initialized?
+    render json: { errors: ['指定された関連データが存在しません'] }, status: :unprocessable_entity
+  end
+
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:account_update, keys: %i[name user_id])
   end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -6,4 +6,29 @@ class Team < ApplicationRecord
   validates :name, presence: true
   validates :category_id, numericality: { only_integer: true, greater_than: 0, allow_nil: true }
   validates :prefecture_id, numericality: { only_integer: true, greater_than: 0, allow_nil: true }
+  validate :prefecture_must_exist
+  validate :category_must_exist
+
+  private
+
+  # prefecture_id がマスターに存在することを保証する。
+  # numericality バリデーションを通り抜けた正の整数でも、prefectures テーブルに該当行が
+  # 存在しなければ FK 違反 (PG::ForeignKeyViolation) になり 500 を返してしまうため、
+  # ActiveRecord 層で先に検出する。
+  def prefecture_must_exist
+    return if prefecture_id.blank?
+    return if errors[:prefecture_id].any?
+    return if Prefecture.exists?(id: prefecture_id)
+
+    errors.add(:prefecture_id, 'は存在しない都道府県です')
+  end
+
+  # category_id がマスターに存在することを保証する。詳細は prefecture_must_exist と同様。
+  def category_must_exist
+    return if category_id.blank?
+    return if errors[:category_id].any?
+    return if BaseballCategory.exists?(id: category_id)
+
+    errors.add(:category_id, 'は存在しないカテゴリです')
+  end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -39,5 +39,19 @@ RSpec.describe Team, type: :model do
       team = described_class.new(name: 'テスト', prefecture_id: -1)
       expect(team).not_to be_valid
     end
+
+    it 'is invalid when prefecture_id refers to a non-existent record' do
+      missing_id = Prefecture.maximum(:id).to_i + 9999
+      team = described_class.new(name: 'テスト', prefecture_id: missing_id)
+      expect(team).not_to be_valid
+      expect(team.errors[:prefecture_id]).to include('は存在しない都道府県です')
+    end
+
+    it 'is invalid when category_id refers to a non-existent record' do
+      missing_id = BaseballCategory.maximum(:id).to_i + 9999
+      team = described_class.new(name: 'テスト', category_id: missing_id)
+      expect(team).not_to be_valid
+      expect(team.errors[:category_id]).to include('は存在しないカテゴリです')
+    end
   end
 end

--- a/spec/requests/api/v1/teams_spec.rb
+++ b/spec/requests/api/v1/teams_spec.rb
@@ -73,6 +73,44 @@ RSpec.describe 'Api::V1::Teams', type: :request do
       end
     end
 
+    context 'when prefecture_id is a positive integer that does not exist' do
+      it 'returns 422 with a Japanese error message' do
+        missing_id = Prefecture.maximum(:id).to_i + 9999
+        post '/api/v1/teams',
+             params: { team: { name: '存在しない都道府県チーム', category_id: category.id, prefecture_id: missing_id } },
+             headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['prefecture_id']).to include('は存在しない都道府県です')
+        expect(Team.where(name: '存在しない都道府県チーム')).to be_empty
+      end
+    end
+
+    context 'when category_id is a positive integer that does not exist' do
+      it 'returns 422 with a Japanese error message' do
+        missing_id = BaseballCategory.maximum(:id).to_i + 9999
+        post '/api/v1/teams',
+             params: { team: { name: '存在しないカテゴリチーム', category_id: missing_id, prefecture_id: prefecture.id } },
+             headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['category_id']).to include('は存在しないカテゴリです')
+        expect(Team.where(name: '存在しないカテゴリチーム')).to be_empty
+      end
+    end
+
+    context 'when ActiveRecord validation is bypassed and FK violation is raised at DB level' do
+      it 'is rescued and returns 422 instead of 500' do
+        allow_any_instance_of(Team).to receive(:valid?).and_return(true) # rubocop:disable RSpec/AnyInstance
+        post '/api/v1/teams',
+             params: { team: { name: 'バリデーションすり抜けチーム', category_id: category.id, prefecture_id: 999_999 } },
+             headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['errors']).to include('指定された関連データが存在しません')
+      end
+    end
+
     context 'when prefecture_id is empty string' do
       it 'creates the team treating it as nil' do
         post '/api/v1/teams',


### PR DESCRIPTION
## issue
close #290

## 実装概要
- `Team` モデルに `prefecture_id` / `category_id` のマスター存在チェックバリデーションを追加
- `ApplicationController` に `ActiveRecord::InvalidForeignKey` の `rescue_from` を追加し、500ではなく422で返すよう保険を敷いた

## 背景
本番iOSアプリ (`BUZZBASE/13`) から `POST /api/v1/teams` に `prefecture_id=0` が送られて `PG::ForeignKeyViolation (fk_rails_61b55c7fe1)` が発生（Sentry: 2026-04-07〜04-25 / 3 users / 15 events）。

`belongs_to :prefecture, optional: true` のため Rails の存在チェックが効かず、`numericality: { greater_than: 0 }` を後から追加したものの、現実には「正の整数だが存在しないID」「validation すり抜けによる並列削除レース」等で同種の事故が起きる可能性が残っていた。ユーザー側では「内部サーバーエラー」のアラートが出るだけで、しかもプロフィール編集画面では同フォームの他の項目（プロフィール本体・ポジション・受賞歴）も連鎖的に保存できなくなっていたため、影響度が大きかった。

## やらなかったこと
- 根本原因と推定される **モバイル `SelectPicker` のクリア戻り値が `0`** だった件は、別リポジトリ（buzzbase_mobile）で対応する
- フロント側のSelectPicker相当コンポーネントの監査は本PRのスコープ外

## 受入基準
- [ ] `prefecture_id=0` を送っても 422 が返り、500 にならない
- [ ] `prefecture_id` が正の整数だが存在しない値（例: 9999）でも 422 が返る
- [ ] `category_id` 側でも同様に 422 が返る
- [ ] 既存の正常系（マスターIDなし / 有効なマスターID）が引き続き 201 で作成される
- [ ] バリデーションをすり抜けた DB レベルの FK 違反でも 500 ではなく 422 が返る

## 実装詳細
### `app/models/team.rb`
- `validate :prefecture_must_exist` / `validate :category_must_exist` を追加
- `numericality` で既に検出済みの場合は二重エラーにならないよう `errors[...].any?` を見てスキップ
- 日本語のエラーメッセージを `errors.add` で追加

### `app/controllers/application_controller.rb`
- `rescue_from ActiveRecord::InvalidForeignKey` を追加
- 422 で `errors: ['指定された関連データが存在しません']` を返却
- Sentry にも `capture_exception` で記録（後追い調査のため）

### `spec/models/team_spec.rb`
- 「`prefecture_id` が存在しない正の整数の場合 invalid」「`category_id` 同様」のケースを追加

### `spec/requests/api/v1/teams_spec.rb`
- 「存在しない `prefecture_id`/`category_id` で 422 が返り、日本語エラーメッセージが含まれる」を追加
- 「`Team#valid?` を `true` に差し替えてバリデーションをすり抜けさせ、DB レベルで FK 違反を起こしたケースで `rescue_from` が 422 で握る」を追加

## スクリーンショット
なし

## 確認手順
1. `docker compose exec back bundle exec rspec spec/models/team_spec.rb spec/requests/api/v1/teams_spec.rb` で 22 examples / 0 failures を確認
2. ローカル起動の API に `curl -X POST http://localhost:3100/api/v1/teams -H 'Content-Type: application/json' -H '<auth headers>' -d '{\"team\":{\"name\":\"a\",\"prefecture_id\":0}}'` を送って 422 と日本語エラーが返ることを確認
3. `prefecture_id` を 99999 / 不正値 / 省略 / 有効値 でそれぞれ動作確認

## 影響範囲
- `POST /api/v1/teams` の挙動：`prefecture_id`/`category_id` が不正な場合、500 → 422 + 日本語エラーに変化
- `ActiveRecord::InvalidForeignKey` を投げる他の経路すべて：500 → 422 に変化（保険的に効くが、本来はそれぞれの所でバリデーションすべき）

## コード上の懸念点
- `rescue_from ActiveRecord::InvalidForeignKey` は他のテーブルの不正FKでも 422 を返すようになる。ユーザー向けには適切だが、サーバー側のバグを 422 で覆い隠すリスクがある。Sentry には記録するので調査自体は可能

## その他
モバイル側 `SelectPicker` のクリア戻り値修正（`0` → `null`）は別途 buzzbase_mobile リポジトリで対応する。