### PR TITLE
Feature: お知らせ公開時に全ユーザーへプッシュ通知を送る

### DIFF
--- a/app/jobs/management_notice_push_job.rb
+++ b/app/jobs/management_notice_push_job.rb
@@ -6,6 +6,13 @@ class ManagementNoticePushJob < ApplicationJob
   # 完了後は update_column で notified_at を更新し、ManagementNotice の
   # after_commit コールバックを再発火させない（無限ループ防止）。
   #
+  # 失敗時のリカバリ:
+  #   :async アダプタは自動リトライしないため、PushNotificationService.send_to_all が
+  #   raise した場合は notified_at が nil のまま残り、ジョブは失敗で終了する。
+  #   ステータスは published のままで after_commit は再発火しないため、自動再送はされない。
+  #   Sentry アラートを受けたら、管理者は Rails コンソールから手動で再送する:
+  #     ManagementNoticePushJob.perform_later(<notice_id>)
+  #
   # @param notice_id [Integer] ManagementNotice の id
   def perform(notice_id)
     notice = ManagementNotice.find_by(id: notice_id)

--- a/app/jobs/management_notice_push_job.rb
+++ b/app/jobs/management_notice_push_job.rb
@@ -1,0 +1,28 @@
+class ManagementNoticePushJob < ApplicationJob
+  queue_as :default
+
+  # お知らせ公開時に、全ユーザーの端末へプッシュ通知を一斉送信する。
+  # 冪等性ガード: notified_at が既にセットされている場合はスキップする。
+  # 完了後は update_column で notified_at を更新し、ManagementNotice の
+  # after_commit コールバックを再発火させない（無限ループ防止）。
+  #
+  # @param notice_id [Integer] ManagementNotice の id
+  def perform(notice_id)
+    notice = ManagementNotice.find_by(id: notice_id)
+    unless notice
+      Rails.logger.warn("ManagementNoticePushJob: notice not found (id=#{notice_id})")
+      return
+    end
+
+    return if notice.notified_at.present?
+
+    PushNotificationService.send_to_all(
+      title: 'BUZZ BASE お知らせ',
+      body: notice.title
+    )
+
+    # NOTE: ManagementNotice の after_commit コールバックの再発火を防ぐため、
+    # 意図的に update_column を使用してコールバックをスキップする。
+    notice.update_column(:notified_at, Time.current) # rubocop:disable Rails/SkipsModelValidations
+  end
+end

--- a/app/models/management_notice.rb
+++ b/app/models/management_notice.rb
@@ -8,6 +8,7 @@ class ManagementNotice < ApplicationRecord
   validates :status, presence: true
 
   before_save :set_published_at
+  after_commit :enqueue_push_notification_if_needed, on: %i[create update]
 
   scope :published, -> { where(status: :published).order(published_at: :desc) }
 
@@ -15,5 +16,14 @@ class ManagementNotice < ApplicationRecord
 
   def set_published_at
     self.published_at = Time.current if status_changed? && published?
+  end
+
+  # ステータスが published へ変わったタイミングでのみプッシュ通知ジョブをenqueueする。
+  # notified_at が既にセットされている場合は重複送信防止のためスキップする。
+  def enqueue_push_notification_if_needed
+    return unless saved_change_to_status?(to: ManagementNotice.statuses[:published])
+    return if notified_at.present?
+
+    ManagementNoticePushJob.perform_later(id)
   end
 end

--- a/app/services/push_notification_service.rb
+++ b/app/services/push_notification_service.rb
@@ -1,4 +1,10 @@
 class PushNotificationService
+  EXPO_BATCH_SIZE = 100
+
+  # 指定ユーザーの全デバイストークンにプッシュ通知を送信する。
+  # @param user [User] 通知対象ユーザー
+  # @param title [String] 通知タイトル
+  # @param body [String] 通知本文
   def self.send_to_user(user, title:, body:)
     tokens = user.device_tokens.pluck(:token)
     return if tokens.empty?
@@ -18,4 +24,51 @@ class PushNotificationService
     Rails.logger.error("Push notification failed: #{e.message}")
     Sentry.capture_exception(e, extra: { user_id: user.id, title:, token_count: tokens&.size }) if Sentry.initialized?
   end
