### PR TITLE
Fix: 試合結果削除APIを冪等化し404連打ループを解消

### DIFF
--- a/app/controllers/api/v1/game_results_controller.rb
+++ b/app/controllers/api/v1/game_results_controller.rb
@@ -91,7 +91,7 @@ module Api
         if game_result.destroy
           render json: { message: '試合結果を削除しました' }, status: :ok
         else
-          render json: { errors: '試合成績の削除に失敗しました' }, status: :unprocessable_entity
+          render json: { errors: ['試合成績の削除に失敗しました'] }, status: :unprocessable_entity
         end
       end
 

--- a/app/controllers/api/v1/game_results_controller.rb
+++ b/app/controllers/api/v1/game_results_controller.rb
@@ -5,7 +5,7 @@ module Api
       before_action :authenticate_api_v1_user!,
                     only: %i[create update update_batting_average_id game_associated_data_index destroy game_associated_data_index_user_id
                              filtered_game_associated_data filtered_game_associated_data_user_id]
-      before_action :set_game_result, only: %i[update update_batting_average_id update_pitching_result_id destroy]
+      before_action :set_game_result, only: %i[update update_batting_average_id update_pitching_result_id]
 
       def all_game_associated_data
         game_results = GameResult.all_game_associated_data
@@ -78,8 +78,17 @@ module Api
         render json: game_results
       end
 
+      # DELETE /api/v1/game_results/:id
+      # 冪等化: 既に削除済み・他ユーザー所有・存在しない id でも 200 を返す。
+      # 理由: DELETE は HTTP 仕様上冪等であるべきで、クライアント側のキャッシュやナビゲーション
+      # パラメータに古い id が残っている場合に 404 連打ループを起こさないため。
+      # @return [JSON] { message: String }
       def destroy
-        if @game_result.destroy
+        game_result = current_api_v1_user.game_results.find_by(id: params[:id])
+
+        return render json: { message: '試合結果は既に削除されています' }, status: :ok if game_result.nil?
+
+        if game_result.destroy
           render json: { message: '試合結果を削除しました' }, status: :ok
         else
           render json: { errors: '試合成績の削除に失敗しました' }, status: :unprocessable_entity

--- a/app/controllers/api/v1/match_results_controller.rb
+++ b/app/controllers/api/v1/match_results_controller.rb
@@ -4,7 +4,8 @@ module Api
       include MatchTypeConvertible
 
       before_action :authenticate_api_v1_user!, only: %i[create update destroy existing_search current_game_result_search current_user_match_index match_index_user_id user_game_result_search available_years]
-      before_action :set_match_result, only: %i[show update destroy]
+      before_action :set_match_result, only: %i[show]
+      before_action :set_owned_match_result, only: %i[update destroy]
       before_action :normalize_match_type, only: %i[create update]
 
       def index
@@ -13,6 +14,8 @@ module Api
       end
 
       def show
+        return render json: { errors: ['リソースが見つかりません'] }, status: :not_found if @match_result.nil?
+
         render json: @match_result
       end
 
@@ -26,6 +29,8 @@ module Api
       end
 
       def update
+        return render json: { errors: ['リソースが見つかりません'] }, status: :not_found if @match_result.nil?
+
         if @match_result.update(match_results_params)
           render json: @match_result
         else
@@ -33,8 +38,14 @@ module Api
         end
       end
 
+      # DELETE /api/v1/match_results/:id
+      # 冪等化: 既に削除済みでも 200 を返す。所有権チェックは authorize_match_result_owner! で実施済み。
+      # @return [JSON] { message: String }
       def destroy
+        return render json: { message: '試合情報は既に削除されています' }, status: :ok if @match_result.nil?
+
         @match_result.destroy
+        render json: { message: '試合情報を削除しました' }, status: :ok
       end
 
       def match_index_user_id
@@ -110,8 +121,17 @@ module Api
 
       private
 
+      # show 用: 認証なしでもアクセス可能なため、ユーザースコープで絞らずに取得する。
+      # 取得後の表示可否は、必要に応じて呼び出し元で判断する。
       def set_match_result
