### PR TITLE
Add: Pro サブスクリプション骨格 (#317)

### DIFF
--- a/app/controllers/api/v1/pro/entitlements_controller.rb
+++ b/app/controllers/api/v1/pro/entitlements_controller.rb
@@ -1,0 +1,21 @@
+module Api
+  module V1
+    module Pro
+      # GET /api/v1/pro/entitlements
+      # 全 entitlement キーごとに granted フラグを返す。
+      # クライアント側で個別画面の出し分けや paywall 表示を判定するために使う。
+      class EntitlementsController < ApplicationController
+        before_action :authenticate_api_v1_user!
+
+        def index
+          user = current_api_v1_user
+          entitlements = ::Entitlement::ALL_FEATURES.map do |key|
+            { key:, granted: user.has_entitlement?(key) }
+          end
+
+          render json: { entitlements: }, status: :ok
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/pro/status_controller.rb
+++ b/app/controllers/api/v1/pro/status_controller.rb
@@ -11,10 +11,7 @@ module Api
           subscription = user.subscription_or_default
 
           render json: {
-            subscription: ActiveModelSerializers::SerializableResource.new(
-              subscription,
-              serializer: ::V1::SubscriptionSerializer
-            ).as_json,
+            subscription: ::V1::SubscriptionSerializer.new(subscription).as_json,
             entitlements: granted_entitlement_keys(user)
           }, status: :ok
         end

--- a/app/controllers/api/v1/pro/status_controller.rb
+++ b/app/controllers/api/v1/pro/status_controller.rb
@@ -1,0 +1,32 @@
+module Api
+  module V1
+    module Pro
+      # GET /api/v1/pro/status
+      # 現在ユーザーの Pro 状態と保有 Entitlement を返す。
+      class StatusController < ApplicationController
+        before_action :authenticate_api_v1_user!
+
+        def show
+          user = current_api_v1_user
+          subscription = user.subscription_or_default
+
+          render json: {
+            subscription: ActiveModelSerializers::SerializableResource.new(
+              subscription,
+              serializer: ::V1::SubscriptionSerializer
+            ).as_json,
+            entitlements: granted_entitlement_keys(user)
+          }, status: :ok
+        end
+
+        private
+
+        # ユーザーが現在保有している entitlement キーのリスト。
+        # 無料機能は常に含まれ、Pro 機能は pro_active? のときのみ含まれる。
+        def granted_entitlement_keys(user)
+          ::Entitlement::ALL_FEATURES.select { |key| user.has_entitlement?(key) }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/pro/sync_controller.rb
+++ b/app/controllers/api/v1/pro/sync_controller.rb
@@ -14,10 +14,7 @@ module Api
           subscription.update!(last_synced_at: Time.current)
 
           render json: {
-            subscription: ActiveModelSerializers::SerializableResource.new(
-              subscription,
-              serializer: ::V1::SubscriptionSerializer
-            ).as_json,
+            subscription: ::V1::SubscriptionSerializer.new(subscription).as_json,
             entitlements: ::Entitlement::ALL_FEATURES.select { |key| user.has_entitlement?(key) }
           }, status: :ok
         end

--- a/app/controllers/api/v1/pro/sync_controller.rb
+++ b/app/controllers/api/v1/pro/sync_controller.rb
@@ -1,0 +1,27 @@
+module Api
+  module V1
+    module Pro
+      # POST /api/v1/pro/sync
+      # クライアントから「RevenueCat と Rails の状態を再同期してくれ」と要求する暫定エンドポイント。
+      # 本実装は #318 で RevenueCat REST API を叩いて状態を取得・反映する形に差し替える予定。
+      # 本 Issue では last_synced_at の刻印と現在状態の返却だけを行うスタブとする。
+      class SyncController < ApplicationController
+        before_action :authenticate_api_v1_user!
+
+        def create
+          user = current_api_v1_user
+          subscription = user.subscription || user.create_subscription!(status: 'free')
+          subscription.update!(last_synced_at: Time.current)
+
+          render json: {
+            subscription: ActiveModelSerializers::SerializableResource.new(
+              subscription,
+              serializer: ::V1::SubscriptionSerializer
+            ).as_json,
+            entitlements: ::Entitlement::ALL_FEATURES.select { |key| user.has_entitlement?(key) }
+          }, status: :ok
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/webhooks/revenuecat_controller.rb
+++ b/app/controllers/api/v1/webhooks/revenuecat_controller.rb
@@ -1,0 +1,18 @@
+module Api
+  module V1
+    module Webhooks
+      # POST /api/v1/webhooks/revenuecat
+      # RevenueCat からの Webhook 受信スタブ。
+      # 本 Issue ではルートの受け皿のみ用意し、署名検証と payload 解釈・状態遷移は #318 で実装する。
+      # スタブ実装でも 401/403 ではなく 200 を返し、RevenueCat 側のリトライ抑止を担保する。
+      class RevenuecatController < ApplicationController
+        skip_before_action :verify_authenticity_token, raise: false
+
+        # TODO(#318): X-RevenueCat-Signature ヘッダの HMAC 検証 + payload 解釈 + 状態遷移処理を実装する。
+        def create
+          head :ok
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/entitlement.rb
+++ b/app/models/concerns/entitlement.rb
@@ -1,0 +1,48 @@
+# 機能アクセス権（Entitlement）を判定するための concern。User に include して使う。
+# 機能キーは FREE_FEATURES（常に true）と PRO_FEATURES（Pro 加入時のみ true）で構成する。
+module Entitlement
+  extend ActiveSupport::Concern
+
+  FREE_FEATURES = %w[
+    basic_game_record
+    basic_stats
+    group_ranking
+    calculation_tools
+    baseball_note_basic
+    shadow_swing_basic
+    practice_log_basic
+    grass_recent_30days
+    monthly_goal_single
+    schedule_single
+  ].freeze
+
+  PRO_FEATURES = %w[
+    no_ads
+    season_transition_graph
+    grass_full_history
+    unlimited_practice_menus
+    unlimited_media_uploads
+    media_long_term_storage
+    unlimited_schedules
+    unlimited_monthly_goals
+    season_goals
+    custom_notification_messages
+    advanced_goal_tracking
+    detailed_condition_log
+  ].freeze
+
+  ALL_FEATURES = (FREE_FEATURES + PRO_FEATURES).freeze
+
+  # 指定 feature_key にユーザーがアクセス可能か。
+  # 無料機能は常に true、Pro 機能は subscription が pro_active? のときのみ true。
+  # 命名はクライアント側 `hasEntitlement` と揃えるため Naming/PredicateName を無効化する。
+  # @param feature_key [String]
+  # @return [Boolean]
+  # @raise [ArgumentError] 未知の feature_key が渡されたとき
+  def has_entitlement?(feature_key) # rubocop:disable Naming/PredicateName
+    raise ArgumentError, "Unknown feature: #{feature_key}" unless ALL_FEATURES.include?(feature_key)
+    return true if FREE_FEATURES.include?(feature_key)
+
+    pro_active?
+  end
+end

--- a/app/models/concerns/entitlement.rb
+++ b/app/models/concerns/entitlement.rb
@@ -4,33 +4,33 @@ module Entitlement
   extend ActiveSupport::Concern
 
   # 無料プランで利用可能な機能キー。Pro 加入の有無に関わらず常に許可される。
-  FREE_FEATURES = %w[
-    basic_game_record # 試合記録(基本): 試合結果・打撃成績の入力と表示
-    basic_stats # 基本成績集計: 打率・防御率などの基本指標
-    group_ranking # グループ内ランキング機能
-    calculation_tools # 打率・防御率などの計算ツール
-    baseball_note_basic # 野球ノート(基本): 練習・試合の振り返りメモ
-    shadow_swing_basic # 素振りカウンター(基本): スイング回数の記録
-    practice_log_basic # 練習記録(基本): 練習内容のログ
-    grass_recent_30days # 草機能: 直近30日分のヒートマップ表示
-    monthly_goal_single # 月次目標: 1つまで作成可
-    schedule_single # 自主練スケジュール: 1つまで作成可
+  FREE_FEATURES = [
+    'basic_game_record',     # 試合記録(基本): 試合結果・打撃成績の入力と表示
+    'basic_stats',           # 基本成績集計: 打率・防御率などの基本指標
+    'group_ranking',         # グループ内ランキング機能
+    'calculation_tools',     # 打率・防御率などの計算ツール
+    'baseball_note_basic',   # 野球ノート(基本): 練習・試合の振り返りメモ
+    'shadow_swing_basic',    # 素振りカウンター(基本): スイング回数の記録
+    'practice_log_basic',    # 練習記録(基本): 練習内容のログ
+    'grass_recent_30days',   # 草機能: 直近30日分のヒートマップ表示
+    'monthly_goal_single',   # 月次目標: 1つまで作成可
+    'schedule_single'        # 自主練スケジュール: 1つまで作成可
   ].freeze
 
   # Pro 加入時のみ利用可能な機能キー。subscription が pro_active? のとき true。
-  PRO_FEATURES = %w[
-    no_ads # 広告非表示
-    season_transition_graph # シーズン跨ぎ成績推移グラフ(複数シーズン比較)
-    grass_full_history # 草機能: 全期間ヒートマップ表示
-    unlimited_practice_menus # 練習メニュー無制限(無料は3件まで)
-    unlimited_media_uploads # 動画・画像アップロード無制限(無料は月3件)
-    media_long_term_storage # メディア長期保管(31日以上前も閲覧可)
-    unlimited_schedules # 自主練スケジュール無制限(無料は1件まで)
-    unlimited_monthly_goals # 月次目標無制限(無料は1件まで)
-    season_goals # シーズン目標(無料は利用不可)
-    custom_notification_messages # カスタム通知メッセージの設定
-    advanced_goal_tracking # 高度な目標トラッキング(達成率の詳細推移)
-    detailed_condition_log # 詳細コンディションログ(体調・気分の詳細記録)
+  PRO_FEATURES = [
+    'no_ads',                       # 広告非表示
+    'season_transition_graph',      # シーズン跨ぎ成績推移グラフ(複数シーズン比較)
+    'grass_full_history',           # 草機能: 全期間ヒートマップ表示
+    'unlimited_practice_menus',     # 練習メニュー無制限(無料は3件まで)
+    'unlimited_media_uploads',      # 動画・画像アップロード無制限(無料は月3件)
+    'media_long_term_storage',      # メディア長期保管(31日以上前も閲覧可)
+    'unlimited_schedules',          # 自主練スケジュール無制限(無料は1件まで)
+    'unlimited_monthly_goals',      # 月次目標無制限(無料は1件まで)
+    'season_goals',                 # シーズン目標(無料は利用不可)
+    'custom_notification_messages', # カスタム通知メッセージの設定
+    'advanced_goal_tracking',       # 高度な目標トラッキング(達成率の詳細推移)
+    'detailed_condition_log'        # 詳細コンディションログ(体調・気分の詳細記録)
   ].freeze
 
   ALL_FEATURES = (FREE_FEATURES + PRO_FEATURES).freeze

--- a/app/models/concerns/entitlement.rb
+++ b/app/models/concerns/entitlement.rb
@@ -3,32 +3,34 @@
 module Entitlement
   extend ActiveSupport::Concern
 
+  # 無料プランで利用可能な機能キー。Pro 加入の有無に関わらず常に許可される。
   FREE_FEATURES = %w[
-    basic_game_record
-    basic_stats
-    group_ranking
-    calculation_tools
-    baseball_note_basic
-    shadow_swing_basic
-    practice_log_basic
-    grass_recent_30days
-    monthly_goal_single
-    schedule_single
+    basic_game_record # 試合記録(基本): 試合結果・打撃成績の入力と表示
+    basic_stats # 基本成績集計: 打率・防御率などの基本指標
+    group_ranking # グループ内ランキング機能
+    calculation_tools # 打率・防御率などの計算ツール
+    baseball_note_basic # 野球ノート(基本): 練習・試合の振り返りメモ
+    shadow_swing_basic # 素振りカウンター(基本): スイング回数の記録
+    practice_log_basic # 練習記録(基本): 練習内容のログ
+    grass_recent_30days # 草機能: 直近30日分のヒートマップ表示
+    monthly_goal_single # 月次目標: 1つまで作成可
+    schedule_single # 自主練スケジュール: 1つまで作成可
   ].freeze
 
+  # Pro 加入時のみ利用可能な機能キー。subscription が pro_active? のとき true。
   PRO_FEATURES = %w[
-    no_ads
-    season_transition_graph
-    grass_full_history
-    unlimited_practice_menus
-    unlimited_media_uploads
-    media_long_term_storage
-    unlimited_schedules
-    unlimited_monthly_goals
-    season_goals
-    custom_notification_messages
-    advanced_goal_tracking
-    detailed_condition_log
+    no_ads # 広告非表示
+    season_transition_graph # シーズン跨ぎ成績推移グラフ(複数シーズン比較)
+    grass_full_history # 草機能: 全期間ヒートマップ表示
+    unlimited_practice_menus # 練習メニュー無制限(無料は3件まで)
+    unlimited_media_uploads # 動画・画像アップロード無制限(無料は月3件)
+    media_long_term_storage # メディア長期保管(31日以上前も閲覧可)
+    unlimited_schedules # 自主練スケジュール無制限(無料は1件まで)
+    unlimited_monthly_goals # 月次目標無制限(無料は1件まで)
+    season_goals # シーズン目標(無料は利用不可)
+    custom_notification_messages # カスタム通知メッセージの設定
+    advanced_goal_tracking # 高度な目標トラッキング(達成率の詳細推移)
+    detailed_condition_log # 詳細コンディションログ(体調・気分の詳細記録)
   ].freeze
 
   ALL_FEATURES = (FREE_FEATURES + PRO_FEATURES).freeze

--- a/app/models/concerns/plan_limits.rb
+++ b/app/models/concerns/plan_limits.rb
@@ -1,0 +1,69 @@
+# 無料プランの数量制限を表すビジネスルール。User に include して使う。
+# 各 can_*? は Pro Entitlement を保有していれば即 true、無料時は現在の保有数で判定する。
+# カウント取得側のメソッドは User 本体（実関連のあるメソッド）で上書きする想定だが、
+# 関連未実装の機能は 0 を返すデフォルト実装で済む。
+module PlanLimits
+  extend ActiveSupport::Concern
+
+  PRACTICE_MENU_FREE_LIMIT = 3
+  MEDIA_UPLOAD_FREE_LIMIT_PER_MONTH = 3
+  SCHEDULE_FREE_LIMIT = 1
+  MONTHLY_GOAL_FREE_LIMIT = 1
+
+  # 練習メニューを新規作成できるか。無料は archived 以外3つまで。
+  # @return [Boolean]
+  def can_create_practice_menu?
+    return true if has_entitlement?('unlimited_practice_menus')
+
+    practice_menus_count_for_business_rules < PRACTICE_MENU_FREE_LIMIT
+  end
+
+  # 当月のメディアアップロードが可能か。無料は月3点まで。
+  # @return [Boolean]
+  def can_upload_media_this_month?
+    return true if has_entitlement?('unlimited_media_uploads')
+
+    media_attachments_count_this_month < MEDIA_UPLOAD_FREE_LIMIT_PER_MONTH
+  end
+
+  # 自主練スケジュールを新規作成できるか。無料は active なものが1つまで。
+  # @return [Boolean]
+  def can_create_schedule?
+    return true if has_entitlement?('unlimited_schedules')
+
+    active_schedules_count < SCHEDULE_FREE_LIMIT
+  end
+
+  # 月次目標を新規作成できるか。無料は active なものが1つまで。
+  # @return [Boolean]
+  def can_create_monthly_goal?
+    return true if has_entitlement?('unlimited_monthly_goals')
+
+    active_monthly_goals_count < MONTHLY_GOAL_FREE_LIMIT
+  end
+
+  # シーズン目標を新規作成できるか。Pro 限定機能。
+  # @return [Boolean]
+  def can_create_season_goal?
+    has_entitlement?('season_goals')
+  end
+
+  private
+
+  # 各 Pro 機能 issue で実関連に差し替える。関連未実装のため現状は 0 を返す。
+  def practice_menus_count_for_business_rules
+    0
+  end
+
+  def media_attachments_count_this_month
+    0
+  end
+
+  def active_schedules_count
+    0
+  end
+
+  def active_monthly_goals_count
+    0
+  end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -6,7 +6,23 @@ class Subscription < ApplicationRecord
   PRO_ACTIVE_STATUSES = %w[trial active cancelled billing_issue].freeze
   GRACE_STATUSES = %w[cancelled billing_issue].freeze
 
-  enum status: STATUSES.index_with(&:itself)
+  # status の取りうる値:
+  # - free          : 一度も加入していない、または完全期限切れ
+  # - trial         : トライアル期間中（期限内）
+  # - active        : 通常課金中（期限内）
+  # - cancelled     : 解約申請済み、期限まで利用可
+  # - billing_issue : 課金失敗、Grace Period 中
+  # - expired       : 期限切れ、Pro 機能不可
+  # - pending       : 課金処理中の遷移状態。Pro 機能は不可（PRO_ACTIVE_STATUSES に含めない）
+  enum status: {
+    free: 'free',
+    trial: 'trial',
+    active: 'active',
+    cancelled: 'cancelled',
+    billing_issue: 'billing_issue',
+    expired: 'expired',
+    pending: 'pending'
+  }
   enum plan_type: { monthly: 'monthly', yearly: 'yearly' }, _prefix: :plan
   enum platform: { ios: 'ios', web: 'web', android: 'android' }, _prefix: :platform
 
@@ -27,10 +43,14 @@ class Subscription < ApplicationRecord
     trial? && (expires_at.nil? || expires_at > Time.current)
   end
 
-  # グレースピリオド中か（解約済みだが期限内、または課金失敗中）。
+  # グレースピリオド中か（解約済みだが期限内、または課金失敗中で期限内）。
+  # 「期限切れの cancelled / billing_issue」は無料状態と見なすため false を返す。
+  # クライアントはこのフラグを Pro アクセス判定に直接使ってよい。
   # @return [Boolean]
   def in_grace_period?
-    GRACE_STATUSES.include?(status)
+    return false unless GRACE_STATUSES.include?(status)
+
+    expires_at.nil? || expires_at > Time.current
   end
 
   # 期限までの残日数（負数にはならない）。expires_at が nil なら nil を返す。

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,0 +1,49 @@
+class Subscription < ApplicationRecord
+  belongs_to :user
+  has_many :user_subscription_events, dependent: :nullify
+
+  STATUSES = %w[free trial active cancelled billing_issue expired pending].freeze
+  PRO_ACTIVE_STATUSES = %w[trial active cancelled billing_issue].freeze
+  GRACE_STATUSES = %w[cancelled billing_issue].freeze
+
+  enum status: STATUSES.index_with(&:itself)
+  enum plan_type: { monthly: 'monthly', yearly: 'yearly' }, _prefix: :plan
+  enum platform: { ios: 'ios', web: 'web', android: 'android' }, _prefix: :platform
+
+  validates :status, inclusion: { in: STATUSES }
+
+  # Pro 機能が利用可能か。
+  # 期限内かつ status が trial / active / cancelled / billing_issue のとき true。
+  # @return [Boolean]
+  def pro_active?
+    return false unless PRO_ACTIVE_STATUSES.include?(status)
+
+    expires_at.nil? || expires_at > Time.current
+  end
+
+  # トライアル期間中か。
+  # @return [Boolean]
+  def in_trial?
+    trial? && (expires_at.nil? || expires_at > Time.current)
+  end
+
+  # グレースピリオド中か（解約済みだが期限内、または課金失敗中）。
+  # @return [Boolean]
+  def in_grace_period?
+    GRACE_STATUSES.include?(status)
+  end
+
+  # 期限までの残日数（負数にはならない）。expires_at が nil なら nil を返す。
+  # @return [Integer, nil]
+  def days_remaining
+    return nil unless expires_at
+
+    [(expires_at.to_date - Date.current).to_i, 0].max
+  end
+
+  # トライアル利用可能か。1ユーザー1回までの制約を表現する。
+  # @return [Boolean]
+  def can_use_trial?
+    !has_used_trial?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,9 @@
 class User < ActiveRecord::Base
+  include Entitlement
+  include PlanLimits
+
   mount_uploader :image, AvatarUploader
+  has_one :subscription, dependent: :destroy
   has_many :user_positions, dependent: :destroy
   has_many :positions, through: :user_positions
   belongs_to :team, foreign_key: 'user_id', primary_key: 'id', optional: true, inverse_of: :user
@@ -39,6 +43,7 @@ class User < ActiveRecord::Base
   include DeviseTokenAuth::Concerns::User
 
   before_validation :normalize_user_id
+  after_create :create_default_subscription
   after_commit :notify_slack_new_user, on: :create
 
   validates :password, custom_password: true, on: :create, unless: -> { provider.in?(%w[google apple]) }
@@ -136,6 +141,21 @@ class User < ActiveRecord::Base
 
   delegate :count, to: :followers, prefix: true
 
+  # subscription が未生成の場合に「無料状態」を表す未保存レコードを返す。
+  # API レスポンス時に nil チェックを避ける目的で利用する。
+  # @return [Subscription]
+  def subscription_or_default
+    subscription || Subscription.new(user: self, status: 'free')
+  end
+
+  # Pro 機能が利用可能か。
+  # @return [Boolean]
+  delegate :pro_active?, to: :subscription_or_default
+
+  # トライアル期間中か。
+  # @return [Boolean]
+  delegate :in_trial?, to: :subscription_or_default
+
   private
 
   def normalize_user_id
@@ -144,5 +164,12 @@ class User < ActiveRecord::Base
 
   def notify_slack_new_user
     SlackNotificationService.notify_new_user(self)
+  end
+
+  # subscription が無いユーザー（コールバック前のレコード等）でも nil 安全に動作させる。
+  def create_default_subscription
+    return if subscription.present?
+
+    create_subscription!(status: 'free')
   end
 end

--- a/app/models/user_subscription_event.rb
+++ b/app/models/user_subscription_event.rb
@@ -1,0 +1,21 @@
+# Pro 加入状態に関する監査ログ。
+# 書き込みロジック（Webhook 受信時の event 記録）は #318 で実装する。
+# 本 Issue ではモデルクラスのみ用意し、Subscription / User からの関連を成立させる。
+class UserSubscriptionEvent < ApplicationRecord
+  belongs_to :user
+  belongs_to :subscription, optional: true
+
+  EVENT_TYPES = %w[
+    trial_started
+    purchased
+    renewed
+    cancelled
+    expired
+    refunded
+    billing_issue
+    recovered
+  ].freeze
+
+  validates :event_type, presence: true
+  validates :occurred_at, presence: true
+end

--- a/app/models/webhook_event.rb
+++ b/app/models/webhook_event.rb
@@ -1,0 +1,10 @@
+# 外部サービスからの Webhook 受信ログ（冪等性キャッシュ）。
+# 書き込みロジックは #318 で実装する。
+class WebhookEvent < ApplicationRecord
+  STATUSES = %w[pending processed failed skipped].freeze
+
+  validates :provider, presence: true
+  validates :external_event_id, presence: true,
+                                uniqueness: { scope: :provider }
+  validates :status, inclusion: { in: STATUSES }
+end

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -1,0 +1,24 @@
+module V1
+  # /api/v1/pro/status から返却する subscription 部分のシリアライザ。
+  # フロント・モバイル共通の Pro 状態判定の根拠となるため、
+  # クライアントの pro_active? と同じロジックをここで露出させる。
+  class SubscriptionSerializer < ActiveModel::Serializer
+    attributes :status, :plan_type, :platform,
+               :started_at, :expires_at,
+               :in_trial, :in_grace_period, :days_remaining,
+               :is_early_subscriber, :has_used_trial
+
+    # @return [Boolean]
+    def in_trial
+      object.in_trial?
+    end
+
+    # @return [Boolean]
+    def in_grace_period
+      object.in_grace_period?
+    end
+
+    # @return [Integer, nil]
+    delegate :days_remaining, to: :object
+  end
+end

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -5,8 +5,13 @@ module V1
   class SubscriptionSerializer < ActiveModel::Serializer
     attributes :status, :plan_type, :platform,
                :started_at, :expires_at,
-               :in_trial, :in_grace_period, :days_remaining,
+               :pro_active, :in_trial, :in_grace_period, :days_remaining,
                :is_early_subscriber, :has_used_trial
+
+    # @return [Boolean] 期限内かつ Pro 加入扱いの status か
+    def pro_active
+      object.pro_active?
+    end
 
     # @return [Boolean]
     def in_trial

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -151,6 +151,16 @@ Rails.application.routes.draw do
 
       resources :management_notices, only: %i[index show]
 
+      namespace :pro do
+        resource :status, only: %i[show], controller: 'status'
+        resource :sync, only: %i[create], controller: 'sync'
+        resources :entitlements, only: %i[index]
+      end
+
+      namespace :webhooks do
+        resource :revenuecat, only: %i[create], controller: 'revenuecat'
+      end
+
       namespace :admin do
         resources :analytics, only: [] do
           collection do

--- a/db/migrate/20260517100001_create_subscriptions.rb
+++ b/db/migrate/20260517100001_create_subscriptions.rb
@@ -13,7 +13,10 @@ class CreateSubscriptions < ActiveRecord::Migration[7.0]
       t.datetime :billing_issue_at
       t.boolean :has_used_trial, null: false, default: false
       t.string :revenuecat_user_id
-      t.string :revenuecat_entitlement_id, default: 'pro'
+      # RevenueCat 側で割り当てられた entitlement の ID。Pro 加入時のみ値が入り、
+      # 無料ユーザーは NULL のままにする（'pro' 等のデフォルトを置くと
+      # RevenueCat 連携時に「pro entitlement 保有」と誤判定される）
+      t.string :revenuecat_entitlement_id
       t.boolean :is_early_subscriber, null: false, default: false
       t.datetime :last_synced_at
       t.timestamps

--- a/db/migrate/20260517100001_create_subscriptions.rb
+++ b/db/migrate/20260517100001_create_subscriptions.rb
@@ -1,0 +1,26 @@
+class CreateSubscriptions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :subscriptions do |t|
+      t.references :user, null: false, foreign_key: true, index: { unique: true }
+      t.string :status, null: false, default: 'free'
+      t.string :plan_type
+      t.string :platform
+      t.string :product_id
+      t.datetime :started_at
+      t.datetime :expires_at
+      t.datetime :cancelled_at
+      t.datetime :refunded_at
+      t.datetime :billing_issue_at
+      t.boolean :has_used_trial, null: false, default: false
+      t.string :revenuecat_user_id
+      t.string :revenuecat_entitlement_id, default: 'pro'
+      t.boolean :is_early_subscriber, null: false, default: false
+      t.datetime :last_synced_at
+      t.timestamps
+    end
+
+    add_index :subscriptions, :status
+    add_index :subscriptions, :expires_at
+    add_index :subscriptions, :revenuecat_user_id, unique: true
+  end
+end

--- a/db/migrate/20260517100002_create_user_subscription_events.rb
+++ b/db/migrate/20260517100002_create_user_subscription_events.rb
@@ -1,0 +1,20 @@
+class CreateUserSubscriptionEvents < ActiveRecord::Migration[7.0]
+  def change
+    create_table :user_subscription_events do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :subscription, null: true, foreign_key: true
+      t.string :event_type, null: false
+      t.string :platform
+      t.string :product_id
+      t.string :period_type
+      t.datetime :occurred_at, null: false
+      t.jsonb :raw_payload
+      t.string :revenuecat_event_id
+      t.timestamps
+    end
+
+    add_index :user_subscription_events, :revenuecat_event_id, unique: true
+    add_index :user_subscription_events, %i[user_id occurred_at]
+    add_index :user_subscription_events, :event_type
+  end
+end

--- a/db/migrate/20260517100003_create_webhook_events.rb
+++ b/db/migrate/20260517100003_create_webhook_events.rb
@@ -1,0 +1,17 @@
+class CreateWebhookEvents < ActiveRecord::Migration[7.0]
+  def change
+    create_table :webhook_events do |t|
+      t.string :provider, null: false
+      t.string :external_event_id, null: false
+      t.string :event_type
+      t.datetime :received_at, null: false
+      t.datetime :processed_at
+      t.string :status, null: false, default: 'pending'
+      t.jsonb :payload
+      t.timestamps
+    end
+
+    add_index :webhook_events, %i[provider external_event_id], unique: true
+    add_index :webhook_events, :status
+  end
+end

--- a/db/migrate/20260517100004_backfill_default_subscriptions_for_existing_users.rb
+++ b/db/migrate/20260517100004_backfill_default_subscriptions_for_existing_users.rb
@@ -1,0 +1,14 @@
+class BackfillDefaultSubscriptionsForExistingUsers < ActiveRecord::Migration[7.0]
+  def up
+    execute <<~SQL.squish
+      INSERT INTO subscriptions (user_id, status, has_used_trial, is_early_subscriber, revenuecat_entitlement_id, created_at, updated_at)
+      SELECT id, 'free', FALSE, FALSE, 'pro', NOW(), NOW()
+      FROM users
+      WHERE id NOT IN (SELECT user_id FROM subscriptions);
+    SQL
+  end
+
+  def down
+    execute "DELETE FROM subscriptions WHERE status = 'free';"
+  end
+end

--- a/db/migrate/20260517100004_backfill_default_subscriptions_for_existing_users.rb
+++ b/db/migrate/20260517100004_backfill_default_subscriptions_for_existing_users.rb
@@ -1,14 +1,20 @@
 class BackfillDefaultSubscriptionsForExistingUsers < ActiveRecord::Migration[7.0]
+  # Pro 機能リリース前から存在する既存ユーザーには User#after_create が遡及しないため、
+  # 全ユーザーに status = 'free' の subscription を1件ずつ作る。
+  # 以降のコードは「全ユーザーが必ず subscription を持つ」前提で書ける。
+  # revenuecat_entitlement_id は無料ユーザーには NULL で残す（Pro 加入時に入る）。
   def up
     execute <<~SQL.squish
-      INSERT INTO subscriptions (user_id, status, has_used_trial, is_early_subscriber, revenuecat_entitlement_id, created_at, updated_at)
-      SELECT id, 'free', FALSE, FALSE, 'pro', NOW(), NOW()
+      INSERT INTO subscriptions (user_id, status, has_used_trial, is_early_subscriber, created_at, updated_at)
+      SELECT id, 'free', FALSE, FALSE, NOW(), NOW()
       FROM users
       WHERE id NOT IN (SELECT user_id FROM subscriptions);
     SQL
   end
 
+  # down は危険：単に「status = free」で消すと、Pro 解約 → free に戻った正規データも
+  # 巻き込んで削除してしまう。元データを特定する手段がないため、ロールバック不能とする。
   def down
-    execute "DELETE FROM subscriptions WHERE status = 'free';"
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -355,7 +355,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_17_100004) do
     t.datetime "billing_issue_at"
     t.boolean "has_used_trial", default: false, null: false
     t.string "revenuecat_user_id"
-    t.string "revenuecat_entitlement_id", default: "pro"
+    t.string "revenuecat_entitlement_id"
     t.boolean "is_early_subscriber", default: false, null: false
     t.datetime "last_synced_at"
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_05_12_142637) do
+ActiveRecord::Schema[7.0].define(version: 2026_05_17_100004) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -342,6 +342,30 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_12_142637) do
     t.index ["user_id"], name: "index_seasons_on_user_id"
   end
 
