### PR TITLE
Feature: 代打のみ・代走のみの出場記録に対応

### DIFF
--- a/app/controllers/api/v1/match_results_controller.rb
+++ b/app/controllers/api/v1/match_results_controller.rb
@@ -155,7 +155,8 @@ module Api
 
       def match_results_params
         params.require(:match_result).permit(:user_id, :game_result_id, :date_and_time, :match_type, :my_team_id, :opponent_team_id, :my_team_score,
-                                             :opponent_team_score, :batting_order, :defensive_position, :tournament_id, :memo, :inning_format)
+                                             :opponent_team_score, :batting_order, :defensive_position, :tournament_id, :memo, :inning_format,
+                                             :appearance_type)
       end
     end
   end

--- a/app/models/match_result.rb
+++ b/app/models/match_result.rb
@@ -5,14 +5,25 @@ class MatchResult < ApplicationRecord
   belongs_to :tournament, optional: true
   belongs_to :game_result
 
+  # 出場区分: 先発 / 途中出場 / 代打 / 代走 / 未出場。
+  # starter のときのみ batting_order と defensive_position を必須とし、
+  # 途中出場・代打・代走・未出場は打順／守備位置の入力を任意にする。
+  # ※ Rails 7.0 の enum は不正値代入で ArgumentError を投げてしまうため、
+  #   API レイヤで 422 として返したい本ケースでは inclusion バリデーションで弾く方式を採用する。
+  APPEARANCE_TYPES = %w[starter substitute pinch_hitter pinch_runner no_play].freeze
+  APPEARANCE_TYPES.each do |type|
+    define_method("appearance_type_#{type}?") { appearance_type == type }
+  end
+
   validates :game_result_id, uniqueness: true
   validates :date_and_time, presence: true
   validates :match_type, presence: true
   validates :my_team_score, presence: true
   validates :opponent_team_score, presence: true
-  validates :batting_order, presence: true
-  validates :defensive_position, presence: true
+  validates :batting_order, presence: true, if: :appearance_type_starter?
+  validates :defensive_position, presence: true, if: :appearance_type_starter?
   validates :inning_format, presence: true, inclusion: { in: [7, 9] }
+  validates :appearance_type, presence: true, inclusion: { in: APPEARANCE_TYPES }
 
   # 指定ユーザーの試合データに紐づく年度を新しい順で返す
   # @param user [User]

--- a/app/models/match_result.rb
+++ b/app/models/match_result.rb
@@ -5,14 +5,11 @@ class MatchResult < ApplicationRecord
   belongs_to :tournament, optional: true
   belongs_to :game_result
 
-  # 出場区分: 先発 / 途中出場 / 代打 / 代走 / 未出場。
-  # starter のときのみ batting_order と defensive_position を必須とし、
-  # 途中出場・代打・代走・未出場は打順／守備位置の入力を任意にする。
-  # ※ Rails 7.0 の enum は不正値代入で ArgumentError を投げてしまうため、
-  #   API レイヤで 422 として返したい本ケースでは inclusion バリデーションで弾く方式を採用する。
+  # Rails 7.0 enum は不正値で ArgumentError になるため inclusion バリデーション方式を採用。
   APPEARANCE_TYPES = %w[starter substitute pinch_hitter pinch_runner no_play].freeze
-  APPEARANCE_TYPES.each do |type|
-    define_method("appearance_type_#{type}?") { appearance_type == type }
+
+  def appearance_type_starter?
+    appearance_type == 'starter'
   end
 
   validates :game_result_id, uniqueness: true

--- a/app/serializers/v2/match_result_serializer.rb
+++ b/app/serializers/v2/match_result_serializer.rb
@@ -9,6 +9,7 @@ module V2
     attributes :id, :date_and_time, :match_type, :my_team_id, :opponent_team_id,
                :my_team_score, :opponent_team_score, :batting_order,
                :defensive_position, :tournament_id, :memo, :inning_format,
+               :appearance_type,
                :my_team_name, :opponent_team_name, :tournament_name
 
     # @return [String, nil] 自チーム名（eager-load済み）

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,6 +19,8 @@ ja:
           attributes:
             inning_format:
               inclusion: "は7または9を指定してください"
+            appearance_type:
+              inclusion: "は先発・途中出場・代打・代走・未出場のいずれかを指定してください"
   email_authentication_mailer:
     signup_subject: "buzzbaseにご登録ありがとうございます！"
   email_subjects:

--- a/db/migrate/20260510062318_add_appearance_type_to_match_results.rb
+++ b/db/migrate/20260510062318_add_appearance_type_to_match_results.rb
@@ -1,0 +1,5 @@
+class AddAppearanceTypeToMatchResults < ActiveRecord::Migration[7.0]
+  def change
+    add_column :match_results, :appearance_type, :string, null: false, default: 'starter'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_05_10_033634) do
+ActiveRecord::Schema[7.0].define(version: 2026_05_10_062318) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -252,6 +252,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_10_033634) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "inning_format", default: 9, null: false
+    t.string "appearance_type", default: "starter", null: false
     t.index ["game_result_id"], name: "index_match_results_on_game_result_id_unique", unique: true, where: "(game_result_id IS NOT NULL)"
     t.index ["my_team_id"], name: "index_match_results_on_my_team_id"
     t.index ["opponent_team_id"], name: "index_match_results_on_opponent_team_id"

