### PR TITLE
Add: form_defaults APIに試合種類・打順・守備位置を追加 (#305)

### DIFF
--- a/app/controllers/api/v1/match_results_controller.rb
+++ b/app/controllers/api/v1/match_results_controller.rb
@@ -123,13 +123,27 @@ module Api
       end
 
       # GET /api/v1/match_results/form_defaults
-      # 試合作成フォームの初期値を返す。現状は直近試合のイニング制（7 or 9）。
-      # 履歴がない場合は 9 をデフォルトとして返す。
+      # 試合作成フォームの初期値を返す。
+      # 直近試合のイニング制／試合種類／打順、およびプロフィールのポジション（未設定なら直近試合の守備位置）を返す。
+      # 履歴がない場合は inning_format のみ 9 を返し、その他は nil。
       # フォーム初期値を増やしたくなった際にこのエンドポイントに値を追加していく想定。
-      # @return [JSON] { inning_format: Integer }
+      # @return [JSON]
+      #   {
+      #     inning_format: Integer,            # 直近試合のイニング制（7/9）。履歴なしは 9
+      #     match_type: String|null,           # 直近試合の試合種類（公式戦/オープン戦/それ以外そのまま）。履歴なしは nil
+      #     defensive_position: String|null,   # プロフィール最優先 → 直近試合の守備位置 → nil
+      #     batting_order: String|null         # 直近試合の打順。履歴なしは nil
+      #   }
       def form_defaults
         latest = current_api_v1_user.match_results.order(date_and_time: :desc).first
-        render json: { inning_format: latest&.inning_format || 9 }
+        profile_position = current_api_v1_user.positions.first&.name
+
+        render json: {
+          inning_format: latest&.inning_format || 9,
+          match_type: humanize_match_type(latest&.match_type),
+          defensive_position: profile_position.presence || latest&.defensive_position,
+          batting_order: latest&.batting_order
+        }
       end
 
       private

--- a/app/controllers/api/v1/match_results_controller.rb
+++ b/app/controllers/api/v1/match_results_controller.rb
@@ -135,7 +135,9 @@ module Api
       #     batting_order: String|null         # 直近試合の打順。履歴なしは nil
       #   }
       def form_defaults
-        latest = current_api_v1_user.match_results.order(date_and_time: :desc).first
+        # 同日付の試合が複数ある場合に「最も新しく作成された試合」を確実に取得するため、
+        # date_and_time が等しいときは id 降順（= 直近作成）でタイブレークする。
+        latest = current_api_v1_user.match_results.order(date_and_time: :desc, id: :desc).first
         profile_position = current_api_v1_user.positions.first&.name
 
         render json: {

--- a/app/controllers/concerns/match_type_convertible.rb
+++ b/app/controllers/concerns/match_type_convertible.rb
@@ -10,4 +10,16 @@ module MatchTypeConvertible
     else match_type
     end
   end
+
+  # 内部表現（regular / open）を画面表示用の日本語ラベル（公式戦 / オープン戦）に戻す。
+  # フォームの初期値返却など、モバイル/フロントが直接表示文字列として扱うレスポンスで使用する。
+  # @param match_type [String, nil]
+  # @return [String, nil] 変換できない値や nil はそのまま返す
+  def humanize_match_type(match_type)
+    case match_type
+    when 'regular' then '公式戦'
+    when 'open' then 'オープン戦'
+    else match_type
+    end
+  end
 end

--- a/spec/requests/api/v1/match_results_spec.rb
+++ b/spec/requests/api/v1/match_results_spec.rb
@@ -268,6 +268,26 @@ RSpec.describe 'Api::V1::MatchResults', type: :request do
       end
     end
 
+    context 'when multiple match_results share the same date_and_time' do
+      before do
+        # 同じ日付の試合を順番に作る。最後に作成（id 最大）したのが直近の試合として返るべき。
+        old_gr = create(:game_result, user:)
+        old_gr.match_result.update!(date_and_time: Time.zone.local(2025, 6, 1), match_type: 'open', inning_format: 7)
+
+        new_gr = create(:game_result, user:)
+        new_gr.match_result.update!(date_and_time: Time.zone.local(2025, 6, 1), match_type: 'regular', inning_format: 9)
+      end
+
+      it 'returns the most recently created match_result (tie-broken by id desc)' do
+        get '/api/v1/match_results/form_defaults', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body['match_type']).to eq('公式戦')
+        expect(body['inning_format']).to eq(9)
+      end
+    end
+
     context 'when not authenticated' do
       it 'returns 401' do
         get '/api/v1/match_results/form_defaults'

--- a/spec/requests/api/v1/match_results_spec.rb
+++ b/spec/requests/api/v1/match_results_spec.rb
@@ -200,27 +200,71 @@ RSpec.describe 'Api::V1::MatchResults', type: :request do
   end
 
   describe 'GET /api/v1/match_results/form_defaults' do
-    context 'when the user has no match_results' do
-      it 'returns the default inning_format (9)' do
+    context 'when the user has no match_results and no profile positions' do
+      it 'returns inning_format=9 and nil for the other fields' do
         get '/api/v1/match_results/form_defaults', headers: auth_headers_for(user)
 
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body['inning_format']).to eq(9)
+        body = response.parsed_body
+        expect(body['inning_format']).to eq(9)
+        expect(body['match_type']).to be_nil
+        expect(body['defensive_position']).to be_nil
+        expect(body['batting_order']).to be_nil
       end
     end
 
     context 'when the user has prior match_results' do
