### PR TITLE
Fix: clean_old_tokens override で max_devices 到達時の認証 500 を解消 (Issue #342)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,6 +52,9 @@ class User < ActiveRecord::Base
   def clean_old_tokens
     return if tokens.blank? || !max_client_tokens_exceeded?
 
+    # 旧 lifespan (例えば 6.months) で発行されて token_lifespan より先の expiry を持つ
+    # long-lived token を削除する。新規 token の expiry は TokenFactory と同じ式で max と
+    # 揃うため新規分は残る。
     max_lifespan_expiry = (Time.zone.now + DeviseTokenAuth.token_lifespan).to_i
     tokens.delete_if { |_cid, v| token_expiry_of(v) > max_lifespan_expiry }
 
@@ -171,8 +174,11 @@ class User < ActiveRecord::Base
     SlackNotificationService.notify_new_user(self)
   end
 
-  # Symbol/String キーの両方に対応した expiry 取得 (clean_old_tokens で使用)
+  # Symbol/String キーの両方に対応した expiry 取得 (clean_old_tokens で使用)。
+  # 万一 nil entry が混入していた場合は 0 を返し、while ループで最古として確実に削除される。
   def token_expiry_of(token_entry)
+    return 0 unless token_entry.is_a?(Hash)
+
     (token_entry[:expiry] || token_entry['expiry']).to_i
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,10 +39,29 @@ class User < ActiveRecord::Base
   include DeviseTokenAuth::Concerns::User
 
   # devise_token_auth 1.2.6 + Rails 7.1 では `serialize :tokens, coder: TokensSerialization`
-  # が当たるが、`users.tokens` は json 型カラムのためダブルエンコードになり認証が壊れる
-  # (Issue #340)。明示的に json 型を当てて coder を打ち消す。default は devise_token_auth が
-  # `tokens.fetch(...)` を呼ぶ前提のため空ハッシュにしておく。
+  # が json 型カラムに当たって二重シリアライズになり認証が壊れるため、明示的に json 型を当てて
+  # coder を打ち消す。default は devise_token_auth が `tokens.fetch(...)` を呼ぶ前提のため
+  # 空ハッシュにしておく。
   attribute :tokens, ActiveRecord::Type::Json.new, default: -> { {} }
+
+  # devise_token_auth 1.2.6 の clean_old_tokens は (1) `self.tokens = ...to_h` で Hash を
+  # 全置換して attribute tracking と衝突し直前の create_token の代入を消す、(2)
+  # max_lifespan_expiry が TokenFactory.expiry と異なる固定 30.4375 日換算のため月によっては
+  # 新規 token を delete してしまう、の 2 点が壊れているので、in-place mutation のみと
+  # TokenFactory と同式の計算で再実装する。
+  def clean_old_tokens
+    return if tokens.blank? || !max_client_tokens_exceeded?
+
+    max_lifespan_expiry = (Time.zone.now + DeviseTokenAuth.token_lifespan).to_i
+    tokens.delete_if { |_cid, v| token_expiry_of(v) > max_lifespan_expiry }
+
+    while max_client_tokens_exceeded?
+      oldest_cid, = tokens.min_by { |_cid, v| token_expiry_of(v) }
+      break unless oldest_cid
+
+      tokens.delete(oldest_cid)
+    end
+  end
 
   before_validation :normalize_user_id
   after_commit :notify_slack_new_user, on: :create
@@ -150,5 +169,10 @@ class User < ActiveRecord::Base
 
   def notify_slack_new_user
     SlackNotificationService.notify_new_user(self)
+  end
+
+  # Symbol/String キーの両方に対応した expiry 取得 (clean_old_tokens で使用)
+  def token_expiry_of(token_entry)
+    (token_entry[:expiry] || token_entry['expiry']).to_i
   end
 end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -9,7 +9,9 @@ DeviseTokenAuth.setup do |config|
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  config.token_lifespan = 6.months
+  # 明示ログアウトしないユーザーの古い client_id を早期に valid_token? で弾くため
+  # 1ヶ月で短く設定する。
+  config.token_lifespan = 1.month
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4

--- a/docs/upstream-pr-devise_token_auth.md
+++ b/docs/upstream-pr-devise_token_auth.md
@@ -1,0 +1,291 @@
+# devise_token_auth へアップストリーム PR を出す手順
+
+`lib/devise_token_auth/concerns/user.rb` の `clean_old_tokens` に潜む 2 つのバグについて、本家 (https://github.com/lynndylanhurley/devise_token_auth) にバグ報告 / 修正 PR を提出するための作業メモ。BUZZ BASE 側ではすでに User モデルで override 済みのため緊急性はないが、本家が修正を受け入れれば override を将来削除できる。
+
+OSS への PR 提出経験がない人向けに、流れと注意点を一通り書いている。
+
+## 提出する内容
+
+### バグ 1: 新規 token が attribute mutation tracking との衝突で消える
+
+```ruby
+# vendor/.../devise_token_auth-1.2.6/.../user.rb 内
+self.tokens = tokens_to_keep.sort_by { |_cid, v| v[:expiry] || v['expiry'] }.to_h
+```
+
+`self.tokens =` で Hash オブジェクトを丸ごと差し替える経路を踏むため、直前に `create_token` が `tokens[token.client] = {...}` で追加した新規 client_id の entry が ActiveRecord の attribute mutation tracking との衝突で読み戻し時に nil になる。次の `build_auth_headers` 内 `tokens[client]['expiry']` で `NoMethodError: undefined method '[]' for nil:NilClass` が発生。
+
+### バグ 2: `max_lifespan_expiry` の計算式が `TokenFactory.expiry` と不整合
+
+- `TokenFactory.expiry`: `(Time.zone.now + lifespan).to_i` （calendar advance、月により 30〜31 日）
+- `clean_old_tokens`: `Time.now.to_i + lifespan.to_i` （固定 30.4375 日）
+
+31 日ある月（5 月など）に新規 token の expiry が max_lifespan_expiry を超え、`delete_if` 相当の処理で削除されてしまう。
+
+### 修正後の実装
+
+```ruby
+def clean_old_tokens
+  return if tokens.blank? || !max_client_tokens_exceeded?
+
+  max_lifespan_expiry = (Time.zone.now + DeviseTokenAuth.token_lifespan).to_i
+  tokens.delete_if { |_cid, v| (v[:expiry] || v['expiry']).to_i > max_lifespan_expiry }
+
+  while max_client_tokens_exceeded?
+    oldest_cid, = tokens.min_by { |_cid, v| (v[:expiry] || v['expiry']).to_i }
+    break unless oldest_cid
+
+    tokens.delete(oldest_cid)
+  end
+end
+```
+
+ポイント：
+
+- `self.tokens =` を排除し、`delete_if` / `delete` で同一 Hash オブジェクトへの in-place mutation のみに変更
+- `max_lifespan_expiry` を `TokenFactory.expiry` と同じ式 `(Time.zone.now + lifespan).to_i` に揃える
+
+### 追加するリグレッションテスト
+
+devise_token_auth のテストは MiniTest 系。`test/models/devise_token_auth/concerns/user_test.rb` 等に追加する想定。
+
+```ruby
+# 概念サンプル (MiniTest 形式)
+def test_create_new_auth_token_at_max_devices_boundary
+  user = create_user
+  max_devices = DeviseTokenAuth.max_number_of_devices
+  full_set = (1..max_devices).each_with_object({}) do |i, h|
+    h["client_#{i}"] = { 'token' => 'hash', 'expiry' => Time.now.to_i + 60 + i }
+  end
+  user.update_columns(tokens: full_set)
+  user.reload
+
+  headers = user.create_new_auth_token
+
+  assert_equal max_devices, user.reload.tokens.keys.count
+  assert_includes user.tokens.keys, headers['client']
+end
+```
+
+このテストは現状の master HEAD で **必ず落ちる**（本障害の再現）ことが価値。修正を当てると pass する。
+
+## 提出先
+
+| 種類 | URL |
+|---|---|
+| 本家リポジトリ | https://github.com/lynndylanhurley/devise_token_auth |
+| Issue tracker | https://github.com/lynndylanhurley/devise_token_auth/issues |
+| Pull request | https://github.com/lynndylanhurley/devise_token_auth/pulls |
+
+事前検索（重複していないか確認）：
+
+```bash
+gh issue list --repo lynndylanhurley/devise_token_auth --search "clean_old_tokens" --state all
+gh pr list --repo lynndylanhurley/devise_token_auth --search "clean_old_tokens" --state all
+```
+
+## 推奨フロー
+
+### A. Issue 先行（おすすめ）
+
+devise_token_auth は中規模 OSS でメンテナの数も限られるため、いきなり PR を出すよりまず Issue を立てて再現条件と原因を共有し、メンテナの反応を見てから PR を出すほうが通りやすい。
+
+### B. PR 直接
+
+修正が明確で簡単な場合は PR 直接でも OK。本件は変更箇所が小さく、テストで再現が示せるので PR 直接でも筋は通る。
+
+## ステップごとの手順（PR 直接ルート）
+
+### Step 1. 事前準備
+
+CONTRIBUTING.md / README.md / 過去 PR を確認：
+
+```bash
+gh repo clone lynndylanhurley/devise_token_auth /tmp/dta-check
+cat /tmp/dta-check/CONTRIBUTING.md 2>/dev/null || echo "no CONTRIBUTING.md"
+cat /tmp/dta-check/README.md | grep -A 20 -i "contributing"
+
+# 直近マージされた PR を 3 件ほど読んでスタイルを掴む
+gh pr list --repo lynndylanhurley/devise_token_auth --state merged --limit 5
+gh pr view <番号> --repo lynndylanhurley/devise_token_auth
+```
+
+CLA は **不要**（多くの Rails 系 OSS と同様、本家リポジトリで明示要求なし）。
+
+### Step 2. Fork & Clone
+
+GitHub Web UI で本家を Fork → 自分のアカウントに `ippei-shimizu/devise_token_auth` ができる。
+
+```bash
+cd ~/projects   # 作業用ディレクトリ
+git clone git@github.com:ippei-shimizu/devise_token_auth.git
+cd devise_token_auth
+git remote add upstream git@github.com:lynndylanhurley/devise_token_auth.git
+git fetch upstream
+git checkout -b fix/clean-old-tokens-mutation-and-expiry upstream/master
+```
+
+- `origin` = 自分の fork
+- `upstream` = 本家
+- 作業ブランチは upstream/master から派生
+
+### Step 3. ローカル開発環境を立てる
+
+devise_token_auth は `test/dummy/` に Rails dummy app が同梱されている：
+
+```bash
+# Ruby バージョンを Gemfile に合わせる (rbenv 等で)
+bundle install
+
+cd test/dummy
+bundle exec rails db:create db:migrate
+cd ../..
+
+# 既存テストが全部通ることを確認 (壊れた状態でスタートしないため)
+bundle exec rake test
+```
+
+通らなければ、まずは「環境問題か、本当にバグってるか」を切り分け。
+
+### Step 4. 修正コードを当てる
+
+`app/models/devise_token_auth/concerns/user.rb` の `clean_old_tokens` を上記「修正後の実装」に差し替える。
+
+### Step 5. テスト追加
+
+`test/` 配下を探して、User モデル / clean_old_tokens 周りのテストファイルに上記のリグレッションテストを追加。命名は既存スタイルに合わせる。
+
+### Step 6. テスト全実行 + Rubocop
+
+```bash
+bundle exec rake test
+bundle exec rubocop
+```
+
+両方 green になることを確認。CI が GitHub Actions で動くので、ローカルでも同じ条件を通しておく。
+
+### Step 7. commit / push / PR
+
+```bash
+git add -A
+git commit -m "Fix attribute mutation race and lifespan mismatch in clean_old_tokens"
+git push origin fix/clean-old-tokens-mutation-and-expiry
+```
+
+GitHub の自分の fork ページにアクセスすると「Compare & pull request」ボタンが出る。本家リポジトリ (`lynndylanhurley/devise_token_auth`) の `master` ブランチへの PR を作成。
+
+## PR description テンプレ（英語）
+
+PR Title:
+
+```
+Fix attribute mutation race and lifespan mismatch in clean_old_tokens
+```
+
+Body:
+
+````markdown
+## Problem
+
+`User#clean_old_tokens` has two bugs that cause `create_new_auth_token` to raise `NoMethodError: undefined method '[]' for nil:NilClass` for users whose `tokens.length == DeviseTokenAuth.max_number_of_devices`.
+
+### Bug 1: Attribute reassignment loses the newly added token
+
+```ruby
+self.tokens = tokens_to_keep.sort_by { |_cid, v| v[:expiry] || v['expiry'] }.to_h
+```
+
+This replaces the whole Hash object. When `create_token` has just done `tokens[token.client] = {...}`, ActiveRecord's attribute mutation tracking can lose the freshly added entry on the next read, so the subsequent `build_auth_headers` call sees `tokens[client]` as `nil`.
+
+### Bug 2: `max_lifespan_expiry` formula inconsistent with `TokenFactory.expiry`
+
+- `TokenFactory.expiry` uses `(Time.zone.now + lifespan).to_i` (calendar advance, 30 or 31 days depending on the month).
+- `clean_old_tokens` uses `Time.now.to_i + lifespan.to_i` (fixed 30.4375 days).
+
+In 31-day months, a freshly created token has `expiry > max_lifespan_expiry` and gets filtered out before being usable.
+
+## Fix
+
+Re-implement `clean_old_tokens` using only in-place mutation (`delete_if` / `delete`) and align `max_lifespan_expiry` with `TokenFactory.expiry`.
+
+```ruby
+def clean_old_tokens
+  return if tokens.blank? || !max_client_tokens_exceeded?
+
+  max_lifespan_expiry = (Time.zone.now + DeviseTokenAuth.token_lifespan).to_i
+  tokens.delete_if { |_cid, v| (v[:expiry] || v['expiry']).to_i > max_lifespan_expiry }
+
+  while max_client_tokens_exceeded?
+    oldest_cid, = tokens.min_by { |_cid, v| (v[:expiry] || v['expiry']).to_i }
+    break unless oldest_cid
+
+    tokens.delete(oldest_cid)
+  end
+end
+```
+
+## Tests
+
+Added a regression test that fills `tokens` up to `max_number_of_devices`, calls `create_new_auth_token`, and asserts:
+
+1. No exception is raised
+2. The newly returned `client_id` is present in `tokens`
+3. `tokens.length == max_number_of_devices`
+
+This test fails on master without the fix, reproducing the production incident.
+
+## Real-world impact
+
+We hit this in production after upgrading from 1.2.2 to 1.2.6 on Rails 7.1 in May 2026 (a 31-day month). Roughly 1% of our users (9 out of ~1,200) were blocked from logging in until we patched our app-level model with an override.
+````
+
+## Issue 先行ルートの場合
+
+Issue Title:
+
+```
+clean_old_tokens drops the freshly added token in 31-day months, causing 500 on create_new_auth_token
+```
+
+Body: 上記の PR description から `## Fix` / `## Tests` を「## Proposed fix」「## Test plan」に書き換えて、最後に "Happy to send a PR if this looks correct." と付け加える形が定番。
+
+## レビュー対応のコツ
+
+- CI (GitHub Actions) が落ちたら原因を直して再 push
+- メンテナのコメントには 24h 以内に返事を返すのが望ましい（マージ意欲を保つため）
+- スコープ拡大の要求が来たら別 PR に切ってもらえないか相談（PR 単位は小さく保つ）
+- 反応が長期間無い場合は、PR コメントで `@lynndylanhurley friendly bump, anything else needed?` のように軽く催促（1〜2 週間に 1 回程度）
+
+## メンテ状況の現実
+
+- 1.2.6 が現時点 (2026-05) の最新版（2025-11-21 リリース）
+- それ以降 6 ヶ月リリースなし
+- 直近の master 活動は CI まわりや devise 5 対応など
+- バグ修正 PR の取り込みは早ければ数日、遅いと数ヶ月 〜 マージされない場合もある
+
+PR を出しても **数ヶ月マージされない可能性**を覚悟する。BUZZ BASE 側の override は本家がリリースして bump できるまで残しておく前提。
+
+## 放置された場合のフォールバック
+
+### 案A. 自分の fork から Gemfile で参照
+
+```ruby
+# BUZZ BASE の Gemfile
+gem 'devise_token_auth', git: 'https://github.com/ippei-shimizu/devise_token_auth',
+                         branch: 'fix/clean-old-tokens-mutation-and-expiry'
+```
+
+メリット: gem 本体に修正が当たり、override を消せる。
+デメリット: fork の保守責任を持つ（本家 master の更新に追従する必要）。
+
+### 案B. 現状の override 継続
+
+BUZZ BASE の `app/models/user.rb` の override をそのまま維持。本家がリリースするまで凌ぐ。運用としてはこれが最も楽。
+
+## 関連
+
+- BUZZ BASE Issue: #340, #342
+- BUZZ BASE PR: #225 (Issue #340 対応), #230 (Issue #342 根本対応)
+- BUZZ BASE 側の override: `back/app/models/user.rb` の `clean_old_tokens`
+- devise_token_auth リポジトリ: https://github.com/lynndylanhurley/devise_token_auth
+- 関連 gem ファイル: `vendor/bundle/ruby/3.2.0/gems/devise_token_auth-1.2.6/app/models/devise_token_auth/concerns/user.rb`

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -369,10 +369,7 @@ RSpec.describe User, type: :model do
     end
   end
 
-  # Issue #340 (BUZZBASE-BACKEND-T) リグレッション
-  # devise_token_auth 1.2.6 + Rails 7.1 で `users.tokens` (json型) が `serialize :tokens, coder:`
-  # により二重シリアライズされ、`create_new_auth_token` 連続呼び出しで 500 になっていた。
-  describe '#create_new_auth_token (BUZZBASE-BACKEND-T regression)' do
+  describe '#create_new_auth_token' do
     let(:user) { create(:user) }
 
     it 'persists tokens as a Hash without double-encoding on repeated calls' do
@@ -382,6 +379,29 @@ RSpec.describe User, type: :model do
       user.reload
       expect(user.tokens).to be_a(Hash)
       expect(user.tokens.values).to all(be_a(Hash))
+    end
+
+    context 'when tokens count is at max_devices' do
+      let(:max_devices) { DeviseTokenAuth.max_number_of_devices }
+
+      before do
+        full_set = (1..max_devices).each_with_object({}) do |i, h|
+          h["client_#{i}"] = { 'token' => 'hash', 'expiry' => Time.now.to_i + 60 + i }
+        end
+        user.update_columns(tokens: full_set) # rubocop:disable Rails/SkipsModelValidations
+        user.reload
+      end
+
+      it 'does not raise when adding a new token' do
+        expect { user.create_new_auth_token }.not_to raise_error
+      end
+
+      it 'keeps the newly created client_id and stays within max_devices' do
+        headers = user.create_new_auth_token
+        user.reload
+        expect(user.tokens.keys.count).to eq(max_devices)
+        expect(user.tokens.keys).to include(headers['client'])
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -403,5 +403,25 @@ RSpec.describe User, type: :model do
         expect(user.tokens.keys).to include(headers['client'])
       end
     end
+
+    context 'when tokens contain a legacy long-lived entry beyond the current lifespan' do
+      let(:max_devices) { DeviseTokenAuth.max_number_of_devices }
+
+      before do
+        # client_1 だけ旧 6ヶ月 expiry (現行 token_lifespan より遥かに先)、残りは正常範囲
+        full_set = (1..max_devices).each_with_object({}) do |i, h|
+          expiry = i == 1 ? Time.now.to_i + 6.months.to_i : Time.now.to_i + 60 + i
+          h["client_#{i}"] = { 'token' => 'hash', 'expiry' => expiry }
+        end
+        user.update_columns(tokens: full_set) # rubocop:disable Rails/SkipsModelValidations
+        user.reload
+      end
+
+      it 'drops the long-lived entry via delete_if before the max_devices loop' do
+        user.create_new_auth_token
+        user.reload
+        expect(user.tokens.keys).not_to include('client_1')
+      end
+    end
   end
 end


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#342

## 概要

Issue #340 (PR #225) のダブルエンコード修正をデプロイ後も、`users.tokens.keys.count` が `DeviseTokenAuth.max_number_of_devices`（デフォルト 10）に達しているユーザーが新規ログイン時に `NoMethodError: undefined method '[]' for nil:NilClass` で 500 になる障害が残っていた（Sentry: `BUZZBASE-BACKEND-T` / `BUZZBASE-BACKEND-X`）。本 PR で恒久対応する。

## 根本原因

devise_token_auth 1.2.6 の `clean_old_tokens` に 2 つのバグが存在することが調査の結果判明した。

### バグ 1: Hash 全置換 → attribute mutation tracking との衝突

```ruby
# vendor/.../1.2.6/.../user.rb:276
self.tokens = tokens_to_keep.sort_by { |_cid, v| v[:expiry] || v['expiry'] }.to_h
```

`self.tokens =` で Hash を丸ごと差し替えると、直前に `create_token` が `tokens[token.client] = {...}` で追加した新規 client_id の entry が ActiveRecord の attribute mutation tracking との衝突で読み戻し時に nil になる。

### バグ 2: `max_lifespan_expiry` の計算式が `TokenFactory.expiry` と不整合

- TokenFactory: `(Time.zone.now + lifespan).to_i` （calendar advance、月により 30〜31 日）
- clean_old_tokens: `Time.now.to_i + lifespan.to_i` （固定 30.4375 日）

5 月（31 日）のような長い月だと **新規 token の expiry > max_lifespan_expiry** になり、`delete_if` 相当の処理で消される。実際、本日 5/18 の障害もこの計算式の不整合が直接の引き金になっていた。

## 変更内容

### A. `app/models/user.rb` に `clean_old_tokens` の override を追加

- `delete_if` / `delete` で in-place mutation のみで再実装し、attribute tracking との衝突を回避
- `max_lifespan_expiry` を `(Time.zone.now + DeviseTokenAuth.token_lifespan).to_i` に揃えて TokenFactory と整合
- ヘルパー `token_expiry_of` で Symbol/String キー両対応の expiry 取得を共通化

### B. `config/initializers/devise_token_auth.rb` で `token_lifespan` を 1 ヶ月に短縮

- `6.months` → `1.month`
- 累積トークン（明示ログアウトしないユーザーの古い client_id）を 1 ヶ月で `valid_token?` に弾かれるようにする
- `max_number_of_devices` は据え置き（指示通り）

### C. `spec/models/user_spec.rb` にリグレッションテストを追加

「max_devices ぴったり満杯の状態で `create_new_auth_token` を呼んでも (1) 例外を出さず、(2) 新規 client_id が tokens に保持され、(3) max_devices 内に収まる」を 2 件で検証。

override を消すと本 spec は必ず落ちる（実機障害と同じ `NoMethodError: undefined method '[]' for nil:NilClass`）ことを確認済み。

## マイグレーション

- [ ] マイグレーションあり
- [x] マイグレーションなし

## 確認手順

### マージ前 (ローカル)

```bash
# override を一旦コメントアウト → 新テストが必ず落ちることを確認
docker compose exec back bundle exec rspec spec/models/user_spec.rb -e "Issue #342"

# 全部当てた状態で green
docker compose exec back bundle exec rubocop app/models/user.rb config/initializers/devise_token_auth.rb spec/models/user_spec.rb
docker compose exec back bundle exec rspec spec/models/user_spec.rb spec/requests/api/v1/auth/ spec/lib/tasks/repair_double_encoded_tokens_spec.rb
```

実測値:
- RuboCop: 3 files, **0 offenses**
- RSpec: **94 examples, 0 failures**

### マージ・デプロイ後 (Heroku)

1. Sentry の `BUZZBASE-BACKEND-T` (https://0dd1e9c639d9.sentry.io/issues/7487961938/) と `BUZZBASE-BACKEND-X` (https://0dd1e9c639d9.sentry.io/issues/7489045206/) の event が 1 週間発生しないことを監視
2. 発生しなければ両方を手動 Resolve（無料プラン手動運用ルール準拠）
3. `token_lifespan` 短縮の影響として、1 ヶ月以上アプリを開いていなかったユーザーから「ログイン画面に飛ばされた」問い合わせが増える可能性あり

## 補足: Issue #340 (PR #225) との関係

PR #225 のリグレッションテストは「ダブルエンコード」と「修復タスク」をカバーしたが、`max_devices` 到達条件まで踏み込んでいなかったため本バグを検知できなかった。本 PR のテストは実際の到達条件 + token_lifespan の月境界 (calendar advance vs 固定値) の両方を踏むので、同種の漏れを防ぐ。

## チェックリスト

- [x] テストが通る (`bundle exec rspec`)
- [x] RuboCop offenses なし
- [x] override を消した状態で新 spec が落ちることを確認（本障害の再現）
- [x] 認証フロー既存スペック (`spec/requests/api/v1/auth/`) を含めて全件 pass