### PR TITLE
Docs: コメント規約に WHY 優先・issue 番号禁止を追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,16 @@ docker compose exec back bundle exec rubocop  # チェック
 docker compose exec back bundle exec rubocop -A  # 自動修正
 ```
 
+## コメント規約
+
+- **コードを読めばわかること（WHAT）は書かない**。識別子・型・処理の流れはコード自身が語る。コメントが繰り返すと冗長になり、コード変更時に陳腐化する
+- **コードからは読み取れない意図・前提・制約（WHY）だけを書く**。例: 性能上の理由で `pluck` を使っている / 仕様で空配列を許容しない / フロントの期待形式に合わせて〜している、など
+- **issue 番号 / PR 番号 / ticket URL をコメントに書かない**。時間と共に陳腐化し、リーダーにとってノイズになる。経緯や参照リンクは PR description やコミットメッセージに残す
+  - NG: `# 二重作成を防ぐ（issue #341）`
+  - NG: `# ユーザーを取得する`（コードを見れば明らか）
+  - OK: `# devise_token_auth の挙動上、create 時に session を残すと次回ログインで衝突する`
+- yardoc (`@param` / `@return` / `@example`) は「責務」「引数・返り値の意味」を簡潔に書いてよい（保守性向上の資産として残す）
+
 ## ディレクトリ構造
 
 ```


### PR DESCRIPTION
## 実装概要
CLAUDE.md に「コメント規約」セクションを新設し、コードコメントの方針を明文化した。`mobile/CLAUDE.md` と同じ規約を back にも適用する。

## 規約内容
- コードを読めばわかること（WHAT）は書かない
- コードから読み取れない意図・前提・制約（WHY）だけを書く
- issue 番号 / PR 番号 / ticket URL をコメントに書かない（経緯は PR description やコミットメッセージへ）
- yardoc (`@param` / `@return` / `@example`) は「責務」「引数・返り値の意味」を簡潔に書いてよい

## やらないこと
- 既存コメントの一斉書き換えはしない（規約は新規 / 変更時に適用）

## 影響範囲
- ドキュメントのみ（実行コードへの影響なし）