### PR TITLE
Feature: 投手成績計算ロジックの試合イニング制対応（草野球7回制対応）

### DIFF
--- a/app/controllers/api/v1/match_results_controller.rb
+++ b/app/controllers/api/v1/match_results_controller.rb
@@ -3,7 +3,7 @@ module Api
     class MatchResultsController < ApplicationController
       include MatchTypeConvertible
 
-      before_action :authenticate_api_v1_user!, only: %i[create update destroy existing_search current_game_result_search current_user_match_index match_index_user_id user_game_result_search available_years]
+      before_action :authenticate_api_v1_user!, only: %i[create update destroy existing_search current_game_result_search current_user_match_index match_index_user_id user_game_result_search available_years form_defaults]
       before_action :set_match_result, only: %i[show]
       before_action :set_owned_match_result, only: %i[update destroy]
       before_action :normalize_match_type, only: %i[create update]
@@ -122,6 +122,16 @@ module Api
         render json: @match_results
       end
 
+      # GET /api/v1/match_results/form_defaults
+      # 試合作成フォームの初期値を返す。現状は直近試合のイニング制（7 or 9）。
+      # 履歴がない場合は 9 をデフォルトとして返す。
+      # フォーム初期値を増やしたくなった際にこのエンドポイントに値を追加していく想定。
+      # @return [JSON] { inning_format: Integer }
+      def form_defaults
+        latest = current_api_v1_user.match_results.order(date_and_time: :desc).first
+        render json: { inning_format: latest&.inning_format || 9 }
+      end
+
       private
 
       # show 用: 認証なしでもアクセス可能なため、ユーザースコープで絞らずに取得する。
@@ -145,7 +155,7 @@ module Api
 
       def match_results_params
         params.require(:match_result).permit(:user_id, :game_result_id, :date_and_time, :match_type, :my_team_id, :opponent_team_id, :my_team_score,
-                                             :opponent_team_score, :batting_order, :defensive_position, :tournament_id, :memo)
+                                             :opponent_team_score, :batting_order, :defensive_position, :tournament_id, :memo, :inning_format)
       end
     end
   end

--- a/app/models/match_result.rb
+++ b/app/models/match_result.rb
@@ -12,6 +12,7 @@ class MatchResult < ApplicationRecord
   validates :opponent_team_score, presence: true
   validates :batting_order, presence: true
   validates :defensive_position, presence: true
+  validates :inning_format, presence: true, inclusion: { in: [7, 9] }
 
   # 指定ユーザーの試合データに紐づく年度を新しい順で返す
   # @param user [User]

--- a/app/models/pitching_result.rb
+++ b/app/models/pitching_result.rb
@@ -4,38 +4,46 @@ class PitchingResult < ApplicationRecord
 
   validate :must_have_any_stats
 
-  INNINGS_PER_GAME = 9
   ZERO = 0
 
+  # 投手集計クエリは ERA / K/9 / BB/9 を「試合のイニング制（match_results.inning_format）で加重平均」する。
+  # 従来の `× 9 / 投球回` 固定ではなく、各試合のイニング制（7 or 9）を係数として掛けることで、
+  # 7回制の試合では「× 7」で換算され、混在試合でも実力が正しく反映される。
+  # match_results は game_result 経由で必ず JOIN する必要がある。
   def self.pitching_aggregate_for_user(user_id)
-    pitching_aggregate_query.where(user_id:)
+    pitching_aggregate_query.where(pitching_results: { user_id: })
   end
 
   def self.pitching_aggregate_for_users(user_ids)
-    pitching_aggregate_query.where(user_id: user_ids)
+    pitching_aggregate_query.where(pitching_results: { user_id: user_ids })
   end
 
   def self.pitching_aggregate_query