+  create_table "subscriptions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "status", default: "free", null: false
+    t.string "plan_type"
+    t.string "platform"
+    t.string "product_id"
+    t.datetime "started_at"
+    t.datetime "expires_at"
+    t.datetime "cancelled_at"
+    t.datetime "refunded_at"
+    t.datetime "billing_issue_at"
+    t.boolean "has_used_trial", default: false, null: false
+    t.string "revenuecat_user_id"
+    t.string "revenuecat_entitlement_id", default: "pro"
+    t.boolean "is_early_subscriber", default: false, null: false
+    t.datetime "last_synced_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["expires_at"], name: "index_subscriptions_on_expires_at"
+    t.index ["revenuecat_user_id"], name: "index_subscriptions_on_revenuecat_user_id", unique: true
+    t.index ["status"], name: "index_subscriptions_on_status"
+    t.index ["user_id"], name: "index_subscriptions_on_user_id", unique: true
+  end
+
   create_table "teams", force: :cascade do |t|
     t.string "name", null: false
     t.bigint "category_id"
@@ -385,6 +409,25 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_12_142637) do
     t.index ["user_id"], name: "index_user_positions_on_user_id"
   end
 
+  create_table "user_subscription_events", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "subscription_id"
+    t.string "event_type", null: false
+    t.string "platform"
+    t.string "product_id"
+    t.string "period_type"
+    t.datetime "occurred_at", null: false
+    t.jsonb "raw_payload"
+    t.string "revenuecat_event_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_type"], name: "index_user_subscription_events_on_event_type"
+    t.index ["revenuecat_event_id"], name: "index_user_subscription_events_on_revenuecat_event_id", unique: true
+    t.index ["subscription_id"], name: "index_user_subscription_events_on_subscription_id"
+    t.index ["user_id", "occurred_at"], name: "index_user_subscription_events_on_user_id_and_occurred_at"
+    t.index ["user_id"], name: "index_user_subscription_events_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "provider", default: "email", null: false
     t.string "uid", default: "", null: false