+
+  # 全ユーザーの全端末トークンへプッシュ通知を一斉送信する。
+  # Expo Push APIの100件制限に対応するため、EXPO_BATCH_SIZE ずつ分割して送信する。
+  #
+  # NOTE: DeviceToken が 10,000 件を超える規模になったら、Jobをバッチ単位に分割し
+  # Sidekiq 導入で並列実行することを検討する。1,000 ユーザー（~1,200 トークン）規模なら
+  # 約5秒で完了する想定。
+  #
+  # @param title [String] 通知タイトル
+  # @param body [String] 通知本文
+  def self.send_to_all(title:, body:)
+    client = Exponent::Push::Client.new
+    token_batch = []
+
+    DeviceToken.find_each(batch_size: 1000) do |device_token|
+      token_batch << device_token.token
+      if token_batch.size >= EXPO_BATCH_SIZE
+        send_batch(client, token_batch, title:, body:)
+        token_batch = []
+      end
+    end
+
+    send_batch(client, token_batch, title:, body:) if token_batch.any?
+  end
+
+  # 1バッチ（最大EXPO_BATCH_SIZE件）を送信する。
+  # Expo APIから返されたエラーレシートはSentryに警告として送り、無効トークンの削除は行わない。
+  def self.send_batch(client, tokens, title:, body:)
+    messages = tokens.map { |token| { to: token, title:, body:, sound: 'default' } }
+    handler = client.send_messages(messages)
+
+    if handler.errors?
+      Rails.logger.error("PushNotificationService.send_to_all errors: #{handler.errors.inspect}")
+      if Sentry.initialized?
+        Sentry.capture_message(
+          'Push notification batch errors',
+          level: :warning,
+          extra: { errors: handler.errors, invalid_tokens: handler.invalid_push_tokens }
+        )
+      end
+    end
+  rescue StandardError => e
+    Rails.logger.error("PushNotificationService.send_batch failed: #{e.message}")
+    Sentry.capture_exception(e, extra: { title:, token_count: tokens.size }) if Sentry.initialized?
+    raise
+  end
+  private_class_method :send_batch
 end

--- a/db/migrate/20260512142637_add_notified_at_to_management_notices.rb
+++ b/db/migrate/20260512142637_add_notified_at_to_management_notices.rb
@@ -4,11 +4,16 @@ class AddNotifiedAtToManagementNotices < ActiveRecord::Migration[7.0]
 
     # 既存のpublishedレコードに対し、デプロイ後の最初のupdate等で
     # 過去お知らせが誤ってプッシュ送信されることを防ぐためバックフィルする。
+    # マイグレーション内ではモデルクラスを直接参照せず、生SQLでstatus=1（published）を指定する。
+    # （モデルにバリデーション/コールバックが追加された際にゼロからのdb:migrateが壊れることを防ぐため）
     reversible do |dir|
       dir.up do
-        ManagementNotice.where(status: ManagementNotice.statuses[:published])
-                        .where.not(published_at: nil)
-                        .update_all('notified_at = published_at') # rubocop:disable Rails/SkipsModelValidations
+        execute <<~SQL.squish
+          UPDATE management_notices
+          SET notified_at = published_at
+          WHERE status = 1
+            AND published_at IS NOT NULL
+        SQL
       end
     end
   end

--- a/db/migrate/20260512142637_add_notified_at_to_management_notices.rb
+++ b/db/migrate/20260512142637_add_notified_at_to_management_notices.rb
@@ -1,0 +1,15 @@
+class AddNotifiedAtToManagementNotices < ActiveRecord::Migration[7.0]
+  def change
+    add_column :management_notices, :notified_at, :datetime
+
+    # 既存のpublishedレコードに対し、デプロイ後の最初のupdate等で
+    # 過去お知らせが誤ってプッシュ送信されることを防ぐためバックフィルする。
+    reversible do |dir|
+      dir.up do
+        ManagementNotice.where(status: ManagementNotice.statuses[:published])
+                        .where.not(published_at: nil)
+                        .update_all('notified_at = published_at') # rubocop:disable Rails/SkipsModelValidations
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_05_10_062318) do
+ActiveRecord::Schema[7.0].define(version: 2026_05_12_142637) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -233,6 +233,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_10_062318) do
     t.bigint "created_by_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "notified_at"
     t.index ["status", "published_at"], name: "index_management_notices_on_status_and_published_at"
   end
 

