### PR TITLE
Update: 試合結果サマリーAPIに試合種別を追加 & 練習試合データ正規化タスクを追加

### DIFF
--- a/app/services/stats/game_summary_service.rb
+++ b/app/services/stats/game_summary_service.rb
@@ -105,6 +105,7 @@ module Stats
               .select(Arel.sql(
                         'game_results.id AS game_result_id, ' \
                         'match_results.date_and_time, ' \
+                        'match_results.match_type, ' \
                         'teams.name AS opponent_name, ' \
                         'match_results.my_team_score, ' \
                         'match_results.opponent_team_score'
@@ -123,6 +124,7 @@ module Stats
         {
           game_result_id: g.game_result_id,
           date: g.date_and_time.strftime('%m/%d'),
+          match_type: g.match_type,
           opponent: g.opponent_name,
           result:,
           my_score: my,

--- a/lib/tasks/dev_data_creator.rb
+++ b/lib/tasks/dev_data_creator.rb
@@ -138,7 +138,11 @@ class DevDataCreator # rubocop:disable Metrics/ClassLength
     end
 
     def create_game_results(users, teams)
-      match_types = %w[練習試合 公式戦 トーナメント リーグ戦 交流戦]
+      # match_results.match_type は本番フォームでは "regular" / "open" の英語キーで
+      # 保存されるため、開発用シードでも同じ値域に揃える。
+      # 過去には日本語値（"練習試合" 等）を使っていたが、表示時の変換が一致せず
+      # バッジが日本語のまま表示される問題があったため英語キーに統一。
+      match_types = %w[regular open]
       users.each do |user|
         rand(3..5).times do
           my_team = teams.sample

--- a/lib/tasks/normalize_match_type.rake
+++ b/lib/tasks/normalize_match_type.rake
@@ -25,7 +25,9 @@ namespace :data do
       next
     end
 
-    updated = target.update_all(match_type: 'open')
+    # バリデーションをスキップして一括更新する。
+    # 既存レコードの他カラムには触れず match_type のみを正規化するためコールバックも不要。
+    updated = target.update_all(match_type: 'open') # rubocop:disable Rails/SkipsModelValidations
     puts "更新完了: #{updated}件"
   end
 end

--- a/lib/tasks/normalize_match_type.rake
+++ b/lib/tasks/normalize_match_type.rake
@@ -1,0 +1,31 @@
+namespace :data do
+  # match_results.match_type に日本語値「練習試合」で保存されたレコードを
+  # 英語キー "open"（オープン戦）に正規化する一度きりのデータ修正タスク。
+  #
+  # 「練習試合」は非公式戦（オープン戦）と同義のため "open" に集約する。
+  # 過去フォームや開発用シード由来で混入したレコードを救済する目的。
+  #
+  # 実行例:
+  #   docker compose exec back bundle exec rails data:normalize_match_type DRY_RUN=1
+  #   docker compose exec back bundle exec rails data:normalize_match_type
+  #   heroku run bundle exec rails data:normalize_match_type
+  desc 'match_type の日本語値「練習試合」を "open" に正規化する'
+  task normalize_match_type: :environment do
+    target = MatchResult.where(match_type: '練習試合')
+    count = target.count
+    puts "対象レコード数: #{count}"
+
+    if count.zero?
+      puts '更新対象がないため終了します。'
+      next
+    end
+
+    if ENV['DRY_RUN'].present?
+      puts 'DRY_RUN=1 が指定されたため、更新はスキップしました。'
+      next
+    end
+
+    updated = target.update_all(match_type: 'open')
+    puts "更新完了: #{updated}件"
+  end
+end

--- a/spec/requests/api/v2/stats_spec.rb
+++ b/spec/requests/api/v2/stats_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Api::V2::Stats', type: :request do
     gr = create(:game_result, user:)
     gr.match_result.update!(
       date_and_time: Time.zone.local(2024, 7, 10),
-      match_type: '公式戦',
+      match_type: 'regular',
       my_team_score: 5,
       opponent_team_score: 3
     )
@@ -120,6 +120,16 @@ RSpec.describe 'Api::V2::Stats', type: :request do
       expect(json['recent_form']).to be_an(Array)
       expect(json['monthly_games']).to be_an(Array)
       expect(json['opponent_records']).to be_an(Array)
+    end
+
+    it 'includes match_type in each recent_form item' do
+      get('/api/v2/stats/game_summary', headers:)
+
+      json = response.parsed_body
+      expect(json['recent_form'].first).to include(
+        'game_result_id', 'date', 'match_type', 'opponent', 'result', 'my_score', 'opponent_score'
+      )
+      expect(json['recent_form'].first['match_type']).to eq('regular')
     end
   end
 end


### PR DESCRIPTION
## Summary

- 試合結果サマリーAPI (`/api/v2/stats/game_summary`) の `recent_form` レスポンスに `match_type` を追加。モバイル側で直近の試合バッジに「公式戦」「オープン戦」を表示できるようにする。
- 過去フォームや開発用シード由来で `match_results.match_type` に日本語値「練習試合」が保存されたレコードを `"open"` に正規化する一度きりのrake taskを追加。
- 開発用シード (`dev_data_creator.rb`) の `match_types` を本番フォームと同じ英語キー (`regular` / `open`) に統一。

関連: #310

## 変更点

| ファイル | 内容 |
| --- | --- |
| `app/services/stats/game_summary_service.rb` | `recent_form` のSELECT/レスポンスに `match_type` を追加 |
| `lib/tasks/normalize_match_type.rake` | 「練習試合」を `"open"` に正規化するrake task（DRY_RUN対応） |
| `lib/tasks/dev_data_creator.rb` | シードの `match_types` を `%w[regular open]` に統一 |

## Test plan

- [ ] `bundle exec rspec spec/requests/api/v2/stats_spec.rb` がパスする
- [ ] ローカルで `bundle exec rails data:normalize_match_type DRY_RUN=1` を実行し対象件数が表示されること
- [ ] ローカルで `bundle exec rails data:normalize_match_type` を実行し「練習試合」レコードが0になること
- [ ] 本番リリース後、`heroku run bundle exec rails data:normalize_match_type DRY_RUN=1` → `heroku run bundle exec rails data:normalize_match_type` を実行する

🤖 Generated with [Claude Code](https://claude.com/claude-code)