-        @match_result = MatchResult.find(params[:id])
+        @match_result = MatchResult.find_by(id: params[:id])
+      end
+
+      # update / destroy 用: 認証ユーザー所有の match_result のみを対象にする。
+      # 他ユーザーのリソースや存在しない id は nil として扱い、各アクションで 404 / 200 にハンドルする。
+      # 「他人のもの」と「存在しない」を区別しないことで、id 列挙によるリソース存在性の漏洩を防ぐ。
+      def set_owned_match_result
+        @match_result = current_api_v1_user.match_results.find_by(id: params[:id])
       end
 
       def normalize_match_type

--- a/app/controllers/api/v1/match_results_controller.rb
+++ b/app/controllers/api/v1/match_results_controller.rb
@@ -39,13 +39,16 @@ module Api
       end
 
       # DELETE /api/v1/match_results/:id
-      # 冪等化: 既に削除済みでも 200 を返す。所有権チェックは authorize_match_result_owner! で実施済み。
-      # @return [JSON] { message: String }
+      # 冪等化: 既に削除済みでも 200 を返す。所有権スコープは set_owned_match_result で適用済み。
+      # @return [JSON] { message: String } または { errors: Array<String> }
       def destroy
         return render json: { message: '試合情報は既に削除されています' }, status: :ok if @match_result.nil?
 
-        @match_result.destroy
-        render json: { message: '試合情報を削除しました' }, status: :ok
+        if @match_result.destroy
+          render json: { message: '試合情報を削除しました' }, status: :ok
+        else
+          render json: { errors: @match_result.errors.full_messages }, status: :unprocessable_entity
+        end
       end
 
       def match_index_user_id

--- a/spec/requests/api/v1/game_results_spec.rb
+++ b/spec/requests/api/v1/game_results_spec.rb
@@ -202,6 +202,30 @@ RSpec.describe 'Api::V1::GameResults', type: :request do
         expect(response).to have_http_status(:unauthorized)
       end
     end
+
+    context 'when the game result does not exist (idempotent)' do
+      it 'returns 200 with already-deleted message' do
+        delete '/api/v1/game_results/999999', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json['message']).to eq('試合結果は既に削除されています')
+      end
+    end
+
+    context 'when the game result belongs to another user (idempotent)' do
+      let(:other_user) { create(:user) }
+      let!(:other_user_game_result) { create(:game_result, user: other_user) }
+
+      it 'returns 200 without deleting the other user\'s record' do
+        delete "/api/v1/game_results/#{other_user_game_result.id}", headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json['message']).to eq('試合結果は既に削除されています')
+        expect(GameResult.exists?(other_user_game_result.id)).to be true
+      end
+    end
   end
 
   describe 'GET /api/v1/game_results/filtered_game_associated_data' do

--- a/spec/requests/api/v1/match_results_spec.rb
+++ b/spec/requests/api/v1/match_results_spec.rb
@@ -52,11 +52,70 @@ RSpec.describe 'Api::V1::MatchResults', type: :request do
         expect(response.parsed_body['errors']).to include('リソースが見つかりません')
       end
     end
+  end
 
-    context 'when the match_result does not exist (DELETE)' do
-      it 'returns 404 instead of 500' do
+  # Bug #287 (mobile Sentry BUZZBASE-MOBILE-8) リグレッション
+  # 既に削除済みリソースへの DELETE で 404 連打ループが発生していた。冪等化する。
+  describe 'DELETE /api/v1/match_results/:id' do
+    let!(:own_game_result) { create(:game_result, user:) }
+    let(:own_match_result) { own_game_result.match_result }
+
+    context 'when authenticated and owner' do
+      it 'destroys the match_result and returns 200' do
+        delete "/api/v1/match_results/#{own_match_result.id}", headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['message']).to eq('試合情報を削除しました')
+        expect(MatchResult.exists?(own_match_result.id)).to be false
+      end
+    end
+
+    context 'when the match_result does not exist (idempotent)' do
+      it 'returns 200 with already-deleted message' do
         delete '/api/v1/match_results/999999', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['message']).to eq('試合情報は既に削除されています')