--- a/spec/factories/admin_users.rb
+++ b/spec/factories/admin_users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :admin_user, class: 'Admin::User' do
+    sequence(:email) { |n| "admin#{n}@example.com" }
+    sequence(:name) { |n| "Admin User #{n}" }
+    password { 'password' }
+  end
+end

--- a/spec/factories/management_notices.rb
+++ b/spec/factories/management_notices.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :management_notice do
+    sequence(:title) { |n| "お知らせ#{n}" }
+    body { 'お知らせ本文' }
+    status { :draft }
+    notified_at { nil }
+    created_by { association :admin_user }
+
+    trait :published do
+      status { :published }
+    end
+  end
+end

--- a/spec/factories/management_notices.rb
+++ b/spec/factories/management_notices.rb
@@ -6,8 +6,12 @@ FactoryBot.define do
     notified_at { nil }
     created_by { association :admin_user }
 
+    # 通常の :published は「すでに通知送信済み」状態を表す。
+    # after_commitによるプッシュ通知ジョブの意図しないenqueueを避けるため notified_at をデフォルトで設定する。
+    # 通知ジョブのenqueue自体をテストしたい場合は notified_at: nil を明示的に渡すこと。
     trait :published do
       status { :published }
+      notified_at { Time.current }
     end
   end
 end

--- a/spec/jobs/management_notice_push_job_spec.rb
+++ b/spec/jobs/management_notice_push_job_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe ManagementNoticePushJob, type: :job do
+  describe '#perform' do
+    context 'notice が存在し、notified_at が nil の場合' do
+      let(:notice) { create(:management_notice, :published, notified_at: nil) }
+
+      it 'PushNotificationService.send_to_all が呼び出される' do
+        allow(PushNotificationService).to receive(:send_to_all)
+
+        described_class.new.perform(notice.id)
+
+        expect(PushNotificationService).to have_received(:send_to_all).with(
+          title: 'BUZZ BASE お知らせ',
+          body: notice.title
+        )
+      end
+
+      it 'notified_at が現在時刻で更新される' do
+        allow(PushNotificationService).to receive(:send_to_all)
+
+        before_time = Time.current
+        described_class.new.perform(notice.id)
+        after_time = Time.current
+
+        notified_at = notice.reload.notified_at
+        expect(notified_at).to be_present
+        expect(notified_at).to be_between(before_time, after_time)
+      end
+    end
+
+    context 'notice の notified_at が既にセットされている場合' do
+      let(:notice) { create(:management_notice, :published, notified_at: 1.day.ago) }
+
+      it 'PushNotificationService.send_to_all は呼び出されない' do
+        allow(PushNotificationService).to receive(:send_to_all)
+
+        described_class.new.perform(notice.id)
+
+        expect(PushNotificationService).not_to have_received(:send_to_all)
+      end
+
+      it 'notified_at は更新されない' do
+        allow(PushNotificationService).to receive(:send_to_all)
+
+        original = notice.notified_at
+        described_class.new.perform(notice.id)
+
+        expect(notice.reload.notified_at).to be_within(1.second).of(original)
+      end
+    end
+
+    context 'notice が存在しない場合' do
+      it '例外を raise せず graceful に終了する' do
+        allow(PushNotificationService).to receive(:send_to_all)
+
+        expect { described_class.new.perform(0) }.not_to raise_error
+        expect(PushNotificationService).not_to have_received(:send_to_all)
+      end
+    end
+
+    context 'PushNotificationService.send_to_all が例外を raise した場合' do
+      let(:notice) { create(:management_notice, :published, notified_at: nil) }
+
+      before do
+        allow(PushNotificationService).to receive(:send_to_all).and_raise(StandardError, 'expo error')
+      end
+
+      it '例外が伝播し、notified_at は更新されない' do
+        expect { described_class.new.perform(notice.id) }.to raise_error(StandardError, 'expo error')
+        expect(notice.reload.notified_at).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/management_notice_spec.rb
+++ b/spec/models/management_notice_spec.rb
@@ -26,7 +26,9 @@ RSpec.describe ManagementNotice, type: :model do
     context '新規作成で status: published の場合' do
       it 'ManagementNoticePushJob がenqueueされる' do
         expect do