-      it 'returns the inning_format of the latest match_result' do
-        gr_old = create(:game_result, user:)
-        gr_old.match_result.update!(date_and_time: Time.zone.local(2024, 1, 1), inning_format: 9)
+      before do
+        old_gr = create(:game_result, user:)
+        old_gr.match_result.update!(date_and_time: Time.zone.local(2024, 1, 1), inning_format: 9,
+                                    match_type: 'open', defensive_position: 'ピッチャー', batting_order: '1')
 
-        gr_latest = create(:game_result, user:)
-        gr_latest.match_result.update!(date_and_time: Time.zone.local(2025, 6, 1), inning_format: 7)
+        latest_gr = create(:game_result, user:)
+        latest_gr.match_result.update!(date_and_time: Time.zone.local(2025, 6, 1), inning_format: 7,
+                                       match_type: 'regular', defensive_position: 'ショート', batting_order: '4')
+      end
+
+      it 'returns the latest match_result values (match_type humanized to Japanese label)' do
+        get '/api/v1/match_results/form_defaults', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body['inning_format']).to eq(7)
+        expect(body['match_type']).to eq('公式戦')
+        expect(body['defensive_position']).to eq('ショート')
+        expect(body['batting_order']).to eq('4')
+      end
+    end
+
+    context 'when the user has profile positions configured' do
+      it 'returns the profile position as defensive_position regardless of latest match_result' do
+        position = Position.create!(name: 'キャッチャー')
+        UserPosition.create!(user:, position:)
+
+        gr = create(:game_result, user:)
+        gr.match_result.update!(
+          date_and_time: Time.zone.local(2025, 6, 1),
+          defensive_position: 'ショート'
+        )
 
         get '/api/v1/match_results/form_defaults', headers: auth_headers_for(user)
 
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body['inning_format']).to eq(7)
+        expect(response.parsed_body['defensive_position']).to eq('キャッチャー')
+      end
+    end
+
+    context 'when the user has profile positions but no match_results' do
+      it 'returns the profile position as defensive_position' do
+        position = Position.create!(name: 'セカンド')
+        UserPosition.create!(user:, position:)
+
+        get '/api/v1/match_results/form_defaults', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body['defensive_position']).to eq('セカンド')
+        expect(body['match_type']).to be_nil
       end
     end
 


### PR DESCRIPTION
## 概要

[ippei-shimizu/buzzbase#305](https://github.com/ippei-shimizu/buzzbase/issues/305) のフェーズ1（要件②⑨⑧）対応。
モバイルの試合作成フォームで、前回の試合・プロフィールから初期値を取得できるよう `form_defaults` API を拡張する。

## 変更内容

`GET /api/v1/match_results/form_defaults` のレスポンスに以下を追加。

| キー | 値 | 補足 |
|------|------|------|
| `match_type` | 直近試合の試合種類 (`公式戦` / `オープン戦`) または `nil` | 内部表現 (`regular` / `open`) から日本語ラベルに変換して返却 |
| `defensive_position` | プロフィール最初のポジション、未設定なら直近試合の `defensive_position` | プロフィール最優先 → 直近試合フォールバック |
| `batting_order` | 直近試合の打順 (`"1"` 〜 `"9"` / `"DH"`) または `nil` | |

履歴なし・プロフィール未設定の組み合わせは `inning_format=9` のみ返り、その他は `nil` を返す（モバイル側で従来のデフォルトを適用）。

`match_type` の日本語ラベル変換用に `MatchTypeConvertible#humanize_match_type` を追加。

## テスト

- 履歴なし・プロフィール未設定: `inning_format=9`、他は `nil`
- 履歴あり: 直近試合の値が返り、`match_type` は日本語ラベルになる
- プロフィールにポジションあり: `defensive_position` はプロフィールを優先（直近試合があってもプロフィール優先）
- プロフィールあり・履歴なし: プロフィールのポジションが `defensive_position` に入る
- 未認証: 401

```bash
docker compose exec back bundle exec rspec spec/requests/api/v1/match_results_spec.rb
docker compose exec back bundle exec rubocop
```

両方ともクリーン。

## モバイル側の対応

このPRマージ後、`mobile/services/matchResultService.ts` の戻り型を拡張し、`step1-game-info.tsx` で各フィールドに反映する（`feature/305-game-record-form-uiux` で対応予定）。