-    select(*pitching_aggregate_columns).group('pitching_results.user_id')
+    joins(game_result: :match_result)
+      .select(*pitching_aggregate_columns)
+      .group('pitching_results.user_id')
   end
 
   def self.pitching_aggregate_columns
     ['pitching_results.user_id',
-     'SUM(CASE WHEN innings_pitched > 0 THEN 1 ELSE 0 END) AS number_of_appearances',
-     'SUM(win) AS win',
-     'SUM(CASE WHEN got_to_the_distance THEN 1 ELSE 0 END) AS complete_games',
-     "SUM(CASE WHEN got_to_the_distance = 't' AND run_allowed = 0 THEN 1 ELSE 0 END) AS shutouts",
-     'SUM(loss) AS loss',
-     'SUM(hold) AS hold',
-     'SUM(saves) AS saves',
-     'ROUND(SUM(innings_pitched)::numeric, 2) AS innings_pitched',
-     'SUM(hits_allowed) AS hits_allowed',
-     'SUM(home_runs_hit) AS home_runs_hit',
-     'SUM(strikeouts) AS strikeouts',
-     'SUM(base_on_balls) AS base_on_balls',
-     'SUM(hit_by_pitch) AS hit_by_pitch',
-     'SUM(run_allowed) AS run_allowed',
-     'SUM(earned_run) AS earned_run']
+     'SUM(CASE WHEN pitching_results.innings_pitched > 0 THEN 1 ELSE 0 END) AS number_of_appearances',
+     'SUM(pitching_results.win) AS win',
+     'SUM(CASE WHEN pitching_results.got_to_the_distance THEN 1 ELSE 0 END) AS complete_games',
+     "SUM(CASE WHEN pitching_results.got_to_the_distance = 't' AND pitching_results.run_allowed = 0 THEN 1 ELSE 0 END) AS shutouts",
+     'SUM(pitching_results.loss) AS loss',
+     'SUM(pitching_results.hold) AS hold',
+     'SUM(pitching_results.saves) AS saves',
+     'ROUND(SUM(pitching_results.innings_pitched)::numeric, 2) AS innings_pitched',
+     'SUM(pitching_results.hits_allowed) AS hits_allowed',
+     'SUM(pitching_results.home_runs_hit) AS home_runs_hit',
+     'SUM(pitching_results.strikeouts) AS strikeouts',
+     'SUM(pitching_results.base_on_balls) AS base_on_balls',
+     'SUM(pitching_results.hit_by_pitch) AS hit_by_pitch',
+     'SUM(pitching_results.run_allowed) AS run_allowed',
+     'SUM(pitching_results.earned_run) AS earned_run',
+     'SUM(pitching_results.earned_run * match_results.inning_format) AS weighted_earned_run',
+     'SUM(pitching_results.strikeouts * match_results.inning_format) AS weighted_strikeouts',
+     'SUM(pitching_results.base_on_balls * match_results.inning_format) AS weighted_base_on_balls']
   end
 
   def self.filtered_pitching_aggregate_for_user(user_id, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
@@ -51,7 +59,7 @@ class PitchingResult < ApplicationRecord
                     .where(pitching_results: { user_id: })
                     .group('pitching_results.user_id').take
     else
-      result = pitching_aggregate_query.find_by(user_id:)
+      result = pitching_aggregate_query.find_by(pitching_results: { user_id: })
     end
 
     return nil unless result
@@ -60,7 +68,7 @@ class PitchingResult < ApplicationRecord
   end
 
   def self.bulk_pitching_stats_for_users(user_ids)
-    results = pitching_aggregate_query.where(user_id: user_ids)
+    results = pitching_aggregate_query.where(pitching_results: { user_id: user_ids })
 
     results.each_with_object({}) do |result, hash|
       hash[result.user_id] = build_pitching_stats_hash(result.user_id, result.attributes)
@@ -80,6 +88,10 @@ class PitchingResult < ApplicationRecord
     scope
   end
 
+  # @param user_id [Integer]
+  # @param stats [Hash] 集計クエリの行（pitching_aggregate_columns で生成された値を含む）
+  # @return [Hash{Symbol=>Numeric}] ERA / K9 / BB9 / WHIP 等の計算済み統計
+  # ERA・K/9・BB/9 は試合のイニング制で加重した分子（weighted_*）を投球回で割って算出する。
   def self.build_pitching_stats_hash(user_id, stats)
     ip = stats['innings_pitched'].to_f
     wins = stats['win'].to_i
@@ -87,13 +99,13 @@ class PitchingResult < ApplicationRecord
 
     {
       user_id:,
-      era: safe_divide_round(stats['earned_run'].to_f * INNINGS_PER_GAME, ip, 2),
+      era: safe_divide_round(stats['weighted_earned_run'].to_f, ip, 2),
       complete_games: stats['complete_games'].to_i,
       shutouts: stats['shutouts'].to_i,
       win_percentage: safe_divide_round(wins.to_f, wins + losses, 3),
-      k_per_nine: safe_divide_round(stats['strikeouts'].to_f * 9, ip, 3),
+      k_per_nine: safe_divide_round(stats['weighted_strikeouts'].to_f, ip, 3),
       whip: safe_divide_round(stats['base_on_balls'].to_f + stats['hits_allowed'].to_f, ip, 3),
-      bb_per_nine: safe_divide_round(stats['base_on_balls'].to_f * 9, ip, 3),
+      bb_per_nine: safe_divide_round(stats['weighted_base_on_balls'].to_f, ip, 3),
       k_bb: safe_divide_round(stats['strikeouts'].to_f, stats['base_on_balls'].to_i, 3)
     }
   end

--- a/app/serializers/v2/match_result_serializer.rb
+++ b/app/serializers/v2/match_result_serializer.rb
@@ -8,7 +8,7 @@ module V2
   class MatchResultSerializer < ActiveModel::Serializer
     attributes :id, :date_and_time, :match_type, :my_team_id, :opponent_team_id,
                :my_team_score, :opponent_team_score, :batting_order,
-               :defensive_position, :tournament_id, :memo,
+               :defensive_position, :tournament_id, :memo, :inning_format,
                :my_team_name, :opponent_team_name, :tournament_name
 
     # @return [String, nil] 自チーム名（eager-load済み）

--- a/app/services/stats/era_trend_service.rb
+++ b/app/services/stats/era_trend_service.rb
@@ -2,8 +2,6 @@
 
 module Stats
   class EraTrendService
-    INNINGS_PER_GAME = 9
-
     def initialize(user_id:, year: nil, season_id: nil, tournament_id: nil)
       @user_id = user_id
       @year = year
@@ -11,16 +9,20 @@ module Stats
       @tournament_id = tournament_id
     end
 
+    # 月別の防御率推移を返す。
+    # ERA は `SUM(earned_run × match_results.inning_format) / SUM(innings_pitched)` で算出し、
+    # 7回制／9回制が混在しても各試合のイニング制を加重した値で計算する。
+    # @return [Array<Hash{Symbol=>Numeric}>] [{ month: Integer, era: Float }, ...]
     def call
       scope = base_scope
       return [] if scope.none?
 
-      # 月ごとに集計
+      # 月ごとに集計（earned_run には inning_format を係数として掛けて加重する）
       monthly = scope
                 .select(Arel.sql(
                           'EXTRACT(MONTH FROM match_results.date_and_time)::int AS month, ' \
                           'SUM(pitching_results.innings_pitched) AS total_ip, ' \
-                          'SUM(pitching_results.earned_run) AS total_er'
+                          'SUM(pitching_results.earned_run * match_results.inning_format) AS total_weighted_er'
                         ))
                 .group(Arel.sql('EXTRACT(MONTH FROM match_results.date_and_time)::int'))
                 .order(Arel.sql('month'))
@@ -29,7 +31,7 @@ module Stats
         ip = r.total_ip.to_f
         next if ip <= 0
 
-        era = (r.total_er.to_f * INNINGS_PER_GAME / ip).round(2)
+        era = (r.total_weighted_er.to_f / ip).round(2)
         { month: r.month, era: }
       end
     end

--- a/app/services/stats/pitching_stats_table_service.rb
+++ b/app/services/stats/pitching_stats_table_service.rb
@@ -4,8 +4,6 @@ module Stats
   class PitchingStatsTableService
     include Concerns::TableServiceConcern
 
-    INNINGS_PER_GAME = 9
-
     PITCHING_FIELDS = %w[
       win loss hold saves complete_games shutouts innings_pitched
       hits_allowed home_runs_hit strikeouts base_on_balls hit_by_pitch run_allowed earned_run
@@ -73,7 +71,7 @@ module Stats
 
       rows = records.map do |pr|
         mr = pr.game_result.match_result
-        row = compose_row(mr.date_and_time.strftime('%m/%d'), extract_pitching_stats(pr))
+        row = compose_row(mr.date_and_time.strftime('%m/%d'), extract_pitching_stats(pr, mr.inning_format))
         row[:opponent] = mr.opponent_team&.name || '不明'
         row
       end
@@ -90,23 +88,40 @@ module Stats
       compose_row(label, agg.attributes)
     end
 
-    def extract_pitching_stats(pitching_result)
+    # @param pitching_result [PitchingResult]
+    # @param inning_format [Integer] 当該試合のイニング制（7 or 9）
+    # @return [Hash{String=>Numeric}] 個別行のスタッツ。
+    #   weighted_* は集計クエリの加重和カラムと整合させるため、当該試合の inning_format を係数として掛ける。
+    def extract_pitching_stats(pitching_result, inning_format)
+      base_pitching_stats(pitching_result)
+        .merge(weighted_pitching_stats(pitching_result, inning_format))
+    end
+
+    def base_pitching_stats(record)
       {
         'appearances' => 1,
-        'win' => pitching_result.win.to_i,
-        'loss' => pitching_result.loss.to_i,
-        'hold' => pitching_result.hold.to_i,
-        'saves' => pitching_result.saves.to_i,
-        'complete_games' => pitching_result.got_to_the_distance ? 1 : 0,
-        'shutouts' => pitching_result.got_to_the_distance && pitching_result.run_allowed.to_i.zero? ? 1 : 0,
-        'innings_pitched' => pitching_result.innings_pitched.to_f,
-        'hits_allowed' => pitching_result.hits_allowed.to_i,
-        'home_runs_hit' => pitching_result.home_runs_hit.to_i,
-        'strikeouts' => pitching_result.strikeouts.to_i,
-        'base_on_balls' => pitching_result.base_on_balls.to_i,
-        'hit_by_pitch' => pitching_result.hit_by_pitch.to_i,
-        'run_allowed' => pitching_result.run_allowed.to_i,
-        'earned_run' => pitching_result.earned_run.to_i
+        'win' => record.win.to_i,
+        'loss' => record.loss.to_i,
+        'hold' => record.hold.to_i,
+        'saves' => record.saves.to_i,
+        'complete_games' => record.got_to_the_distance ? 1 : 0,
+        'shutouts' => record.got_to_the_distance && record.run_allowed.to_i.zero? ? 1 : 0,
+        'innings_pitched' => record.innings_pitched.to_f,
+        'hits_allowed' => record.hits_allowed.to_i,
+        'home_runs_hit' => record.home_runs_hit.to_i,
+        'strikeouts' => record.strikeouts.to_i,
+        'base_on_balls' => record.base_on_balls.to_i,
+        'hit_by_pitch' => record.hit_by_pitch.to_i,
+        'run_allowed' => record.run_allowed.to_i,
+        'earned_run' => record.earned_run.to_i
+      }
+    end
+
+    def weighted_pitching_stats(record, inning_format)
+      {
+        'weighted_earned_run' => record.earned_run.to_i * inning_format,
+        'weighted_strikeouts' => record.strikeouts.to_i * inning_format,
+        'weighted_base_on_balls' => record.base_on_balls.to_i * inning_format
       }
     end
 
@@ -130,12 +145,15 @@ module Stats
       calculate_pitching_rate_values(innings, strikeouts, walks, stats)
     end
 
+    # ERA / K9 / BB9 は試合ごとのイニング制（match_results.inning_format）で加重した分子を投球回で割る。
+    # 集計クエリでは aggregate_columns に weighted_* を追加し、個別行（daily）では
+    # extract_pitching_stats で当該試合の inning_format を掛けた値を渡す。
     def calculate_pitching_rate_values(innings, strikeouts, walks, stats)
       {
-        era: safe_divide(stats['earned_run'].to_f * INNINGS_PER_GAME, innings, 2),
+        era: safe_divide(stats['weighted_earned_run'].to_f, innings, 2),
         whip: safe_divide(walks.to_f + stats['hits_allowed'].to_f, innings),
-        k_per_nine: safe_divide(strikeouts.to_f * 9, innings),
-        bb_per_nine: safe_divide(walks.to_f * 9, innings),
+        k_per_nine: safe_divide(stats['weighted_strikeouts'].to_f, innings),
+        bb_per_nine: safe_divide(stats['weighted_base_on_balls'].to_f, innings),
         k_bb: safe_divide(strikeouts.to_f, walks),
         win_percentage: safe_divide(stats['win'].to_f, stats['win'].to_i + stats['loss'].to_i)
       }
@@ -153,20 +171,23 @@ module Stats
     def aggregate_columns
       [
         'COUNT(*) AS appearances',
-        'SUM(win) AS win',
-        'SUM(loss) AS loss',
-        'SUM(hold) AS hold',
-        'SUM(saves) AS saves',
-        'SUM(CASE WHEN got_to_the_distance THEN 1 ELSE 0 END) AS complete_games',
-        'SUM(CASE WHEN got_to_the_distance = true AND run_allowed = 0 THEN 1 ELSE 0 END) AS shutouts',
-        'ROUND(SUM(innings_pitched)::numeric, 1) AS innings_pitched',
-        'SUM(hits_allowed) AS hits_allowed',
-        'SUM(home_runs_hit) AS home_runs_hit',
-        'SUM(strikeouts) AS strikeouts',
-        'SUM(base_on_balls) AS base_on_balls',
-        'SUM(hit_by_pitch) AS hit_by_pitch',
-        'SUM(run_allowed) AS run_allowed',
-        'SUM(earned_run) AS earned_run'
+        'SUM(pitching_results.win) AS win',
+        'SUM(pitching_results.loss) AS loss',
+        'SUM(pitching_results.hold) AS hold',
+        'SUM(pitching_results.saves) AS saves',
+        'SUM(CASE WHEN pitching_results.got_to_the_distance THEN 1 ELSE 0 END) AS complete_games',
+        'SUM(CASE WHEN pitching_results.got_to_the_distance = true AND pitching_results.run_allowed = 0 THEN 1 ELSE 0 END) AS shutouts',
+        'ROUND(SUM(pitching_results.innings_pitched)::numeric, 1) AS innings_pitched',
+        'SUM(pitching_results.hits_allowed) AS hits_allowed',
+        'SUM(pitching_results.home_runs_hit) AS home_runs_hit',
+        'SUM(pitching_results.strikeouts) AS strikeouts',
+        'SUM(pitching_results.base_on_balls) AS base_on_balls',
+        'SUM(pitching_results.hit_by_pitch) AS hit_by_pitch',
+        'SUM(pitching_results.run_allowed) AS run_allowed',
+        'SUM(pitching_results.earned_run) AS earned_run',
+        'SUM(pitching_results.earned_run * match_results.inning_format) AS weighted_earned_run',
+        'SUM(pitching_results.strikeouts * match_results.inning_format) AS weighted_strikeouts',
+        'SUM(pitching_results.base_on_balls * match_results.inning_format) AS weighted_base_on_balls'
       ]
     end
   end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,6 +15,10 @@ ja:
               required: "カテゴリは必須です"
             prefecture:
               required: "都道府県は必須です"
+        match_result:
+          attributes:
+            inning_format:
+              inclusion: "は7または9を指定してください"
   email_authentication_mailer:
     signup_subject: "buzzbaseにご登録ありがとうございます！"
   email_subjects:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,7 @@ Rails.application.routes.draw do
         collection do
           get :current_user_match_index
           get :available_years
+          get :form_defaults
         end
       end
 

--- a/db/migrate/20260510033634_add_inning_format_to_match_results.rb
+++ b/db/migrate/20260510033634_add_inning_format_to_match_results.rb
@@ -1,0 +1,5 @@
+class AddInningFormatToMatchResults < ActiveRecord::Migration[7.0]
+  def change
+    add_column :match_results, :inning_format, :integer, null: false, default: 9
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_04_04_144851) do
+ActiveRecord::Schema[7.0].define(version: 2026_05_10_033634) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -251,6 +251,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_04_04_144851) do
     t.text "memo"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "inning_format", default: 9, null: false
     t.index ["game_result_id"], name: "index_match_results_on_game_result_id_unique", unique: true, where: "(game_result_id IS NOT NULL)"
     t.index ["my_team_id"], name: "index_match_results_on_my_team_id"
     t.index ["opponent_team_id"], name: "index_match_results_on_opponent_team_id"