@@ -424,6 +467,20 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_12_142637) do
     t.index ["user_id"], name: "index_users_on_user_id", unique: true
   end
 
+  create_table "webhook_events", force: :cascade do |t|
+    t.string "provider", null: false
+    t.string "external_event_id", null: false
+    t.string "event_type"
+    t.datetime "received_at", null: false
+    t.datetime "processed_at"
+    t.string "status", default: "pending", null: false
+    t.jsonb "payload"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["provider", "external_event_id"], name: "index_webhook_events_on_provider_and_external_event_id", unique: true
+    t.index ["status"], name: "index_webhook_events_on_status"
+  end
+
   add_foreign_key "admin_refresh_tokens", "admin_users"
   add_foreign_key "baseball_notes", "users"
   add_foreign_key "batting_averages", "users"
@@ -450,6 +507,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_12_142637) do
   add_foreign_key "plate_appearances", "game_results", on_delete: :cascade
   add_foreign_key "plate_appearances", "users"
   add_foreign_key "seasons", "users"
+  add_foreign_key "subscriptions", "users"
   add_foreign_key "teams", "baseball_categories", column: "category_id"
   add_foreign_key "teams", "prefectures"
   add_foreign_key "user_awards", "awards"
@@ -458,4 +516,6 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_12_142637) do
   add_foreign_key "user_notifications", "users"
   add_foreign_key "user_positions", "positions"
   add_foreign_key "user_positions", "users"