-          create(:management_notice, :published)
+          # :publishedトレイトはデフォルトで notified_at をセットするため、
+          # 通知ジョブのenqueueをテストする目的で明示的に nil を渡す。
+          create(:management_notice, :published, notified_at: nil)
         end.to have_enqueued_job(ManagementNoticePushJob)
       end
     end

--- a/spec/models/management_notice_spec.rb
+++ b/spec/models/management_notice_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe ManagementNotice, type: :model do
+  describe 'バリデーション' do
+    it 'title, body, status が必須である' do
+      notice = described_class.new
+      notice.valid?
+      expect(notice.errors[:title]).to include('を入力してください')
+      expect(notice.errors[:body]).to include('を入力してください')
+    end
+
+    it 'title は200文字以内' do
+      notice = build(:management_notice, title: 'a' * 201)
+      expect(notice).not_to be_valid
+    end
+  end
+
+  describe '#set_published_at' do
+    it 'draft から published に変更すると published_at がセットされる' do
+      notice = create(:management_notice, status: :draft)
+      expect { notice.update!(status: :published) }.to change { notice.reload.published_at }.from(nil)
+    end
+  end
+
+  describe '#enqueue_push_notification_if_needed' do
+    context '新規作成で status: published の場合' do
+      it 'ManagementNoticePushJob がenqueueされる' do
+        expect do
+          create(:management_notice, :published)
+        end.to have_enqueued_job(ManagementNoticePushJob)
+      end
+    end
+
+    context '新規作成で status: draft の場合' do
+      it 'ManagementNoticePushJob はenqueueされない' do
+        expect do
+          create(:management_notice, status: :draft)
+        end.not_to have_enqueued_job(ManagementNoticePushJob)
+      end
+    end
+
+    context 'draft → published の更新の場合' do
+      it 'ManagementNoticePushJob がenqueueされる' do
+        notice = create(:management_notice, status: :draft)
+        expect do
+          notice.update!(status: :published)
+        end.to have_enqueued_job(ManagementNoticePushJob).with(notice.id)
+      end
+    end
+
+    context 'published 状態でタイトルのみを更新した場合' do
+      it 'ManagementNoticePushJob はenqueueされない（status変更がないため）' do
+        notice = create(:management_notice, :published, notified_at: Time.current)
+        expect do
+          notice.update!(title: 'タイトル変更')
+        end.not_to have_enqueued_job(ManagementNoticePushJob)
+      end
+    end
+
+    context 'notified_at が既にセットされた状態で draft → published に変更した場合' do
+      it 'ManagementNoticePushJob はenqueueされない（重複防止）' do
+        notice = create(:management_notice, status: :draft, notified_at: Time.current)
+        expect do
+          notice.update!(status: :published)
+        end.not_to have_enqueued_job(ManagementNoticePushJob)
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,6 +26,9 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
   config.include AuthHelpers, type: :request