--- a/spec/factories/match_results.rb
+++ b/spec/factories/match_results.rb
@@ -13,5 +13,6 @@ FactoryBot.define do
     tournament { nil }
     memo { nil }
     inning_format { 9 }
+    appearance_type { 'starter' }
   end
 end

--- a/spec/models/match_result_spec.rb
+++ b/spec/models/match_result_spec.rb
@@ -88,9 +88,9 @@ RSpec.describe MatchResult, type: :model do
   end
 
   describe 'APPEARANCE_TYPES' do
-    it 'defines starter / substitute / pinch_hitter / pinch_runner / no_play' do
-      expect(described_class::APPEARANCE_TYPES)
-        .to eq(%w[starter substitute pinch_hitter pinch_runner no_play])
+    # 値ごとの挙動はバリデーション spec で網羅しているので、ここでは件数だけ守る。
+    it 'has 5 entries' do
+      expect(described_class::APPEARANCE_TYPES.size).to eq(5)
     end
   end
 end

--- a/spec/models/match_result_spec.rb
+++ b/spec/models/match_result_spec.rb
@@ -14,14 +14,83 @@ RSpec.describe MatchResult, type: :model do
     it { should validate_presence_of(:match_type) }
     it { should validate_presence_of(:my_team_score) }
     it { should validate_presence_of(:opponent_team_score) }
-    it { should validate_presence_of(:batting_order) }
-    it { should validate_presence_of(:defensive_position) }
     it { should validate_presence_of(:inning_format) }
 
     it 'validates inning_format inclusion with the Japanese locale message' do
       expect(described_class.new).to validate_inclusion_of(:inning_format)
         .in_array([7, 9])
         .with_message('は7または9を指定してください')
+    end
+
+    # appearance_type に応じた条件付きバリデーション。
+    # starter は打順／守備位置必須、代打のみ・代走のみは任意。
+    context 'when appearance_type is starter' do
+      it 'requires batting_order' do
+        mr = build(:match_result, appearance_type: 'starter', batting_order: nil)
+        expect(mr).not_to be_valid
+        expect(mr.errors[:batting_order]).to be_present
+      end
+
+      it 'requires defensive_position' do
+        mr = build(:match_result, appearance_type: 'starter', defensive_position: nil)
+        expect(mr).not_to be_valid
+        expect(mr.errors[:defensive_position]).to be_present
+      end
+    end
+
+    context 'when appearance_type is substitute' do
+      it 'allows missing batting_order and defensive_position' do
+        mr = build(:match_result,
+                   appearance_type: 'substitute',
+                   batting_order: nil,
+                   defensive_position: nil)
+        expect(mr).to be_valid
+      end
+    end
+
+    context 'when appearance_type is pinch_hitter' do
+      it 'allows missing batting_order and defensive_position' do
+        mr = build(:match_result,
+                   appearance_type: 'pinch_hitter',
+                   batting_order: nil,
+                   defensive_position: nil)
+        expect(mr).to be_valid
+      end
+    end
+
+    context 'when appearance_type is pinch_runner' do
+      it 'allows missing batting_order and defensive_position' do
+        mr = build(:match_result,
+                   appearance_type: 'pinch_runner',
+                   batting_order: nil,
+                   defensive_position: nil)
+        expect(mr).to be_valid
+      end
+    end
+
+    context 'when appearance_type is no_play' do
+      it 'allows missing batting_order and defensive_position' do
+        mr = build(:match_result,
+                   appearance_type: 'no_play',
+                   batting_order: nil,
+                   defensive_position: nil)
+        expect(mr).to be_valid
+      end
+    end
+
+    context 'with an unknown appearance_type' do
+      it 'is invalid' do
+        mr = build(:match_result, appearance_type: 'unknown')
+        expect(mr).not_to be_valid
+        expect(mr.errors[:appearance_type]).to be_present
+      end
+    end
+  end
+
+  describe 'APPEARANCE_TYPES' do
+    it 'defines starter / substitute / pinch_hitter / pinch_runner / no_play' do
+      expect(described_class::APPEARANCE_TYPES)
+        .to eq(%w[starter substitute pinch_hitter pinch_runner no_play])
     end
   end
 end

--- a/spec/requests/api/v1/match_results_spec.rb
+++ b/spec/requests/api/v1/match_results_spec.rb
@@ -266,6 +266,71 @@ RSpec.describe 'Api::V1::MatchResults', type: :request do
     end
   end
 