--- a/spec/factories/match_results.rb
+++ b/spec/factories/match_results.rb
@@ -12,5 +12,6 @@ FactoryBot.define do
     defensive_position { 'ショート' }
     tournament { nil }
     memo { nil }
+    inning_format { 9 }
   end
 end

--- a/spec/models/match_result_spec.rb
+++ b/spec/models/match_result_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe MatchResult, type: :model do
     it { should validate_presence_of(:batting_order) }
     it { should validate_presence_of(:defensive_position) }
     it { should validate_presence_of(:inning_format) }
-    it { should validate_inclusion_of(:inning_format).in_array([7, 9]) }
+
+    it 'validates inning_format inclusion with the Japanese locale message' do
+      expect(described_class.new).to validate_inclusion_of(:inning_format)
+        .in_array([7, 9])
+        .with_message('は7または9を指定してください')
+    end
   end
 end

--- a/spec/models/match_result_spec.rb
+++ b/spec/models/match_result_spec.rb
@@ -16,5 +16,7 @@ RSpec.describe MatchResult, type: :model do
     it { should validate_presence_of(:opponent_team_score) }
     it { should validate_presence_of(:batting_order) }
     it { should validate_presence_of(:defensive_position) }
+    it { should validate_presence_of(:inning_format) }
+    it { should validate_inclusion_of(:inning_format).in_array([7, 9]) }
   end
 end