+  add_foreign_key "user_subscription_events", "subscriptions"
+  add_foreign_key "user_subscription_events", "users"
 end

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -1,0 +1,58 @@
+FactoryBot.define do
+  factory :subscription do
+    user
+    status { 'free' }
+    revenuecat_entitlement_id { 'pro' }
+    has_used_trial { false }
+    is_early_subscriber { false }
+
+    trait :free do
+      status { 'free' }
+    end
+
+    trait :trial do
+      status { 'trial' }
+      started_at { 7.days.ago }
+      expires_at { 7.days.from_now }
+      has_used_trial { true }
+    end
+
+    trait :active do
+      status { 'active' }
+      plan_type { 'monthly' }
+      platform { 'ios' }
+      started_at { 30.days.ago }
+      expires_at { 30.days.from_now }
+      has_used_trial { true }
+    end
+
+    trait :cancelled do
+      status { 'cancelled' }
+      plan_type { 'monthly' }
+      platform { 'ios' }
+      started_at { 60.days.ago }
+      expires_at { 5.days.from_now }
+      cancelled_at { 2.days.ago }
+      has_used_trial { true }
+    end
+
+    trait :billing_issue do
+      status { 'billing_issue' }
+      plan_type { 'monthly' }
+      platform { 'ios' }
+      started_at { 60.days.ago }
+      expires_at { 3.days.from_now }
+      billing_issue_at { 1.day.ago }
+      has_used_trial { true }
+    end
+
+    trait :expired do
+      status { 'expired' }
+      plan_type { 'monthly' }
+      platform { 'ios' }
+      started_at { 90.days.ago }
+      expires_at { 5.days.ago }
+      has_used_trial { true }
+    end
+  end
+end

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -1,10 +1,31 @@
 FactoryBot.define do
