### PR TITLE
Fix: tokens カラムのダブルエンコードによるログイン全滅を解消 (Issue #340)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,6 +38,12 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :validatable, :confirmable
   include DeviseTokenAuth::Concerns::User
 
+  # devise_token_auth 1.2.6 + Rails 7.1 では `serialize :tokens, coder: TokensSerialization`
+  # が当たるが、`users.tokens` は json 型カラムのためダブルエンコードになり認証が壊れる
+  # (Issue #340)。明示的に json 型を当てて coder を打ち消す。default は devise_token_auth が
+  # `tokens.fetch(...)` を呼ぶ前提のため空ハッシュにしておく。
+  attribute :tokens, ActiveRecord::Type::Json.new, default: -> { {} }
+
   before_validation :normalize_user_id
   after_commit :notify_slack_new_user, on: :create
 

--- a/lib/tasks/repair_double_encoded_tokens.rake
+++ b/lib/tasks/repair_double_encoded_tokens.rake
@@ -1,0 +1,42 @@
+namespace :data do
+  # devise_token_auth 1.2.6 + Rails 7.1 アップグレード (PR #221) 後、json 型カラムである
+  # `users.tokens` に対して devise_token_auth 側が `serialize :tokens, coder: TokensSerialization`
+  # を当てたためダブルエンコードが発生し、`"...JSON文字列..."` のように JSON 文字列を
+  # さらに文字列としてラップした値が DB に書き込まれた (Issue #340)。
+  # 本タスクは `user.tokens` が String を返すレコード（健全な状態なら Hash が返る）を
+  # JSON.parse して Hash に戻し、json カラムに直接書き戻す一度きりの修復タスク。
+  # User モデル側で `attribute :tokens, ActiveRecord::Type::Json.new` を当てた状態で
+  # 実行すること（先に実行すると再度ダブルエンコードされる）。
+  #
+  # 実行例:
+  #   docker compose exec back bundle exec rails data:repair_double_encoded_tokens DRY_RUN=1
+  #   heroku run bundle exec rails data:repair_double_encoded_tokens
+  desc 'devise_token_auth アップグレードで発生した tokens カラムのダブルエンコードを修復する'
+  task repair_double_encoded_tokens: :environment do
+    dry_run = ENV['DRY_RUN'].present?
+    scanned = 0
+    repaired = 0
+
+    User.find_each(batch_size: 200) do |user|
+      scanned += 1
+      current = user.tokens
+      next unless current.is_a?(String)
+
+      parsed = begin
+        JSON.parse(current)
+      rescue JSON::ParserError => e
+        Rails.logger.warn("[repair_double_encoded_tokens] user_id=#{user.id} skip: #{e.message}")
+        next
+      end
+      next unless parsed.is_a?(Hash)
+
+      repaired += 1
+      next if dry_run
+
+      # コールバック・updated_at に触れずに tokens のみを書き戻す
+      user.update_columns(tokens: parsed) # rubocop:disable Rails/SkipsModelValidations
+    end
+
+    puts "対象 #{scanned} 件中 #{repaired} 件を#{dry_run ? '修復可能と判定' : '修復しました'}。"
+  end
+end

--- a/spec/lib/tasks/repair_double_encoded_tokens_spec.rb
+++ b/spec/lib/tasks/repair_double_encoded_tokens_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'data:repair_double_encoded_tokens' do # rubocop:disable RSpec/DescribeClass
+  before(:all) do # rubocop:disable RSpec/BeforeAfterAll
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  let(:task) { Rake::Task['data:repair_double_encoded_tokens'] }
+
+  before { task.reenable }
+
+  context 'when a user has a double-encoded tokens value' do
+    let!(:user) do
+      u = create(:user)
+      raw_json = '{"client_a":{"token":"hash","expiry":1234567890}}'
+      # 実障害と同形 (json カラムに JSON 文字列を文字列としてラップした状態) を生 SQL で再現
+      ActiveRecord::Base.connection.execute(
+        ActiveRecord::Base.sanitize_sql_array(
+          ['UPDATE users SET tokens = ?::json WHERE id = ?', raw_json.to_json, u.id]
+        )
+      )
+      u
+    end
+
+    it 'rewrites tokens as a plain Hash' do
+      task.invoke
+      user.reload
+      expect(user.tokens).to eq('client_a' => { 'token' => 'hash', 'expiry' => 1_234_567_890 })
+    end
+
+    context 'when DRY_RUN=1' do
+      around do |example|
+        ENV['DRY_RUN'] = '1'
+        example.run
+      ensure
+        ENV.delete('DRY_RUN')
+      end
+
+      it 'does not modify the underlying row' do
+        task.invoke
+        expect(user.reload.tokens).to be_a(String)
+      end
+    end
+  end
+
+  context 'when a user already has a healthy tokens hash' do
+    let!(:user) do
+      create(:user).tap do |u|
+        u.update_columns(tokens: { 'client_a' => { 'token' => 'hash', 'expiry' => 1_234_567_890 } }) # rubocop:disable Rails/SkipsModelValidations
+      end
+    end
+
+    it 'leaves the row untouched' do
+      expect { task.invoke }.not_to(change { user.reload.tokens })
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -368,4 +368,20 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  # Issue #340 (BUZZBASE-BACKEND-T) リグレッション
+  # devise_token_auth 1.2.6 + Rails 7.1 で `users.tokens` (json型) が `serialize :tokens, coder:`
+  # により二重シリアライズされ、`create_new_auth_token` 連続呼び出しで 500 になっていた。
+  describe '#create_new_auth_token (BUZZBASE-BACKEND-T regression)' do
+    let(:user) { create(:user) }
+
+    it 'persists tokens as a Hash without double-encoding on repeated calls' do
+      user.create_new_auth_token
+      user.create_new_auth_token
+
+      user.reload
+      expect(user.tokens).to be_a(Hash)
+      expect(user.tokens.values).to all(be_a(Hash))
+    end
+  end
 end


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#340

## 概要

PR #221 (Rails 7.1 + devise_token_auth 1.2.2→1.2.6 アップグレード) のデプロイ後、Google ログインとメール+パスワードログインが両方 500 で失敗していた障害 (Sentry: BUZZBASE-BACKEND-T、`NoMethodError: undefined method '[]' for nil:NilClass`) を恒久的に解消する。

## 原因

- `users.tokens` は PostgreSQL の `json` 型 (`db/schema.rb` `t.json "tokens"`)
- devise_token_auth 1.2.6 が Rails 7.1+ 環境で `serialize :tokens, coder: DeviseTokenAuth::Concerns::TokensSerialization` を追加
- `json` カラム + `serialize` coder の二重がけでダブルエンコード状態になり、`tokens` getter が毎回新しい Hash を返すため、`create_token` 内の `tokens[token.client] = {...}` 代入が次の `build_auth_headers` 内で見えず `tokens[client]` が nil → 例外

## 変更内容

- **パッチ A**: `app/models/user.rb` に `attribute :tokens, ActiveRecord::Type::Json.new, default: -> { {} }` を追加し、devise_token_auth が当てた coder を打ち消す。default は `tokens.fetch(...)` 前提のため空ハッシュ
- **パッチ B**: `lib/tasks/repair_double_encoded_tokens.rake` を新規追加。`user.tokens` が String を返すユーザー（= ダブルエンコード状態）を対象に JSON.parse して json カラムに書き戻す一度きりの修復タスク。`DRY_RUN=1` で件数のみ算出可能
- **リグレッションテスト**: User モデル spec / Rake task spec を追加。spec では生 SQL で json カラムに JSON 文字列を文字列としてラップした状態を再現してから修復を検証

## マイグレーション

- [ ] マイグレーションあり
- [x] マイグレーションなし

## 確認手順

### マージ前 (ローカル)

```bash
docker compose exec back bundle exec rubocop app/models/user.rb \
  lib/tasks/repair_double_encoded_tokens.rake spec/models/user_spec.rb \
  spec/lib/tasks/repair_double_encoded_tokens_spec.rb
docker compose exec back bundle exec rspec spec/models/user_spec.rb \
  spec/lib/tasks/repair_double_encoded_tokens_spec.rb \
  spec/requests/api/v1/auth/
```

### マージ後 (Heroku)

1. デプロイ完了を確認（パッチ A が反映されてから B を実行する点が重要）
2. 件数確認:
   \`\`\`bash
   heroku run -a <app-name> bundle exec rails data:repair_double_encoded_tokens DRY_RUN=1
   \`\`\`
3. 本実行:
   \`\`\`bash
   heroku run -a <app-name> bundle exec rails data:repair_double_encoded_tokens
   \`\`\`
4. Sentry Issue `BUZZBASE-BACKEND-T` の event 発生が止まったことを 30 分監視
5. 問い合わせユーザーに「再度お試しください」と返信

## チェックリスト

- [x] テストが通る (`bundle exec rspec`)
- [x] RuboCop offenses なし
- [x] 既存の認証フロースペック (sessions / apple / passwords / registrations / confirmations) 36件すべて pass