--- a/spec/models/pitching_result_spec.rb
+++ b/spec/models/pitching_result_spec.rb
@@ -126,6 +126,93 @@ RSpec.describe PitchingResult, type: :model do
     end
   end
 
+  describe 'inning_format weighted aggregation' do
+    # ERA / K9 / BB9 が試合のイニング制（match_results.inning_format）で加重平均されることを検証する。
+    # 7回制で完投2失点（IP=7, ER=2）→ ERA=2.00、K8/BB1 → K/9=8.0, BB/9=1.0 が直感どおりに出ることを確認する。
+    context 'when inning_format = 7' do
+      before do
+        gr = create(:game_result, user:)
+        gr.match_result.update!(date_and_time: Time.zone.local(2024, 6, 15), inning_format: 7)
+        create(:pitching_result, game_result: gr, user:,
+                                 win: 1, loss: 0, innings_pitched: 7.0, earned_run: 2, strikeouts: 8,
+                                 base_on_balls: 1, hits_allowed: 4)
+      end
+
+      it 'calculates ERA using the match inning_format (× 7)' do
+        result = described_class.filtered_pitching_stats_for_user(user.id, year: '2024')
+        # ERA = (ER × inning_format) / IP = (2 × 7) / 7 = 2.0
+        expect(result[:era]).to eq(2.0)
+      end
+
+      it 'calculates K/9 using the match inning_format (× 7)' do
+        result = described_class.filtered_pitching_stats_for_user(user.id, year: '2024')
+        # K/9 = (K × inning_format) / IP = (8 × 7) / 7 = 8.0
+        expect(result[:k_per_nine]).to eq(8.0)
+      end
+
+      it 'calculates BB/9 using the match inning_format (× 7)' do
+        result = described_class.filtered_pitching_stats_for_user(user.id, year: '2024')
+        # BB/9 = (BB × inning_format) / IP = (1 × 7) / 7 = 1.0
+        expect(result[:bb_per_nine]).to eq(1.0)
+      end
+    end
+
+    # 7回制完投2失点 + 9回制完投2失点 → 同じ実力なので ERA=2.00 にブレないことを検証する。
+    # 旧ロジックでは ERA=(2+2)×9/(7+9)=2.25 と過大評価されていた。
+    context 'when 7-inning and 9-inning games are mixed' do
+      before do
+        gr1 = create(:game_result, user:)
+        gr1.match_result.update!(date_and_time: Time.zone.local(2024, 6, 15), inning_format: 9)
+        create(:pitching_result, game_result: gr1, user:,
+                                 win: 1, loss: 0, innings_pitched: 9.0, earned_run: 2, strikeouts: 9,
+                                 base_on_balls: 0, hits_allowed: 5)
+
+        gr2 = create(:game_result, user:)
+        gr2.match_result.update!(date_and_time: Time.zone.local(2024, 7, 1), inning_format: 7)
+        create(:pitching_result, game_result: gr2, user:,
+                                 win: 1, loss: 0, innings_pitched: 7.0, earned_run: 2, strikeouts: 7,
+                                 base_on_balls: 0, hits_allowed: 4)
+      end
+
+      it 'computes the weighted ERA as 2.00 (not skewed)' do
+        result = described_class.filtered_pitching_stats_for_user(user.id, year: '2024')
+        # 加重和 ERA = (2×9 + 2×7) / (9+7) = 32 / 16 = 2.0
+        expect(result[:era]).to eq(2.0)
+      end
+
+      it 'keeps K/9 stable across mixed inning formats' do
+        result = described_class.filtered_pitching_stats_for_user(user.id, year: '2024')
+        # 加重和 K/9 = (9×9 + 7×7) / (9+7) = (81+49) / 16 = 8.125
+        expect(result[:k_per_nine]).to eq(8.125)
+      end
+    end
+  end
+
+  describe '.bulk_pitching_stats_for_users' do
+    let(:other_user) { create(:user) }
+
+    before do
+      gr1 = create(:game_result, user:)
+      gr1.match_result.update!(date_and_time: Time.zone.local(2024, 6, 15), inning_format: 7)
+      create(:pitching_result, game_result: gr1, user:,
+                               win: 1, innings_pitched: 7.0, earned_run: 2, strikeouts: 8,
+                               base_on_balls: 1, hits_allowed: 3)
+
+      gr2 = create(:game_result, user: other_user)
+      gr2.match_result.update!(date_and_time: Time.zone.local(2024, 6, 20), inning_format: 9)
+      create(:pitching_result, game_result: gr2, user: other_user,
+                               win: 1, innings_pitched: 9.0, earned_run: 3, strikeouts: 6,
+                               base_on_balls: 2, hits_allowed: 7)
+    end
+
+    it 'returns weighted stats for each user keyed by user_id' do
+      stats = described_class.bulk_pitching_stats_for_users([user.id, other_user.id])
+
+      expect(stats[user.id][:era]).to eq(2.0) # (2×7)/7
+      expect(stats[other_user.id][:era]).to eq(3.0) # (3×9)/9
+    end
+  end
+
   describe 'must_have_any_stats validation' do
     let(:game_result) { create(:game_result, user:) }
 