+  # User の after_create :create_default_subscription が必ず free な subscription を
+  # 作るため、create(:subscription) で 2 つ目を INSERT すると unique index 違反になる。
+  # ここでは「ユーザーを作って、その既存 subscription を attributes で上書きする」戦略を取る。
+  # build / build_stubbed では `user` が未保存なので after_create が走らず、そのまま使える。
   factory :subscription do
-    user
+    transient do
+      owner { nil }
+    end
+
+    user { owner || association(:user) }
     status { 'free' }
-    revenuecat_entitlement_id { 'pro' }
     has_used_trial { false }
     is_early_subscriber { false }
+
+    to_create do |instance|
+      # User の after_create で free subscription が既に作られているケースを考慮する。
+      # association キャッシュが追従しないため、DB を直接見て existing を取得する。
+      existing = Subscription.find_by(user_id: instance.user_id)
+      if existing
+        attrs = instance.attributes.except('id', 'created_at', 'updated_at')
+        existing.update!(attrs)
+        instance.id = existing.id
+        instance.reload
+      else
+        instance.save!
+      end
+    end
 
     trait :free do
       status { 'free' }
@@ -15,6 +36,7 @@ FactoryBot.define do
       started_at { 7.days.ago }
       expires_at { 7.days.from_now }
       has_used_trial { true }