+  config.include ActiveJob::TestHelper, type: :job
+  config.include ActiveJob::TestHelper, type: :model
+  config.include ActiveJob::TestHelper, type: :request
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/requests/api/v1/admin/management_notices_spec.rb
+++ b/spec/requests/api/v1/admin/management_notices_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Admin::ManagementNotices', type: :request do
+  let(:admin_user) { create(:admin_user) }
+  let(:headers) do
+    {
+      'Authorization' => "Bearer #{InternalJwtService.encode_access_token(admin_user.id)}",
+      'Content-Type' => 'application/json'
+    }
+  end
+
+  describe 'POST /api/v1/admin/management_notices' do
+    context 'status: published で新規作成する場合' do
+      let(:params) do
+        {
+          management_notice: {
+            title: 'お知らせタイトル',
+            body: '本文',
+            status: 'published'
+          }
+        }
+      end
+
+      it 'ManagementNoticePushJob がenqueueされる' do
+        expect do
+          post '/api/v1/admin/management_notices', params: params.to_json, headers:
+        end.to have_enqueued_job(ManagementNoticePushJob)
+
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context 'status: draft で新規作成する場合' do
+      let(:params) do
+        {
+          management_notice: {
+            title: 'お知らせタイトル',
+            body: '本文',
+            status: 'draft'
+          }
+        }
+      end
+
+      it 'ManagementNoticePushJob はenqueueされない' do
+        expect do
+          post '/api/v1/admin/management_notices', params: params.to_json, headers:
+        end.not_to have_enqueued_job(ManagementNoticePushJob)
+
+        expect(response).to have_http_status(:created)
+      end
+    end
+  end
+
+  describe 'PATCH /api/v1/admin/management_notices/:id' do
+    context 'draft から published への更新の場合' do
+      let!(:notice) { create(:management_notice, status: :draft, created_by: admin_user) }
+      let(:params) { { management_notice: { status: 'published' } } }
+
+      it 'ManagementNoticePushJob がenqueueされる' do
+        expect do
+          patch "/api/v1/admin/management_notices/#{notice.id}", params: params.to_json, headers:
+        end.to have_enqueued_job(ManagementNoticePushJob).with(notice.id)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'published 状態でタイトルのみ変更する場合' do
+      let!(:notice) { create(:management_notice, :published, notified_at: Time.current, created_by: admin_user) }
+      let(:params) { { management_notice: { title: 'タイトル変更' } } }
+
+      it 'ManagementNoticePushJob はenqueueされない' do
+        expect do
+          patch "/api/v1/admin/management_notices/#{notice.id}", params: params.to_json, headers:
+        end.not_to have_enqueued_job(ManagementNoticePushJob)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/services/push_notification_service_spec.rb
+++ b/spec/services/push_notification_service_spec.rb
@@ -76,4 +76,91 @@ RSpec.describe PushNotificationService do
       end
     end
   end