--- a/spec/requests/api/v1/match_results_spec.rb
+++ b/spec/requests/api/v1/match_results_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe 'Api::V1::MatchResults', type: :request do
     end
   end
 
-  describe 'POST /api/v1/match_results (inning_format)' do
+  describe 'PUT /api/v1/match_results/:id (inning_format)' do
     let(:my_team) { create(:team) }
     let(:opponent_team) { create(:team) }
     let(:game_result) { create(:game_result, user:) }

--- a/spec/requests/api/v1/match_results_spec.rb
+++ b/spec/requests/api/v1/match_results_spec.rb
@@ -199,6 +199,73 @@ RSpec.describe 'Api::V1::MatchResults', type: :request do
     end
   end
 
+  describe 'GET /api/v1/match_results/form_defaults' do
+    context 'when the user has no match_results' do
+      it 'returns the default inning_format (9)' do
+        get '/api/v1/match_results/form_defaults', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['inning_format']).to eq(9)
+      end
+    end
+
+    context 'when the user has prior match_results' do
+      it 'returns the inning_format of the latest match_result' do
+        gr_old = create(:game_result, user:)
+        gr_old.match_result.update!(date_and_time: Time.zone.local(2024, 1, 1), inning_format: 9)
+
+        gr_latest = create(:game_result, user:)
+        gr_latest.match_result.update!(date_and_time: Time.zone.local(2025, 6, 1), inning_format: 7)
+
+        get '/api/v1/match_results/form_defaults', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['inning_format']).to eq(7)
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v1/match_results/form_defaults'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'POST /api/v1/match_results (inning_format)' do
+    let(:my_team) { create(:team) }
+    let(:opponent_team) { create(:team) }
+    let(:game_result) { create(:game_result, user:) }
+
+    # game_result 作成時に factory の after(:create) で match_result が自動生成されるため、
+    # テスト用に game_result を作っておき、その game_result 用の MatchResult を別途作るのではなく
+    # factory が生成した既存 match_result を inning_format = 7 に更新するパターンも併設する。
+    context 'when inning_format = 7 is provided' do
+      it 'persists inning_format on the existing match_result via update' do
+        match_result = game_result.match_result
+
+        put "/api/v1/match_results/#{match_result.id}",
+            params: { match_result: { inning_format: 7 } },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(match_result.reload.inning_format).to eq(7)
+      end
+    end
+
+    context 'when inning_format is invalid (e.g. 5)' do
+      it 'returns 422 with validation errors' do
+        match_result = game_result.match_result
+
+        put "/api/v1/match_results/#{match_result.id}",
+            params: { match_result: { inning_format: 5 } },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
   describe 'GET /api/v1/user_game_result_search' do
     context 'when authenticated' do
       it 'returns 200' do