+      revenuecat_entitlement_id { 'pro' }
     end
 
     trait :active do
@@ -24,6 +46,7 @@ FactoryBot.define do
       started_at { 30.days.ago }
       expires_at { 30.days.from_now }
       has_used_trial { true }
+      revenuecat_entitlement_id { 'pro' }
     end
 
     trait :cancelled do
@@ -34,6 +57,7 @@ FactoryBot.define do
       expires_at { 5.days.from_now }
       cancelled_at { 2.days.ago }
       has_used_trial { true }
+      revenuecat_entitlement_id { 'pro' }
     end
 
     trait :billing_issue do
@@ -44,6 +68,7 @@ FactoryBot.define do
       expires_at { 3.days.from_now }
       billing_issue_at { 1.day.ago }
       has_used_trial { true }
+      revenuecat_entitlement_id { 'pro' }
     end
 
     trait :expired do
@@ -53,6 +78,11 @@ FactoryBot.define do
       started_at { 90.days.ago }
       expires_at { 5.days.ago }
       has_used_trial { true }
+      revenuecat_entitlement_id { 'pro' }
+    end
+
+    trait :pending do
+      status { 'pending' }
     end
   end
 end

--- a/spec/models/concerns/entitlement_spec.rb
+++ b/spec/models/concerns/entitlement_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe Entitlement, type: :model do
+  let(:user) { create(:user) }
+
+  describe '#has_entitlement?' do
+    context 'with a free feature' do
+      it 'returns true for a free user' do
+        expect(user.has_entitlement?('basic_game_record')).to be true
+      end
+
+      it 'returns true for a Pro user' do
+        user.subscription.update!(status: 'active', expires_at: 30.days.from_now)
+        expect(user.has_entitlement?('basic_game_record')).to be true
+      end
+    end
+
+    context 'with a Pro feature' do
+      it 'returns false for a free user' do
+        expect(user.has_entitlement?('season_transition_graph')).to be false
+      end
+
+      it 'returns true for a user with active Pro subscription' do
+        user.subscription.update!(status: 'active', expires_at: 30.days.from_now)
+        expect(user.has_entitlement?('season_transition_graph')).to be true
+      end
+
+      it 'returns true for a user in trial' do
+        user.subscription.update!(status: 'trial', expires_at: 7.days.from_now)
+        expect(user.has_entitlement?('season_transition_graph')).to be true
+      end
+
+      it 'returns true for a user in grace period (cancelled within expiration)' do
+        user.subscription.update!(status: 'cancelled', expires_at: 3.days.from_now)
+        expect(user.has_entitlement?('season_transition_graph')).to be true
+      end
+
+      it 'returns false for a user whose subscription has expired' do
+        user.subscription.update!(status: 'expired', expires_at: 1.day.ago)
+        expect(user.has_entitlement?('season_transition_graph')).to be false
+      end
+    end
+
+    context 'with an unknown feature key' do
+      it 'raises ArgumentError' do
+        expect { user.has_entitlement?('unknown_feature') }.to raise_error(ArgumentError, /Unknown feature/)
+      end
+    end
+  end
+
+  describe '#can_create_practice_menu?' do
+    it 'returns true for a Pro user (unlimited)' do
+      user.subscription.update!(status: 'active', expires_at: 30.days.from_now)
+      expect(user.can_create_practice_menu?).to be true
+    end
+
+    it 'returns true for a free user when below limit' do
+      expect(user.can_create_practice_menu?).to be true
+    end
+  end
+
+  describe '#can_create_season_goal?' do
+    it 'returns false for a free user' do
+      expect(user.can_create_season_goal?).to be false
+    end
+
+    it 'returns true for a Pro user' do
+      user.subscription.update!(status: 'active', expires_at: 30.days.from_now)
+      expect(user.can_create_season_goal?).to be true
+    end
+  end
+end

--- a/spec/models/concerns/entitlement_spec.rb
+++ b/spec/models/concerns/entitlement_spec.rb
@@ -3,6 +3,21 @@ require 'rails_helper'
 RSpec.describe Entitlement, type: :model do
   let(:user) { create(:user) }
 