+  describe 'PUT /api/v1/match_results/:id (appearance_type)' do
+    let(:game_result) { create(:game_result, user:) }
+
+    context 'when appearance_type = pinch_hitter is provided with empty batting_order/defensive_position' do
+      it 'persists the appearance_type without batting_order / defensive_position' do
+        match_result = game_result.match_result
+
+        put "/api/v1/match_results/#{match_result.id}",
+            params: { match_result: {
+              appearance_type: 'pinch_hitter',
+              batting_order: '',
+              defensive_position: ''
+            } },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(match_result.reload.appearance_type).to eq('pinch_hitter')
+      end
+    end
+
+    context 'when appearance_type = pinch_runner is provided with empty batting_order/defensive_position' do
+      it 'persists the appearance_type without batting_order / defensive_position' do
+        match_result = game_result.match_result
+
+        put "/api/v1/match_results/#{match_result.id}",
+            params: { match_result: {
+              appearance_type: 'pinch_runner',
+              batting_order: '',
+              defensive_position: ''
+            } },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(match_result.reload.appearance_type).to eq('pinch_runner')
+      end
+    end
+
+    context 'when appearance_type = starter and batting_order is missing' do
+      it 'returns 422 because starter requires batting_order' do
+        match_result = game_result.match_result
+
+        put "/api/v1/match_results/#{match_result.id}",
+            params: { match_result: {
+              appearance_type: 'starter',
+              batting_order: ''
+            } },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'when appearance_type is invalid (e.g. unknown)' do
+      it 'returns 422 with validation errors' do
+        match_result = game_result.match_result
+
+        put "/api/v1/match_results/#{match_result.id}",
+            params: { match_result: { appearance_type: 'unknown' } },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
   describe 'GET /api/v1/user_game_result_search' do
     context 'when authenticated' do
       it 'returns 200' do

--- a/spec/serializers/v2/match_result_serializer_spec.rb
+++ b/spec/serializers/v2/match_result_serializer_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe V2::MatchResultSerializer, type: :serializer do
   it 'includes all base attributes' do
     %i[id date_and_time match_type my_team_id opponent_team_id
        my_team_score opponent_team_score batting_order
-       defensive_position tournament_id memo].each do |attr|
+       defensive_position tournament_id memo inning_format
+       appearance_type].each do |attr|
       expect(serialization).to have_key(attr)
     end
   end


### PR DESCRIPTION
## issue
close #304

## 実装概要
試合 (`match_results`) に「出場区分」(`appearance_type`) カラムを追加し、先発／途中出場／代打／代走／未出場 を表現できるようにする。先発のときのみ batting_order / defensive_position を必須とし、それ以外の区分では任意とする条件付きバリデーションを実装。

## 背景
従来の試合記録は「先発出場」前提で `batting_order` / `defensive_position` が必須だったため、代打のみ・代走のみ・途中出場・未出場のケースが記録できなかった。試合に出場した／していないも含めて記録ニーズに合わせる。

## やらなかったこと
- 集計画面側での「先発出場」「代打出場」等の区分別カウント表示（別途検討）
- DB enum 採用（Rails 7.0 では不正値が ArgumentError を投げて 500 になるため、inclusion バリデーションで弾く方式を採用）

## 受入基準
- [x] `match_results.appearance_type` カラム追加（NOT NULL, default 'starter'）
- [x] APPEARANCE_TYPES = `%w[starter substitute pinch_hitter pinch_runner no_play]`
- [x] starter の場合は batting_order / defensive_position が必須、それ以外は任意
- [x] 不正値は 422 で返す（i18n で日本語メッセージ）
- [x] v2 シリアライザに appearance_type を含める
- [x] RSpec / RuboCop 全パス、既存ユーザーの試合は default `'starter'` で後方互換

## 実装詳細
- `db/migrate/20260510062318_add_appearance_type_to_match_results.rb`: 新規マイグレーション
- `app/models/match_result.rb`: `APPEARANCE_TYPES` 定数 + 述語メソッド（`appearance_type_starter?` 等）+ 条件付き必須バリデーション
- `app/controllers/api/v1/match_results_controller.rb`: Strong Params に `:appearance_type` を追加
- `app/serializers/v2/match_result_serializer.rb`: attributes に `:appearance_type` を追加
- `config/locales/ja.yml`: `match_result.attributes.appearance_type.inclusion` の日本語メッセージ
- `spec/factories/match_results.rb`: `appearance_type { 'starter' }` のデフォルト
- `spec/models/match_result_spec.rb`: 区分別バリデーションテスト
- `spec/requests/api/v1/match_results_spec.rb`: API での appearance_type 受け付けテスト

## 確認手順
1. `docker compose exec back bundle exec rails db:migrate`
2. `docker compose exec back bundle exec rspec spec/models/match_result_spec.rb spec/requests/api/v1/match_results_spec.rb`
3. PUT `/api/v1/match_results/:id` で `appearance_type=pinch_hitter` を送信、batting_order/defensive_position 空でも 200
4. PUT で `appearance_type=starter` で batting_order 空 → 422
5. PUT で `appearance_type=unknown` → 422

## 影響範囲
- `MatchResult` の create/update バリデーション
- v2 シリアライザレスポンス（`appearance_type` フィールドが追加）
- 既存レコードはデフォルト値 `'starter'` で埋まるため挙動変化なし

## コード上の懸念点
- enum を使わず inclusion バリデーションで運用しているため、コード補完が効きにくい。Rails 7.1 にアップグレードすれば `enum ... validate: true` で置き換え可能

## その他
特になし