### PR DESCRIPTION
## issue
close #294

## 実装概要
投手成績（ERA・K/9・BB/9）の計算式を「9イニング固定」から「試合のイニング制（7 or 9）で加重平均」に変更。`match_results.inning_format` カラムを追加し、集計クエリで `× match_results.inning_format` を係数とする加重和ベースに切り替える。

## 背景
ターゲット層（中高生・草野球プレーヤー）は7回制で行う試合も多く、現状だと「7回制で完投2失点」が `2×9/7 ≒ 2.57` と表示され、直感（= 2.00）と乖離していた。

## やらなかったこと
- `got_to_the_distance`（完投フラグ）のスコープ変更
- 計算ツール `/tools/era` 等のSEO関連ページ（野球用語の一般解説として9イニング基準のまま据え置き）
- 既存 `group_ranking_snapshot` レコードの再計算（履歴連続性のため新規生成分から新ロジック）

## 受入基準
- [x] `match_results.inning_format` カラム追加（NOT NULL, default 9, inclusion: [7, 9]）
- [x] ERA / K/9 / BB/9 を加重平均で計算（7/9混在試合でも実力どおりブレない）
- [x] 既存ユーザー（全試合9回制）の数値は変わらない（後方互換）
- [x] `GET /api/v1/match_results/form_defaults` で直近試合のイニング制を返す
- [x] `inning_format` を Strong Params に追加
- [x] v2 シリアライザに `inning_format` を含める
- [x] RSpec 全パス・RuboCop 全パス