+  describe 'feature key constants' do
+    it 'defines exactly 10 free features and 12 pro features' do
+      # %w[] とインラインコメントの混在で feature key が壊れる回帰を防ぐ
+      expect(described_class::FREE_FEATURES.size).to eq 10
+      expect(described_class::PRO_FEATURES.size).to eq 12
+      expect(described_class::ALL_FEATURES.size).to eq 22
+    end
+
+    it 'contains only valid feature key strings (no stray symbols)' do
+      described_class::ALL_FEATURES.each do |key|
+        expect(key).to match(/\A[a-z][a-z0-9_]+\z/), "Invalid feature key: #{key.inspect}"
+      end
+    end
+  end
+
   describe '#has_entitlement?' do
     context 'with a free feature' do
       it 'returns true for a free user' do

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+RSpec.describe Subscription, type: :model do
+  describe '#pro_active?' do
+    it 'returns false for free status' do
+      subscription = build(:subscription, :free)
+      expect(subscription.pro_active?).to be false
+    end
+
+    it 'returns true for active status within expiration' do
+      subscription = build(:subscription, :active)
+      expect(subscription.pro_active?).to be true
+    end
+
+    it 'returns true for trial status within expiration' do
+      subscription = build(:subscription, :trial)
+      expect(subscription.pro_active?).to be true
+    end
+
+    it 'returns true for cancelled status within expiration' do
+      subscription = build(:subscription, :cancelled)
+      expect(subscription.pro_active?).to be true
+    end
+
+    it 'returns true for billing_issue status within expiration' do
+      subscription = build(:subscription, :billing_issue)
+      expect(subscription.pro_active?).to be true
+    end
+
+    it 'returns false for expired status' do
+      subscription = build(:subscription, :expired)
+      expect(subscription.pro_active?).to be false
+    end
+
+    it 'returns false when expires_at is in the past even with active status' do
+      subscription = build(:subscription, :active, expires_at: 1.minute.ago)
+      expect(subscription.pro_active?).to be false
+    end
+
+    it 'returns true when expires_at is nil and status is active' do
+      subscription = build(:subscription, :active, expires_at: nil)
+      expect(subscription.pro_active?).to be true
+    end
+  end
+
+  describe '#in_trial?' do
+    it 'returns true for trial status within expiration' do
+      subscription = build(:subscription, :trial)
+      expect(subscription.in_trial?).to be true
+    end
+
+    it 'returns false for non-trial status even within Pro period' do
+      subscription = build(:subscription, :active)
+      expect(subscription.in_trial?).to be false
+    end
+
+    it 'returns false for trial whose expires_at has passed' do
+      subscription = build(:subscription, :trial, expires_at: 1.minute.ago)
+      expect(subscription.in_trial?).to be false
+    end
+  end
+
+  describe '#in_grace_period?' do
+    it 'returns true for cancelled' do
+      expect(build(:subscription, :cancelled).in_grace_period?).to be true
+    end
+
+    it 'returns true for billing_issue' do
+      expect(build(:subscription, :billing_issue).in_grace_period?).to be true
+    end
+
+    it 'returns false for active' do
+      expect(build(:subscription, :active).in_grace_period?).to be false
+    end
+
+    it 'returns false for free' do
+      expect(build(:subscription, :free).in_grace_period?).to be false
+    end
+  end
+
+  describe '#days_remaining' do
+    it 'returns the integer days until expires_at' do
+      subscription = build(:subscription, :active, expires_at: 10.days.from_now)
+      expect(subscription.days_remaining).to eq 10
+    end
+
+    it 'returns 0 when expires_at is in the past' do
+      subscription = build(:subscription, :active, expires_at: 1.day.ago)
+      expect(subscription.days_remaining).to eq 0
+    end
+
+    it 'returns nil when expires_at is nil' do
+      subscription = build(:subscription, :free, expires_at: nil)
+      expect(subscription.days_remaining).to be_nil
+    end
+  end
+
+  describe '#can_use_trial?' do
+    it 'returns true when has_used_trial is false' do
+      subscription = build(:subscription, :free, has_used_trial: false)
+      expect(subscription.can_use_trial?).to be true
+    end
+
+    it 'returns false when has_used_trial is true' do
+      subscription = build(:subscription, :expired, has_used_trial: true)
+      expect(subscription.can_use_trial?).to be false
+    end
+  end
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -32,6 +32,11 @@ RSpec.describe Subscription, type: :model do
       expect(subscription.pro_active?).to be false
     end
 
+    it 'returns false for pending status (purchase in progress, not yet confirmed)' do
+      subscription = build(:subscription, :pending)
+      expect(subscription.pro_active?).to be false
+    end
+
     it 'returns false when expires_at is in the past even with active status' do
       subscription = build(:subscription, :active, expires_at: 1.minute.ago)
       expect(subscription.pro_active?).to be false
@@ -61,12 +66,24 @@ RSpec.describe Subscription, type: :model do
   end
 
   describe '#in_grace_period?' do
-    it 'returns true for cancelled' do
+    it 'returns true for cancelled within expiration' do
       expect(build(:subscription, :cancelled).in_grace_period?).to be true
     end
 
-    it 'returns true for billing_issue' do
+    it 'returns true for billing_issue within expiration' do
       expect(build(:subscription, :billing_issue).in_grace_period?).to be true
+    end
+
+    # クライアントが in_grace_period を Pro アクセス判定に使うため、
+    # 期限切れの cancelled / billing_issue で true を返してはならない
+    it 'returns false for cancelled whose expires_at has passed' do
+      subscription = build(:subscription, :cancelled, expires_at: 1.minute.ago)
+      expect(subscription.in_grace_period?).to be false
+    end
+
+    it 'returns false for billing_issue whose expires_at has passed' do
+      subscription = build(:subscription, :billing_issue, expires_at: 1.minute.ago)
+      expect(subscription.in_grace_period?).to be false
     end
 
     it 'returns false for active' do
@@ -104,6 +121,23 @@ RSpec.describe Subscription, type: :model do
     it 'returns false when has_used_trial is true' do
       subscription = build(:subscription, :expired, has_used_trial: true)
       expect(subscription.can_use_trial?).to be false
+    end
+  end
+
+  # User の after_create で必ず free な subscription が生成されるため、
+  # 同じユーザーに 2 つ目の subscription を作るとユニーク制約に当たる。
+  # ファクトリ側で「既存 subscription を attributes で上書きする」戦略が
+  # 正しく動いていることを保証する。
+  describe 'factory create behavior' do
+    it 'reuses the auto-created free subscription when create(:subscription, :active) is called' do
+      subscription = create(:subscription, :active)
+      expect(described_class.where(user_id: subscription.user_id).count).to eq 1
+      expect(subscription.status).to eq 'active'
+      expect(subscription.expires_at).to be > Time.current
+    end
+
+    it 'does not raise unique constraint violation on create' do
+      expect { create(:subscription, :trial) }.not_to raise_error
     end
   end
 end

--- a/spec/requests/api/v1/pro_spec.rb
+++ b/spec/requests/api/v1/pro_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'Api::V1::Pro', type: :request do
         expect(response).to have_http_status(:ok)
         json = response.parsed_body
         expect(json['subscription']['status']).to eq 'free'
+        expect(json['subscription']['pro_active']).to be false
         expect(json['subscription']['in_trial']).to be false
         expect(json['subscription']['in_grace_period']).to be false
         expect(json['entitlements']).to include('basic_game_record')
@@ -36,6 +37,7 @@ RSpec.describe 'Api::V1::Pro', type: :request do
         expect(response).to have_http_status(:ok)
         json = response.parsed_body
         expect(json['subscription']['status']).to eq 'active'
+        expect(json['subscription']['pro_active']).to be true
         expect(json['subscription']['days_remaining']).to be > 0
         expect(json['entitlements']).to include('season_transition_graph', 'no_ads', 'basic_game_record')
       end

