### PR TITLE
Fix: アカウント削除時の500エラーを解消（issue #288）

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -129,7 +129,8 @@ module Api
         current_api_v1_user.destroy!
         render json: { success: true, message: 'アカウントが削除されました' }
       rescue StandardError => e
-        Rails.logger.error "Account deletion failed: #{e.message}"
+        Rails.logger.error "Account deletion failed: #{e.class}: #{e.message}"
+        Sentry.capture_exception(e) if defined?(Sentry) && Sentry.initialized?
         render json: {
           success: false,
           error: 'アカウントの削除に失敗しました。しばらく時間をおいてから再度お試しください。'

--- a/app/models/group_invite_link.rb
+++ b/app/models/group_invite_link.rb
@@ -3,7 +3,7 @@ class GroupInviteLink < ApplicationRecord
   CODE_LENGTH = 8
 
   belongs_to :group
-  belongs_to :inviter, class_name: 'User'
+  belongs_to :inviter, class_name: 'User', inverse_of: :group_invite_links
 
   validates :code, presence: true, uniqueness: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ActiveRecord::Base
   mount_uploader :image, AvatarUploader
   has_many :user_positions, dependent: :destroy
   has_many :positions, through: :user_positions
-  belongs_to :team, foreign_key: 'user_id', primary_key: 'id', optional: true, inverse_of: :team
+  belongs_to :team, foreign_key: 'user_id', primary_key: 'id', optional: true, inverse_of: :user
   has_many :user_awards, dependent: :destroy
   has_many :awards, through: :user_awards
   has_many :active_relationships, class_name: 'Relationship', foreign_key: 'follower_id', dependent: :destroy, inverse_of: :follower
@@ -18,6 +18,9 @@ class User < ActiveRecord::Base
   has_many :group_users, dependent: :destroy
   has_many :groups, through: :group_users
   has_many :group_invitations, dependent: :destroy
+  has_many :group_invite_links, class_name: 'GroupInviteLink', foreign_key: 'inviter_id',
+                                dependent: :destroy, inverse_of: :inviter
+  has_many :group_ranking_snapshots, dependent: :destroy
   has_many :user_notifications, dependent: :destroy
   has_many :notifications, through: :user_notifications
   has_many :actor_notifications, class_name: 'Notification', foreign_key: 'actor_id',

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -74,4 +74,71 @@ RSpec.describe 'Api::V1::Users', type: :request do
       end
     end
   end
+
+  describe 'DELETE /api/v1/user' do
+    let(:user) { create(:user) }
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        delete '/api/v1/user'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated with no related records' do
+      it 'destroys the user and returns success' do
+        headers = auth_headers_for(user)
+
+        expect do
+          delete '/api/v1/user', headers:
+        end.to change(User, :count).by(-1)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to eq('success' => true, 'message' => 'アカウントが削除されました')
+        expect(User.exists?(user.id)).to be(false)
+      end
+    end
+
+    # BUZZBASE-MOBILE-1 (issue #288) リグレッション防止:
+    # group_invite_links / group_ranking_snapshots を持つユーザーが
+    # PG::ForeignKeyViolation で削除できなかった問題への回帰テスト
+    context 'when user has a group invite link as inviter (issue #288 regression)' do
+      it 'destroys the user and cascades the invite link' do
+        invite_link = create(:group_invite_link, inviter: user)
+
+        delete '/api/v1/user', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(User.exists?(user.id)).to be(false)
+        expect(GroupInviteLink.exists?(invite_link.id)).to be(false)
+      end
+    end
+
+    context 'when user has group ranking snapshots (issue #288 regression)' do
+      it 'destroys the user and cascades the snapshots' do
+        snapshot = create(:group_ranking_snapshot, user:)
+
+        delete '/api/v1/user', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(User.exists?(user.id)).to be(false)
+        expect(GroupRankingSnapshot.exists?(snapshot.id)).to be(false)
+      end
+    end
+
+    context 'when destroy! raises an unexpected error' do
+      it 'returns 500 with a localized message instead of leaking the exception' do
+        # Devise が返す current_api_v1_user を直接掴めないため any_instance を許可
+        allow_any_instance_of(User).to receive(:destroy!).and_raise(StandardError, 'boom') # rubocop:disable RSpec/AnyInstance
+
+        delete '/api/v1/user', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:internal_server_error)
+        expect(response.parsed_body).to include(
+          'success' => false,
+          'error' => a_string_including('アカウントの削除に失敗しました')
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
## issue
close ippei-shimizu/buzzbase#288

## 実装概要

mobileから `DELETE /api/v1/user`（アカウント削除）を実行すると500が返る問題を解消する。User モデルに `dependent: :destroy` の宣言が漏れていた2つの関連を追加し、退会処理で `PG::ForeignKeyViolation` が発生しないようにする。あわせてSentry通知の追加と、検出済みの inverse_of 誤りを修正する。

## 背景

- Sentry `BUZZBASE-MOBILE-1`: 4ユーザー × 12イベントが発生（`AxiosError: Request failed with status code 500` / `method=delete` / `url=/user`）
- バックエンドSentryには痕跡がなく追えなかった原因は、`UsersController#destroy` の `rescue StandardError` が例外を握りつぶし、`Sentry.capture_exception` を呼んでいなかったため
- 開発環境で `User#destroy!` を再現したところ以下の例外を確認:
  ```
  ActiveRecord::InvalidForeignKey: PG::ForeignKeyViolation:
  update or delete on table "users" violates foreign key constraint
  "fk_rails_edbef21e41" on table "group_invite_links"
  ```
- 全テーブルの users.id 参照FKを走査し、User側に逆向き関連が無いものを抽出:
  - `group_invite_links.inviter_id`（招待コード機能で導入。今回の500の直接原因）
  - `group_ranking_snapshots.user_id`（同じ仕組みで500になる潜在バグ）
- 同時期発生中の `BUZZBASE-BACKEND-Q`（`InverseOfAssociationNotFoundError` on TeamsController#index）の主因も `app/models/user.rb:5` の `belongs_to :team, inverse_of: :team`（`:user` の誤り）と特定済み。User#destroy のキャスケード処理にも波及するため同梱

## やらなかったこと

- `group_ranking_snapshots` を「履歴データ」として残す方針（schema変更で `user_id` を nullable にして `dependent: :nullify` 化）。スコープ拡大のため今回は `dependent: :destroy` で一括削除を採用
- User の `soft_delete!` メソッドへの切り替え。ストアレビュー要件もありハード destroy を維持
- User参照FKの追加検知CIの整備。今回は対象外

## 受入基準

- [ ] グループ招待リンクを発行したことのあるユーザーが退会できる
- [ ] グループランキングスナップショットを持つユーザーが退会できる
- [ ] User#destroy で例外が発生した場合に Sentry buzzbase-backend へキャプチャされる
- [ ] TeamsController#index で `InverseOfAssociationNotFoundError` が発生しない
- [ ] 既存のチーム/グループ/招待リンク関連スペックが全てパスする

## 実装詳細

### \`app/models/user.rb\`

3箇所修正。

- **(a) line 5**: `belongs_to :team, ..., inverse_of: :team` → `inverse_of: :user` に修正。Team側 `has_one :user, inverse_of: :team` (team.rb:4) と整合させる
- **(b) `has_many :group_invite_links` 追加**: `actor_notifications` と同パターンで `class_name: 'GroupInviteLink', foreign_key: 'inviter_id', dependent: :destroy, inverse_of: :inviter`
- **(c) `has_many :group_ranking_snapshots, dependent: :destroy` 追加**

### \`app/controllers/api/v1/users_controller.rb\`

destroy の rescue で `Sentry.capture_exception(e) if defined?(Sentry) && Sentry.initialized?` を追加。エラーログにも `e.class` を含めて原因切り分けやすくした。既存慣習（application_controller.rb:15, registrations_controller.rb:19）に合わせて `Sentry.initialized?` ガードを使用。

### \`spec/requests/api/v1/users_spec.rb\`

`DELETE /api/v1/user` のリクエストスペックを5ケース追加:

1. 未認証時に 401
2. 関連レコードなしのユーザーが destroy 成功
3. group_invite_link を inviter として持つユーザーが destroy 成功（issue #288 リグレッションテスト）
4. group_ranking_snapshot を持つユーザーが destroy 成功（同）
5. destroy! が予期せぬ例外を投げた場合に 500 + ローカライズ済みメッセージを返す

## スクリーンショット

なし（API変更のみ）。

## 確認手順

1. \`docker compose exec back bundle exec rspec spec/requests/api/v1/users_spec.rb\` がパスすることを確認
2. ステージング環境で対象ユーザーがアカウント削除できることを確認
3. 削除後に \`group_invite_links\` / \`group_ranking_snapshots\` の関連レコードが残っていないことを確認
4. （任意）destroy! の前で意図的に \`raise\` を仕込んで Sentry buzzbase-backend にキャプチャされることを確認

## 影響範囲

- アカウント削除API（DELETE /api/v1/user）の挙動が「FK違反で500」→「正常系で200」へ
- User#team の inverse 解決が正しくなるため、TeamsController#index 等の関連クエリも影響あり（修正方向のため改善）

## コード上の懸念点

- `group_ranking_snapshots` を `dependent: :destroy` にしたため、退会者が過去にランキング1位を取った履歴も同時に消える。プロダクト要件として履歴を残したい場合は別途schema変更（user_id を nullable + on_delete SET NULL）が必要

## その他

特になし。