## 実装詳細
- `db/migrate/20260510033634_add_inning_format_to_match_results.rb`: カラム追加
- `app/models/match_result.rb`: `inclusion: { in: [7, 9] }` バリデーション
- `app/models/pitching_result.rb`: 集計クエリに JOIN `game_result: :match_result` と `weighted_earned_run` / `weighted_strikeouts` / `weighted_base_on_balls` カラムを追加。`build_pitching_stats_hash` を加重和ベースに変更
- `app/services/stats/era_trend_service.rb`: 月別ERA集計を加重和に変更
- `app/services/stats/pitching_stats_table_service.rb`: 集計・個別行ともに加重和に変更
- `app/controllers/api/v1/match_results_controller.rb`: `form_defaults` アクション追加、Strong Params に `:inning_format` 追加
- `config/routes.rb`: `match_results#form_defaults` ルート追加
- `app/serializers/v2/match_result_serializer.rb`: `:inning_format` を attributes に追加

## 確認手順
1. `docker compose exec back bundle exec rails db:migrate` でマイグレーション
2. `docker compose exec back bundle exec rspec spec/models/match_result_spec.rb spec/models/pitching_result_spec.rb spec/requests/api/v1/match_results_spec.rb` で全テストパス
3. `docker compose exec back bundle exec rails console` で `PitchingResult.pitching_aggregate_for_user(user_id).to_sql` を確認、`INNER JOIN match_results` が1回だけ発行されることを確認
4. 7回制試合を登録 → 防御率が `× 7` で計算されることを確認

## 影響範囲
- `pitching_aggregate_for_user` / `pitching_aggregate_for_users` / `bulk_pitching_stats_for_users` / `filtered_pitching_aggregate_for_user` / `pitching_stats_for_user` を呼び出す全箇所（dashboards_controller v2、dashboard_rankings concern、stats_builder service、group_ranking_snapshot_service）

## コード上の懸念点
- 集計クエリに `joins(game_result: :match_result)` を追加したため、既存呼び出し箇所で重複JOINにならないか SQL ログで要確認
- 既存スナップショット (`group_ranking_snapshot`) は旧ロジック値のまま固定し、新規生成分から新ロジックに切り替える方針

## その他
特になし