--- a/spec/requests/api/v1/pro_spec.rb
+++ b/spec/requests/api/v1/pro_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Pro', type: :request do
+  let(:user) { create(:user) }
+
+  describe 'GET /api/v1/pro/status' do
+    context 'when unauthenticated' do
+      it 'returns unauthorized' do
+        get '/api/v1/pro/status'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated as a free user' do
+      it 'returns subscription with status free and free-only entitlements' do
+        get '/api/v1/pro/status', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json['subscription']['status']).to eq 'free'
+        expect(json['subscription']['in_trial']).to be false
+        expect(json['subscription']['in_grace_period']).to be false
+        expect(json['entitlements']).to include('basic_game_record')
+        expect(json['entitlements']).not_to include('season_transition_graph')
+      end
+    end
+
+    context 'when authenticated as a Pro user' do
+      before do
+        user.subscription.update!(status: 'active', expires_at: 30.days.from_now, plan_type: 'monthly', platform: 'ios')
+      end
+
+      it 'returns active subscription and includes Pro entitlements' do
+        get '/api/v1/pro/status', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json['subscription']['status']).to eq 'active'
+        expect(json['subscription']['days_remaining']).to be > 0
+        expect(json['entitlements']).to include('season_transition_graph', 'no_ads', 'basic_game_record')
+      end
+    end
+  end
+
+  describe 'POST /api/v1/pro/sync' do
+    context 'when unauthenticated' do
+      it 'returns unauthorized' do
+        post '/api/v1/pro/sync'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated' do
+      it 'updates last_synced_at and returns current state' do
+        expect do
+          post '/api/v1/pro/sync', headers: auth_headers_for(user)
+        end.to change { user.subscription.reload.last_synced_at }.from(nil)
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json['subscription']['status']).to eq 'free'
+        expect(json['entitlements']).to be_an(Array)
+      end
+    end
+  end
+
+  describe 'GET /api/v1/pro/entitlements' do
+    context 'when unauthenticated' do
+      it 'returns unauthorized' do
+        get '/api/v1/pro/entitlements'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated as a free user' do
+      it 'returns granted=true for free features and granted=false for Pro features' do
+        get '/api/v1/pro/entitlements', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        entitlements = response.parsed_body['entitlements']
+        expect(entitlements.size).to eq Entitlement::ALL_FEATURES.size
+
+        free_entry = entitlements.find { |e| e['key'] == 'basic_game_record' }
+        pro_entry = entitlements.find { |e| e['key'] == 'season_transition_graph' }
+        expect(free_entry['granted']).to be true
+        expect(pro_entry['granted']).to be false
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/webhooks/revenuecat_spec.rb
+++ b/spec/requests/api/v1/webhooks/revenuecat_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Webhooks::Revenuecat', type: :request do
+  describe 'POST /api/v1/webhooks/revenuecat' do
+    it 'returns 200 without authentication (signature handling is deferred to #318)' do
+      post '/api/v1/webhooks/revenuecat', params: { event: { type: 'INITIAL_PURCHASE' } }, as: :json
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/api/v1/webhooks/revenuecat_spec.rb
+++ b/spec/requests/api/v1/webhooks/revenuecat_spec.rb
@@ -1,9 +1,33 @@
 require 'rails_helper'
 
 RSpec.describe 'Api::V1::Webhooks::Revenuecat', type: :request do
+  # 本 Issue ではスタブ実装で 200 を返すだけ。
+  # 署名検証 (X-RevenueCat-Signature の HMAC 照合) と payload 解釈・状態遷移は #318 で実装する。
+  # スタブ段階でも RevenueCat 側のリトライを抑止するため、どんな入力でも 200 を返すことを保証する。
   describe 'POST /api/v1/webhooks/revenuecat' do
-    it 'returns 200 without authentication (signature handling is deferred to #318)' do
-      post '/api/v1/webhooks/revenuecat', params: { event: { type: 'INITIAL_PURCHASE' } }, as: :json
+    it 'returns 200 for a normal RevenueCat-shaped JSON payload' do
+      post '/api/v1/webhooks/revenuecat',
+           params: { event: { type: 'INITIAL_PURCHASE', app_user_id: 'user_1' } },
+           as: :json
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns 200 for an empty JSON body' do
+      post '/api/v1/webhooks/revenuecat', params: {}, as: :json
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns 200 even without Content-Type header' do
+      post '/api/v1/webhooks/revenuecat'
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns 200 for a raw text body that is not valid JSON' do
+      # RevenueCat の Retry / Probe 等で payload が想定外でも 4xx を返してはならない。
+      # #318 実装時はここを「署名 NG なら 401、payload 不正なら 422」に切り替える設計を検討する。
+      post '/api/v1/webhooks/revenuecat',
+           params: 'not-a-json',
+           headers: { 'CONTENT_TYPE' => 'text/plain' }
       expect(response).to have_http_status(:ok)
     end
   end


### PR DESCRIPTION
## 概要

BUZZ BASE Pro リリースに必要な「Pro 加入状態」「機能アクセス権 (Entitlement)」管理の **バックエンド骨格** を追加する。
ref: ippei-shimizu/buzzbase#317

## 変更内容

### マイグレーション (4 本)

- \`subscriptions\`: Pro 加入状態の主テーブル (1 user 1 subscription)
- \`user_subscription_events\`: 監査ログ用テーブル (Webhook 受信時のイベント記録は #318)
- \`webhook_events\`: 冪等性キャッシュ
- 既存 users への \`'free'\` subscription を SQL バックフィル

### モデル

- \`Subscription\`: status enum 7 値 + \`pro_active?\` / \`in_trial?\` / \`in_grace_period?\` / \`days_remaining\` / \`can_use_trial?\`
- \`Entitlement\` concern: \`FREE_FEATURES\` 10 種 + \`PRO_FEATURES\` 12 種 + \`has_entitlement?\`
- \`PlanLimits\` concern: \`can_create_practice_menu?\` 等の Business Rules
- \`User\`: 上記 concern を include + \`after_create\` で free subscription を自動生成
- \`UserSubscriptionEvent\` / \`WebhookEvent\` モデル骨格

### API

| Method | Path | 概要 |
|--------|------|------|
| GET    | /api/v1/pro/status        | 現ユーザの subscription + 保有 entitlement |
| POST   | /api/v1/pro/sync          | last_synced_at 更新 (RevenueCat 連携の本実装は #318) |
| GET    | /api/v1/pro/entitlements  | 全 entitlement キーごとの granted フラグ |
| POST   | /api/v1/webhooks/revenuecat | 受信骨格のみ (署名検証・状態遷移は #318) |

各エンドポイントは CRUD 原則に従いコントローラを細分化:
- \`Pro::StatusController#show\`
- \`Pro::SyncController#create\`
- \`Pro::EntitlementsController#index\`
- \`Webhooks::RevenuecatController#create\`

### Spec (40 例追加・既存 617 例も全パス)

- \`spec/models/subscription_spec.rb\` (期限境界含む)
- \`spec/models/concerns/entitlement_spec.rb\`
- \`spec/requests/api/v1/pro_spec.rb\`
- \`spec/requests/api/v1/webhooks/revenuecat_spec.rb\`

## 本 Issue で対象外 (別 Issue へ委譲)

- 強制 Pro モード (development 環境の admin 自動 Pro 化): ユーザー判断で未実装
- RevenueCat Webhook の署名検証・状態遷移ロジック: #318 で実装
- Solid Queue / Flipper の導入: 別 Issue
- Business Rules の呼び出し側 controller 連携: 各 Pro 機能 Issue (#319〜#325)

## 受け入れ基準

- [x] Pro 状態の取得 API が動作する
- [x] Entitlement チェック API が動作する
- [x] トライアル / cancelled / billing_issue の期限内ユーザは Pro 機能利用可
- [x] expired は Pro 機能利用不可

## Test plan

- [x] \`docker compose exec back bundle exec rspec\` (617 例 0 failures)
- [x] \`docker compose exec back bundle exec rubocop\` (no offenses)
- [x] \`docker compose exec back bundle exec rails db:migrate\`
- [ ] \`curl /api/v1/pro/status\` で free / Pro ユーザの差分を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)