+
+  describe '.send_to_all' do
+    let(:client_double) { instance_double(Exponent::Push::Client) }
+    let(:handler_double) { instance_double(Exponent::Push::ResponseHandler, errors?: false) }
+
+    before do
+      allow(Exponent::Push::Client).to receive(:new).and_return(client_double)
+      allow(client_double).to receive(:send_messages).and_return(handler_double)
+    end
+
+    context 'DeviceToken が0件の場合' do
+      it 'send_messages を呼び出さない' do
+        described_class.send_to_all(title: 'タイトル', body: '本文')
+        expect(client_double).not_to have_received(:send_messages)
+      end
+    end
+
+    context 'DeviceToken が99件の場合' do
+      before do
+        users = create_list(:user, 99)
+        users.each_with_index do |u, i|
+          u.device_tokens.create!(token: "ExponentPushToken[t#{i}]", platform: 'ios')
+        end
+      end
+
+      it 'send_messages が1回だけ呼ばれる' do
+        described_class.send_to_all(title: 'タイトル', body: '本文')
+        expect(client_double).to have_received(:send_messages).once
+      end
+    end
+
+    context 'DeviceToken が101件の場合（100件チャンクの境界）' do
+      before do
+        users = create_list(:user, 101)
+        users.each_with_index do |u, i|
+          u.device_tokens.create!(token: "ExponentPushToken[t#{i}]", platform: 'ios')
+        end
+      end
+
+      it 'send_messages が2回呼ばれる（100件 + 1件）' do
+        described_class.send_to_all(title: 'タイトル', body: '本文')
+        expect(client_double).to have_received(:send_messages).twice
+      end
+    end
+
+    context 'ResponseHandler が errors? を返す場合' do
+      let(:handler_double) do
+        instance_double(
+          Exponent::Push::ResponseHandler,
+          errors?: true,
+          errors: [{ message: 'invalid token' }],
+          invalid_push_tokens: ['ExponentPushToken[bad]']
+        )
+      end
+
+      before do
+        user = create(:user)
+        user.device_tokens.create!(token: 'ExponentPushToken[t1]', platform: 'ios')
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it 'エラーをログに記録し、例外を raise しない' do
+        expect do
+          described_class.send_to_all(title: 'タイトル', body: '本文')
+        end.not_to raise_error
+
+        expect(Rails.logger).to have_received(:error).with(/send_to_all errors/)
+      end
+    end
+
+    context 'send_messages が例外を raise した場合' do
+      before do
+        user = create(:user)
+        user.device_tokens.create!(token: 'ExponentPushToken[t1]', platform: 'ios')
+        allow(client_double).to receive(:send_messages).and_raise(StandardError, 'network error')
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it '例外が伝播する' do
+        expect do
+          described_class.send_to_all(title: 'タイトル', body: '本文')
+        end.to raise_error(StandardError, 'network error')
+
+        expect(Rails.logger).to have_received(:error).with(/send_batch failed/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## issue
close ippei-shimizu/buzzbase#316

## 実装概要
`ManagementNotice` の status が draft → published に変わったタイミング、または新規作成時にpublished状態で保存されたタイミングで、全ユーザーの全端末トークンへExpo Pushの一斉送信を**非同期**で行う機能を追加。重複送信は `notified_at` カラムで防止。

## 背景
管理画面（`/admin-management-console/notices`）からお知らせを公開しても、アプリ内通知タブには表示されるがiOSアプリの**プッシュ通知（バナー・ロック画面・バッジ）が届かない**問題が判明。調査の結果、お知らせ公開時にプッシュ通知を送る処理そのものが未実装だった（個別ユーザー向けの `PushNotificationService.send_to_user` のみ存在）。

## やらなかったこと
- 無効トークンの自動削除（Sentryログのみで対応、将来的に必要になれば独立対応）
- 管理画面からの「通知再送」ボタン（dyno再起動でジョブが消失した場合は draft → published 再操作で再送可能）
- Sidekiq導入（ユーザー規模が1万を超えるまで `:async` adapter で運用）

## 受入基準
- [x] `notified_at` カラム追加マイグレーション、既存publishedレコードのバックフィル
- [x] 新規作成 status: published → ジョブenqueue
- [x] 新規作成 status: draft → ジョブenqueueされない
- [x] draft → published 更新 → ジョブenqueue
- [x] published状態でタイトル変更 → ジョブenqueueされない
- [x] `notified_at` あり → ジョブenqueueされない（重複防止）
- [x] Job冪等性ガード（再実行でも二重送信されない）
- [x] Expo Push API 100件チャンク分割送信
- [x] 全テスト (577 examples, 0 failures) / RuboCop パス

## 実装詳細
- `db/migrate/20260512142637_add_notified_at_to_management_notices.rb`: `notified_at` カラム追加 + 既存published `update_all` バックフィル
- `app/models/management_notice.rb`: `after_commit :enqueue_push_notification_if_needed, on: %i[create update]` 追加。`saved_change_to_status?(to: published)` と `notified_at.nil?` でガード
- `app/jobs/management_notice_push_job.rb` (新規): Job冪等性ガード後、`PushNotificationService.send_to_all` を呼び `update_column(:notified_at, ...)` で完了マーク（after_commit再発火を避けるため `update_column`）
- `app/services/push_notification_service.rb`: `send_to_all(title:, body:)` 新設。`DeviceToken.find_each(batch_size: 1000)` でDB読み出し、`EXPO_BATCH_SIZE = 100` ずつ Expo APIへ送信。エラーは Sentry に警告として記録
- Push文面: `title: 'BUZZ BASE お知らせ'` / `body: notice.title`
- 新規factory: `spec/factories/admin_users.rb`, `spec/factories/management_notices.rb`
- `spec/rails_helper.rb`: `ActiveJob::TestHelper` を model/job/request にinclude

## 確認手順
1. `docker compose exec back bundle exec rails db:migrate` でマイグレーション適用
2. 管理画面で新規お知らせを「公開」で作成 → iOSアプリにプッシュ通知が届く
3. 同じお知らせを編集（タイトル変更）→ 再送されない
4. アプリ内通知タブにも従来通り表示される

## 影響範囲
- 管理画面のお知らせ作成・更新（フローは変わらず、副作用としてプッシュ送信が追加）
- iOSアプリの実機ユーザー（プッシュ通知が届くようになる）

## コード上の懸念点
- Queue Adapter は現状 `:async`（Railsデフォルト）。Heroku dyno再起動でジョブが消失するリスクがあるが、お知らせは低頻度のため許容。1万ユーザー超えるまでに Sidekiq 導入を検討（`push_notification_service.rb` にコメント記載済み）
- `DeviceToken` の有効期限管理が現状なし。Expo APIから返る `invalid_push_tokens` は Sentry に記録のみで自動削除はしない（独立タスクとして将来検討）

## その他
特になし

🤖 Generated with [Claude Code](https://claude.com/claude-code)