+      end
+    end
+
+    # 他ユーザーの match_result はユーザースコープ外として nil 扱いになるため、
+    # 「既に削除済み」と同じレスポンス (200) を返し、レコードは消えない。
+    context 'when the match_result belongs to another user' do
+      let(:other_match_result) { other_game_result.match_result }
+
+      it 'returns 200 without deleting the record' do
+        delete "/api/v1/match_results/#{other_match_result.id}", headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['message']).to eq('試合情報は既に削除されています')
+        expect(MatchResult.exists?(other_match_result.id)).to be true
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        delete "/api/v1/match_results/#{own_match_result.id}"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'PUT /api/v1/match_results/:id (ownership scope)' do
+    # 他ユーザーの match_result はユーザースコープ外として nil 扱いになるため、
+    # update では 404 を返し、レコードは更新されない。
+    context 'when the match_result belongs to another user' do
+      let(:other_match_result) { other_game_result.match_result }
+
+      it 'returns 404 without updating the record' do
+        original_score = other_match_result.my_team_score
+        put "/api/v1/match_results/#{other_match_result.id}",
+            params: { match_result: { my_team_score: original_score + 99 } },
+            headers: auth_headers_for(user)
+
         expect(response).to have_http_status(:not_found)
+        expect(other_match_result.reload.my_team_score).to eq(original_score)
       end
     end
   end


### PR DESCRIPTION
## Summary
- `GameResultsController#destroy` と `MatchResultsController#destroy` を冪等化し、存在しない/他人の id への DELETE でも 200 を返すよう修正
- `MatchResultsController` の `set_owned_match_result` でユーザースコープを絞り、他人のリソースを編集・削除できるセキュリティ問題も同時に解消

## Background
モバイル Sentry [BUZZBASE-MOBILE-8](https://0dd1e9c639d9.sentry.io/issues/BUZZBASE-MOBILE-8) で 9 users / 22 events の AxiosError 404 が観測されていた。原因は **クライアント側のキャッシュやナビゲーション params に削除済みの `game_result_id` が残ったまま再操作する** ケースで、サーバが 404 を返し、クライアント側が「削除に失敗しました」アラートを表示 → ユーザーが再タップ → また 404 のループ。

DELETE は HTTP 仕様上冪等であるべきで、`find` で `RecordNotFound` を投げる旧実装は仕様違反だった。

## Changes
### GameResultsController
- `set_game_result` の `only:` から `:destroy` を除外
- `destroy` で `current_api_v1_user.game_results.find_by(id:)` を使い、nil なら `200 { message: '試合結果は既に削除されています' }`

### MatchResultsController
- `set_match_result` を show 用、`set_owned_match_result` を update/destroy 用に分離
- `current_api_v1_user.match_results.find_by(id:)` でユーザースコープ化（既存 `User has_many :match_results` を活用）
- `update`: nil なら `404 { errors: ['リソースが見つかりません'] }`
- `destroy`: nil なら `200 { message: '試合情報は既に削除されています' }`、ある場合は破棄して `200 { message: '試合情報を削除しました' }`
- 「他人のもの」と「存在しない」を統一的に nil 扱いにすることで、id 列挙によるリソース存在性漏洩を防ぐ

### Tests
- `game_results_spec.rb`: 「存在しない id」「他ユーザー所有」のコンテキスト追加
- `match_results_spec.rb`: 「自分の destroy 200」「冪等化 200」「他ユーザー destroy → 200 で消えない」「他ユーザー update → 404 で更新されない」を追加
- 既存の「DELETE 999999 → 404」テストは冪等化に合わせて 200 期待に更新

## Test plan
- [x] `docker compose exec back bundle exec rspec spec/requests/api/v1/game_results_spec.rb spec/requests/api/v1/match_results_spec.rb`（41 examples, 0 failures）
- [x] `docker compose exec back bundle exec rubocop`（no offenses detected）
- [ ] フロント・モバイルの対応 PR と合わせてステージング環境で手動確認
- [ ] デプロイ後 Sentry でリグレッション監視

refs #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)