### PR TITLE
Add: Webhook 冪等処理基盤 + Solid Queue + Flipper 導入 (#345)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,3 +94,13 @@ gem 'sentry-rails', '~> 5.13'
 gem 'kaminari'
 
 gem 'exponent-server-sdk'
+
+# Background job queue (Rails 7.1+)
+gem 'solid_queue'
+
+# Payment processing (Web subscription)
+gem 'stripe'
+
+# Feature flag management
+gem 'flipper'
+gem 'flipper-active_record'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,8 @@ GEM
     dotenv (2.8.1)
     drb (2.2.3)
     erubi (1.13.1)
+    et-orbi (1.4.0)
+      tzinfo
     ethon (0.18.0)
       ffi (>= 1.15.0)
       logger
@@ -150,6 +152,11 @@ GEM
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
     ffi (1.16.3)
+    flipper (1.4.2)
+      concurrent-ruby (< 2)
+    flipper-active_record (1.4.2)
+      activerecord (>= 4.2, < 9)
+      flipper (~> 1.4.2)
     fog-aws (3.21.0)
       fog-core (~> 2.1)
       fog-json (~> 1.1)
@@ -166,6 +173,9 @@ GEM
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (1.1.0)
+    fugit (1.12.1)
+      et-orbi (~> 1.4)
+      raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
     google-cloud-env (2.3.1)
@@ -276,6 +286,7 @@ GEM
     public_suffix (5.0.4)
     puma (5.6.7)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.8.1)
     rack (2.2.23)
     rack-cors (2.0.1)
@@ -397,8 +408,18 @@ GEM
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
       multi_json (~> 1.10)
+    solid_queue (1.4.0)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      concurrent-ruby (>= 1.3.1)
+      fugit (~> 1.11)
+      railties (>= 7.1)
+      thor (>= 1.3.1)
     ssrf_filter (1.1.2)
     stringio (3.1.0)
+    stripe (19.1.0)
+      bigdecimal
+      logger
     thor (1.5.0)
     timeout (0.6.1)
     tsort (0.2.0)
@@ -435,6 +456,8 @@ DEPENDENCIES
   exponent-server-sdk
   factory_bot_rails
   faker
+  flipper
+  flipper-active_record
   fog-aws
   googleauth
   jwt
@@ -456,6 +479,8 @@ DEPENDENCIES
   sentry-rails (~> 5.13)
   sentry-ruby (~> 5.13)
   shoulda-matchers
+  solid_queue
+  stripe
   tzinfo-data
 
 RUBY VERSION

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec puma -C config/puma.rb
+worker: bin/jobs
 release: bundle exec rails db:migrate

--- a/app/controllers/api/v1/webhooks/revenuecat_controller.rb
+++ b/app/controllers/api/v1/webhooks/revenuecat_controller.rb
@@ -2,9 +2,8 @@ module Api
   module V1
     module Webhooks
       # POST /api/v1/webhooks/revenuecat
-      # RevenueCat からの Webhook 受信エンドポイント。
-      # 10 秒以内の 200 OK 返却が求められるため、本処理は Solid Queue 経由で非同期化する。
-      # 冪等性は webhook_events テーブルの (provider, external_event_id) UNIQUE 制約に委ねる。
+      # 10 秒以内に 200 OK を返す必要があるため、受信時は WebhookEvent への記録だけ済ませてジョブに委譲する。
+      # 冪等性は webhook_events の (provider, external_event_id) UNIQUE 制約に委ねる。
       class RevenuecatController < ApplicationController
         skip_before_action :verify_authenticity_token, raise: false
         before_action :verify_signature!
@@ -27,8 +26,7 @@ module Api
             payload: params.to_unsafe_h
           )
 
-          # 既存レコードが返ったときは既にジョブが enqueue 済み（冪等性）。
-          # 新規作成時だけ pending な状態でジョブを enqueue する。
+          # 既存レコードが返ったときはジョブも enqueue 済みなので新規作成時のみ起動する。
           RevenueCatWebhookJob.perform_later(webhook_event.id) if webhook_event.previously_new_record?
 
           head :ok

--- a/app/controllers/api/v1/webhooks/revenuecat_controller.rb
+++ b/app/controllers/api/v1/webhooks/revenuecat_controller.rb
@@ -9,15 +9,14 @@ module Api
         before_action :verify_signature!
 
         def create
-          event_params = params[:event]
-          event_id = event_params.is_a?(ActionController::Parameters) || event_params.is_a?(Hash) ? event_params[:id] : nil
+          event_id = params.dig(:event, :id)
 
           if event_id.blank?
             Sentry.capture_message('RevenueCat webhook: event.id missing in payload', level: :warning)
             return head :unprocessable_entity
           end
 
-          event_type = event_params[:type]
+          event_type = params.dig(:event, :type)
 
           webhook_event = WebhookEvent.find_or_create_pending!(
             provider: 'revenuecat',
@@ -38,12 +37,11 @@ module Api
         private
 
         # Authorization: Bearer <REVENUECAT_WEBHOOK_SECRET> を期待する。
-        # 共有秘密のタイミング攻撃を避けるため、長さを揃えてから secure_compare する。
+        # 長さの違いをタイミング情報として漏らさないよう、両辺を SHA256 で固定長化してから比較する。
         def verify_signature!
-          expected = "Bearer #{ENV.fetch('REVENUECAT_WEBHOOK_SECRET', nil)}"
-          provided = request.headers['Authorization'].to_s
-          return if provided.bytesize == expected.bytesize &&
-                    ActiveSupport::SecurityUtils.secure_compare(provided, expected)
+          expected = Digest::SHA256.hexdigest("Bearer #{ENV.fetch('REVENUECAT_WEBHOOK_SECRET', nil)}")
+          provided = Digest::SHA256.hexdigest(request.headers['Authorization'].to_s)
+          return if ActiveSupport::SecurityUtils.fixed_length_secure_compare(provided, expected)
 
           head :unauthorized
         end

--- a/app/controllers/api/v1/webhooks/revenuecat_controller.rb
+++ b/app/controllers/api/v1/webhooks/revenuecat_controller.rb
@@ -2,15 +2,52 @@ module Api
   module V1
     module Webhooks
       # POST /api/v1/webhooks/revenuecat
-      # RevenueCat からの Webhook 受信スタブ。
-      # 本 Issue ではルートの受け皿のみ用意し、署名検証と payload 解釈・状態遷移は #318 で実装する。
-      # スタブ実装でも 401/403 ではなく 200 を返し、RevenueCat 側のリトライ抑止を担保する。
+      # RevenueCat からの Webhook 受信エンドポイント。
+      # 10 秒以内の 200 OK 返却が求められるため、本処理は Solid Queue 経由で非同期化する。
+      # 冪等性は webhook_events テーブルの (provider, external_event_id) UNIQUE 制約に委ねる。
       class RevenuecatController < ApplicationController
         skip_before_action :verify_authenticity_token, raise: false
+        before_action :verify_signature!
 
-        # TODO(#318): X-RevenueCat-Signature ヘッダの HMAC 検証 + payload 解釈 + 状態遷移処理を実装する。
         def create
+          event_params = params[:event]
+          event_id = event_params.is_a?(ActionController::Parameters) || event_params.is_a?(Hash) ? event_params[:id] : nil
+
+          if event_id.blank?
+            Sentry.capture_message('RevenueCat webhook: event.id missing in payload', level: :warning)
+            return head :unprocessable_entity
+          end
+
+          event_type = event_params[:type]
+
+          webhook_event = WebhookEvent.find_or_create_pending!(
+            provider: 'revenuecat',
+            external_event_id: event_id,
+            event_type:,
+            payload: params.to_unsafe_h
+          )
+
+          # 既存レコードが返ったときは既にジョブが enqueue 済み（冪等性）。
+          # 新規作成時だけ pending な状態でジョブを enqueue する。
+          RevenueCatWebhookJob.perform_later(webhook_event.id) if webhook_event.previously_new_record?
+
           head :ok
+        rescue StandardError => e
+          Sentry.capture_exception(e, tags: { source: 'revenuecat_webhook_controller' })
+          head :internal_server_error
+        end
+
+        private
+
+        # Authorization: Bearer <REVENUECAT_WEBHOOK_SECRET> を期待する。
+        # 共有秘密のタイミング攻撃を避けるため、長さを揃えてから secure_compare する。
+        def verify_signature!
+          expected = "Bearer #{ENV.fetch('REVENUECAT_WEBHOOK_SECRET', nil)}"
+          provided = request.headers['Authorization'].to_s
+          return if provided.bytesize == expected.bytesize &&
+                    ActiveSupport::SecurityUtils.secure_compare(provided, expected)
+
+          head :unauthorized
         end
       end
     end

--- a/app/jobs/revenue_cat_webhook_job.rb
+++ b/app/jobs/revenue_cat_webhook_job.rb
@@ -1,0 +1,21 @@
+# RevenueCat Webhook の本処理を非同期で実行するジョブ。
+# Webhook 受信は即時 200 を返す必要があるため、controller では Job 化のみ行い、
+# 実際の Subscription 更新はここで RevenueCatWebhookProcessor 経由で行う。
+class RevenueCatWebhookJob < ApplicationJob
+  queue_as :default
+
+  # ApplicationJob の rescue_from が Sentry 通知付きで例外を再 raise するため、
+  # Solid Queue 側でリトライキューに乗せられる。本ジョブ単独でも指数バックオフで最大 5 回リトライする。
+  retry_on StandardError, wait: :polynomially_longer, attempts: 5
+
+  # webhook_event が DB から消えていても落とさない。Sentry の異常通知だけ済ませて終了する。
+  def perform(webhook_event_id)
+    webhook_event = WebhookEvent.find_by(id: webhook_event_id)
+    unless webhook_event
+      Rails.logger.warn("RevenueCatWebhookJob: webhook_event not found (id=#{webhook_event_id})")
+      return
+    end
+
+    RevenueCatWebhookProcessor.new(webhook_event).process
+  end
+end

--- a/app/jobs/revenue_cat_webhook_job.rb
+++ b/app/jobs/revenue_cat_webhook_job.rb
@@ -1,14 +1,11 @@
-# RevenueCat Webhook の本処理を非同期で実行するジョブ。
-# Webhook 受信は即時 200 を返す必要があるため、controller では Job 化のみ行い、
-# 実際の Subscription 更新はここで RevenueCatWebhookProcessor 経由で行う。
+# Webhook 受信時の 10 秒制限を満たすため、本処理は本ジョブに非同期化する。
 class RevenueCatWebhookJob < ApplicationJob
   queue_as :default
 
-  # ApplicationJob の rescue_from が Sentry 通知付きで例外を再 raise するため、
-  # Solid Queue 側でリトライキューに乗せられる。本ジョブ単独でも指数バックオフで最大 5 回リトライする。
+  # 指数バックオフで最大 5 回リトライ。ApplicationJob の rescue_from で Sentry 通知される。
   retry_on StandardError, wait: :polynomially_longer, attempts: 5
 
-  # webhook_event が DB から消えていても落とさない。Sentry の異常通知だけ済ませて終了する。
+  # DB から webhook_event が消えていても落とさない（手動削除や DB 競合に備える）。
   def perform(webhook_event_id)
     webhook_event = WebhookEvent.find_by(id: webhook_event_id)
     unless webhook_event

--- a/app/models/webhook_event.rb
+++ b/app/models/webhook_event.rb
@@ -1,5 +1,3 @@
-# 外部サービスからの Webhook 受信ログ（冪等性キャッシュ）。
-# 書き込みロジックは #318 で実装する。
 class WebhookEvent < ApplicationRecord
   STATUSES = %w[pending processed failed skipped].freeze
 
@@ -7,4 +5,30 @@ class WebhookEvent < ApplicationRecord
   validates :external_event_id, presence: true,
                                 uniqueness: { scope: :provider }
   validates :status, inclusion: { in: STATUSES }
+
+  # provider × external_event_id をキーに pending な受信レコードを取得する。
+  # 既存レコードがあれば status を書き換えず返す（同一イベント二重受信時の冪等性確保）。
+  # @return [WebhookEvent]
+  def self.find_or_create_pending!(provider:, external_event_id:, event_type:, payload:)
+    find_or_create_by!(provider:, external_event_id:) do |we|
+      we.event_type = event_type
+      we.payload = payload
+      we.received_at = Time.current
+      we.status = 'pending'
+    end
+  end
+
+  STATUSES.each do |status_name|
+    define_method("#{status_name}?") { status == status_name }
+  end
+
+  # ジョブが処理完了した時点で呼ぶ。受信〜処理完了までの間に Sentry / 監査で参照される。
+  def mark_processed!
+    update!(status: 'processed', processed_at: Time.current, error_message: nil)
+  end
+
+  # ジョブが例外で落ちた時点で呼ぶ。error_message は Sentry 紐付け用の短い説明。
+  def mark_failed!(message)
+    update!(status: 'failed', error_message: message)
+  end
 end

--- a/app/services/revenue_cat_webhook_processor.rb
+++ b/app/services/revenue_cat_webhook_processor.rb
@@ -1,7 +1,5 @@
-# RevenueCat の Webhook payload を受け取って Subscription を更新するエントリポイント。
-# 個別 event_type の handler は #346 で順次実装する。本クラスは冪等性と
-# エラーハンドリング・Sentry 通知の責務だけを持ち、未対応イベントは Sentry に
-# 警告して processed として記録する（再送ループ防止）。
+# RevenueCat Webhook payload を Subscription 更新に変換するエントリポイント。
+# 未対応イベントも Sentry warning を残しつつ processed として記録し、RevenueCat 側の再送ループを防ぐ。
 class RevenueCatWebhookProcessor
   def initialize(webhook_event)
     @webhook_event = webhook_event
@@ -22,14 +20,14 @@ class RevenueCatWebhookProcessor
 
   private
 
-  # event_type ごとの分岐。#346 で各 handler を実装する想定で、現状は未対応扱い。
+  # 既知イベントは受信記録だけ残して processed 扱いにし、未知イベントは Sentry warning に流す。
+  # 個別 event_type の本処理は後続で積み増す。
   def handle_event
     case @event_data['type']
     when 'INITIAL_PURCHASE', 'TRIAL_STARTED',
          'RENEWAL', 'CANCELLATION', 'EXPIRATION',
          'BILLING_ISSUE', 'PRODUCT_CHANGE', 'REFUND',
          'UNCANCELLATION'
-      # #346 で個別 handler を実装する。現状はスタブとして無処理で processed 扱いにする。
       nil
     else
       Sentry.capture_message(

--- a/app/services/revenue_cat_webhook_processor.rb
+++ b/app/services/revenue_cat_webhook_processor.rb
@@ -7,6 +7,7 @@ class RevenueCatWebhookProcessor
     @event_data = @payload['event'] || {}
   end
 
+  # failed のレコードは手動で再 enqueue されたとき再処理する設計のため processed のみガードする。
   def process
     return if @webhook_event.processed?
 

--- a/app/services/revenue_cat_webhook_processor.rb
+++ b/app/services/revenue_cat_webhook_processor.rb
@@ -21,13 +21,21 @@ class RevenueCatWebhookProcessor
   private
 
   # 既知イベントは受信記録だけ残して processed 扱いにし、未知イベントは Sentry warning に流す。
-  # 個別 event_type の本処理は後続で積み増す。
   def handle_event
     case @event_data['type']
     when 'INITIAL_PURCHASE', 'TRIAL_STARTED',
          'RENEWAL', 'CANCELLATION', 'EXPIRATION',
          'BILLING_ISSUE', 'PRODUCT_CHANGE', 'REFUND',
          'UNCANCELLATION'
+      # TODO: 各 event_type ごとに Subscription を更新する handler を実装する
+      #   - INITIAL_PURCHASE / TRIAL_STARTED: subscription を trial / active に遷移、has_used_trial を true
+      #   - RENEWAL: expires_at を更新（古いイベントなら無視して順序非依存性を担保）
+      #   - CANCELLATION: cancelled_at をセット、expires_at は維持
+      #   - EXPIRATION: status を expired に
+      #   - BILLING_ISSUE: billing_issue_at をセット、Grace 期間を維持
+      #   - PRODUCT_CHANGE: plan_type を切替
+      #   - REFUND: status を expired に、expires_at を即時切れに、refunded_at をセット
+      #   - UNCANCELLATION: cancelled_at をクリアし active に戻す
       nil
     else
       Sentry.capture_message(

--- a/app/services/revenue_cat_webhook_processor.rb
+++ b/app/services/revenue_cat_webhook_processor.rb
@@ -1,0 +1,41 @@
+# RevenueCat の Webhook payload を受け取って Subscription を更新するエントリポイント。
+# 個別 event_type の handler は #346 で順次実装する。本クラスは冪等性と
+# エラーハンドリング・Sentry 通知の責務だけを持ち、未対応イベントは Sentry に
+# 警告して processed として記録する（再送ループ防止）。
+class RevenueCatWebhookProcessor
+  def initialize(webhook_event)
+    @webhook_event = webhook_event
+    @payload = webhook_event.payload || {}
+    @event_data = @payload['event'] || {}
+  end
+
+  def process
+    return if @webhook_event.processed?
+
+    handle_event
+    @webhook_event.mark_processed!
+  rescue StandardError => e
+    @webhook_event.mark_failed!(e.message)
+    Sentry.capture_exception(e, tags: { source: 'revenuecat_webhook' })
+    raise
+  end
+
+  private
+
+  # event_type ごとの分岐。#346 で各 handler を実装する想定で、現状は未対応扱い。
+  def handle_event
+    case @event_data['type']
+    when 'INITIAL_PURCHASE', 'TRIAL_STARTED',
+         'RENEWAL', 'CANCELLATION', 'EXPIRATION',
+         'BILLING_ISSUE', 'PRODUCT_CHANGE', 'REFUND',
+         'UNCANCELLATION'
+      # #346 で個別 handler を実装する。現状はスタブとして無処理で processed 扱いにする。
+      nil
+    else
+      Sentry.capture_message(
+        "RevenueCat unknown event_type: #{@event_data['type'].inspect}",
+        level: :warning
+      )
+    end
+  end
+end

--- a/bin/jobs
+++ b/bin/jobs
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/environment"
+require "solid_queue/cli"
+
+SolidQueue::Cli.start(ARGV)

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,8 @@ module App
     config.api_only = true
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
+    # RevenueCat / Stripe Webhook を 10 秒以内に 200 で返すため、本処理は Solid Queue ジョブへ非同期に渡す。
+    config.active_job.queue_adapter = :solid_queue
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}')]
     config.session_store :cookie_store, key: '_interslice_session'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,8 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter     = :resque
+  # queue_adapter は config/application.rb で全環境一括設定済み。
+  # Solid Queue 用テーブルはアプリ DB に同居させるため connects_to は設定しない。
   # config.active_job.queue_name_prefix = "app_production"
 
   config.action_mailer.perform_caching = false

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,0 +1,15 @@
+# Flipper の永続化に Active Record を使う設定。
+# 既知フィーチャーをコードで宣言しておくことで、未登録キー参照時の typo を検知しやすくする。
+Flipper.configure do |config|
+  config.adapter { Flipper::Adapters::ActiveRecord.new }
+end
+
+Rails.application.config.after_initialize do
+  next unless Flipper::Adapters::ActiveRecord::Feature.table_exists?
+
+  %i[pro_features cancellation_survey].each do |feature|
+    Flipper.add(feature) unless Flipper.exist?(feature)
+  end
+rescue ActiveRecord::ActiveRecordError
+  # マイグレーション前の初回 boot では feature を登録できないが無視する。
+end

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,0 +1,8 @@
+Stripe.api_key =
+  if ENV['USE_STRIPE_TEST_MODE'] == 'true' || !Rails.env.production?
+    ENV.fetch('STRIPE_SECRET_KEY_TEST', ENV.fetch('STRIPE_SECRET_KEY', nil))
+  else
+    ENV.fetch('STRIPE_SECRET_KEY', nil)
+  end
+
+Stripe.api_version = '2024-06-20'

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,6 +1,7 @@
 Stripe.api_key =
   if ENV['USE_STRIPE_TEST_MODE'] == 'true' || !Rails.env.production?
-    ENV.fetch('STRIPE_SECRET_KEY_TEST', ENV.fetch('STRIPE_SECRET_KEY', nil))
+    # テストモード時に本番キーへフォールバックすると事故になるため、必ず test key のみ参照する。
+    ENV.fetch('STRIPE_SECRET_KEY_TEST', nil)
   else
     ENV.fetch('STRIPE_SECRET_KEY', nil)
   end

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -1,0 +1,18 @@
+default: &default
+  dispatchers:
+    - polling_interval: 1
+      batch_size: 500
+  workers:
+    - queues: "*"
+      threads: 3
+      processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
+      polling_interval: 0.1
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -14,5 +14,13 @@ development:
 test:
   <<: *default
 
+# 本番は突発トラフィック前提のため 1.0 秒でも UX 影響なし。常時ポーリングの DB 負荷を抑える。
 production:
-  <<: *default
+  dispatchers:
+    - polling_interval: 1
+      batch_size: 500
+  workers:
+    - queues: "*"
+      threads: 3
+      processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
+      polling_interval: 1.0

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,0 +1,15 @@
+# examples:
+#   periodic_cleanup:
+#     class: CleanSoftDeletedRecordsJob
+#     queue: background
+#     args: [ 1000, { batch_size: 500 } ]
+#     schedule: every hour
+#   periodic_cleanup_with_command:
+#     command: "SoftDeletedRecord.due.delete_all"
+#     priority: 2
+#     schedule: at 5am every day
+
+production:
+  clear_solid_queue_finished_jobs:
+    command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
+    schedule: every hour at minute 12

--- a/db/migrate/20260523220001_create_solid_queue_tables.rb
+++ b/db/migrate/20260523220001_create_solid_queue_tables.rb
@@ -1,0 +1,142 @@
+class CreateSolidQueueTables < ActiveRecord::Migration[7.1]
+  def change
+    create_table :solid_queue_blocked_executions do |t|
+      t.bigint :job_id, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.string :concurrency_key, null: false
+      t.datetime :expires_at, null: false
+      t.datetime :created_at, null: false
+
+      t.index %i[concurrency_key priority job_id], name: 'index_solid_queue_blocked_executions_for_release'
+      t.index %i[expires_at concurrency_key], name: 'index_solid_queue_blocked_executions_for_maintenance'
+      t.index [:job_id], name: 'index_solid_queue_blocked_executions_on_job_id', unique: true
+    end
+
+    create_table :solid_queue_claimed_executions do |t|
+      t.bigint :job_id, null: false
+      t.bigint :process_id
+      t.datetime :created_at, null: false
+
+      t.index [:job_id], name: 'index_solid_queue_claimed_executions_on_job_id', unique: true
+      t.index %i[process_id job_id], name: 'index_solid_queue_claimed_executions_on_process_id_and_job_id'
+    end
+
+    create_table :solid_queue_failed_executions do |t|
+      t.bigint :job_id, null: false
+      t.text :error
+      t.datetime :created_at, null: false
+
+      t.index [:job_id], name: 'index_solid_queue_failed_executions_on_job_id', unique: true
+    end
+
+    create_table :solid_queue_jobs do |t|
+      t.string :queue_name, null: false
+      t.string :class_name, null: false
+      t.text :arguments
+      t.integer :priority, default: 0, null: false
+      t.string :active_job_id
+      t.datetime :scheduled_at
+      t.datetime :finished_at
+      t.string :concurrency_key
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+
+      t.index [:active_job_id], name: 'index_solid_queue_jobs_on_active_job_id'
+      t.index [:class_name], name: 'index_solid_queue_jobs_on_class_name'
+      t.index [:finished_at], name: 'index_solid_queue_jobs_on_finished_at'
+      t.index %i[queue_name finished_at], name: 'index_solid_queue_jobs_for_filtering'
+      t.index %i[scheduled_at finished_at], name: 'index_solid_queue_jobs_for_alerting'
+    end
+
+    create_table :solid_queue_pauses do |t|
+      t.string :queue_name, null: false
+      t.datetime :created_at, null: false
+
+      t.index [:queue_name], name: 'index_solid_queue_pauses_on_queue_name', unique: true
+    end
+
+    create_table :solid_queue_processes do |t|
+      t.string :kind, null: false
+      t.datetime :last_heartbeat_at, null: false
+      t.bigint :supervisor_id
+      t.integer :pid, null: false
+      t.string :hostname
+      t.text :metadata
+      t.datetime :created_at, null: false
+      t.string :name, null: false
+
+      t.index [:last_heartbeat_at], name: 'index_solid_queue_processes_on_last_heartbeat_at'
+      t.index %i[name supervisor_id], name: 'index_solid_queue_processes_on_name_and_supervisor_id', unique: true
+      t.index [:supervisor_id], name: 'index_solid_queue_processes_on_supervisor_id'
+    end
+
+    create_table :solid_queue_ready_executions do |t|
+      t.bigint :job_id, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.datetime :created_at, null: false
+
+      t.index [:job_id], name: 'index_solid_queue_ready_executions_on_job_id', unique: true
+      t.index %i[priority job_id], name: 'index_solid_queue_poll_all'
+      t.index %i[queue_name priority job_id], name: 'index_solid_queue_poll_by_queue'
+    end
+
+    create_table :solid_queue_recurring_executions do |t|
+      t.bigint :job_id, null: false
+      t.string :task_key, null: false
+      t.datetime :run_at, null: false
+      t.datetime :created_at, null: false
+
+      t.index [:job_id], name: 'index_solid_queue_recurring_executions_on_job_id', unique: true
+      t.index %i[task_key run_at], name: 'index_solid_queue_recurring_executions_on_task_key_and_run_at', unique: true
+    end
+
+    create_table :solid_queue_recurring_tasks do |t|
+      t.string :key, null: false
+      t.string :schedule, null: false
+      t.string :command, limit: 2048
+      t.string :class_name
+      t.text :arguments
+      t.string :queue_name
+      t.integer :priority, default: 0
+      t.boolean :static, default: true, null: false
+      t.text :description
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+
+      t.index [:key], name: 'index_solid_queue_recurring_tasks_on_key', unique: true
+      t.index [:static], name: 'index_solid_queue_recurring_tasks_on_static'
+    end
+
+    create_table :solid_queue_scheduled_executions do |t|
+      t.bigint :job_id, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.datetime :scheduled_at, null: false
+      t.datetime :created_at, null: false
+
+      t.index [:job_id], name: 'index_solid_queue_scheduled_executions_on_job_id', unique: true
+      t.index %i[scheduled_at priority job_id], name: 'index_solid_queue_dispatch_all'
+    end
+
+    create_table :solid_queue_semaphores do |t|
+      t.string :key, null: false
+      t.integer :value, default: 1, null: false
+      t.datetime :expires_at, null: false
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+
+      t.index [:expires_at], name: 'index_solid_queue_semaphores_on_expires_at'
+      t.index %i[key value], name: 'index_solid_queue_semaphores_on_key_and_value'
+      t.index [:key], name: 'index_solid_queue_semaphores_on_key', unique: true
+    end
+
+    add_foreign_key :solid_queue_blocked_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_claimed_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_failed_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_ready_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_recurring_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_scheduled_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+  end
+end

--- a/db/migrate/20260523220002_create_flipper_tables.rb
+++ b/db/migrate/20260523220002_create_flipper_tables.rb
@@ -1,0 +1,22 @@
+class CreateFlipperTables < ActiveRecord::Migration[7.1]
+  def up
+    create_table :flipper_features do |t|
+      t.string :key, null: false
+      t.timestamps null: false
+    end
+    add_index :flipper_features, :key, unique: true
+
+    create_table :flipper_gates do |t|
+      t.string :feature_key, null: false
+      t.string :key, null: false
+      t.text :value
+      t.timestamps null: false
+    end
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true, length: { value: 255 }
+  end
+
+  def down
+    drop_table :flipper_gates
+    drop_table :flipper_features
+  end
+end

--- a/db/migrate/20260523220003_add_error_message_to_webhook_events.rb
+++ b/db/migrate/20260523220003_add_error_message_to_webhook_events.rb
@@ -1,0 +1,5 @@
+class AddErrorMessageToWebhookEvents < ActiveRecord::Migration[7.1]
+  def change
+    add_column :webhook_events, :error_message, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_17_100004) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_23_220003) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -152,6 +152,22 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_17_100004) do
     t.datetime "updated_at", null: false
     t.index ["token"], name: "index_device_tokens_on_token", unique: true
     t.index ["user_id"], name: "index_device_tokens_on_user_id"
+  end
+
+  create_table "flipper_features", force: :cascade do |t|
+    t.string "key", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_flipper_features_on_key", unique: true
+  end
+
+  create_table "flipper_gates", force: :cascade do |t|
+    t.string "feature_key", null: false
+    t.string "key", null: false
+    t.text "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
   create_table "game_results", force: :cascade do |t|
@@ -342,6 +358,127 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_17_100004) do
     t.index ["user_id"], name: "index_seasons_on_user_id"
   end
 
+  create_table "solid_queue_blocked_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "concurrency_key", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_claimed_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.bigint "process_id"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+  end
+
+  create_table "solid_queue_failed_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.text "error"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_jobs", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.string "class_name", null: false
+    t.text "arguments"
+    t.integer "priority", default: 0, null: false
+    t.string "active_job_id"
+    t.datetime "scheduled_at"
+    t.datetime "finished_at"
+    t.string "concurrency_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
+  end
+
+  create_table "solid_queue_pauses", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.datetime "created_at", null: false
+    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
+  end
+
+  create_table "solid_queue_processes", force: :cascade do |t|
+    t.string "kind", null: false
+    t.datetime "last_heartbeat_at", null: false
+    t.bigint "supervisor_id"
+    t.integer "pid", null: false
+    t.string "hostname"
+    t.text "metadata"
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
+  end
+
+  create_table "solid_queue_ready_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
+  end
+
+  create_table "solid_queue_recurring_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "task_key", null: false
+    t.datetime "run_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+  end
+
+  create_table "solid_queue_recurring_tasks", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "schedule", null: false
+    t.string "command", limit: 2048
+    t.string "class_name"
+    t.text "arguments"
+    t.string "queue_name"
+    t.integer "priority", default: 0
+    t.boolean "static", default: true, null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
+  end
+
+  create_table "solid_queue_scheduled_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "scheduled_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
+  end
+
+  create_table "solid_queue_semaphores", force: :cascade do |t|
+    t.string "key", null: false
+    t.integer "value", default: 1, null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+  end
+
   create_table "subscriptions", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "status", default: "free", null: false
@@ -477,6 +614,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_17_100004) do
     t.jsonb "payload"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "error_message"
     t.index ["provider", "external_event_id"], name: "index_webhook_events_on_provider_and_external_event_id", unique: true
     t.index ["status"], name: "index_webhook_events_on_status"
   end
@@ -507,6 +645,12 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_17_100004) do
   add_foreign_key "plate_appearances", "game_results", on_delete: :cascade
   add_foreign_key "plate_appearances", "users"
   add_foreign_key "seasons", "users"
+  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "subscriptions", "users"
   add_foreign_key "teams", "baseball_categories", column: "category_id"
   add_foreign_key "teams", "prefectures"

--- a/spec/factories/webhook_events.rb
+++ b/spec/factories/webhook_events.rb
@@ -1,0 +1,24 @@
+FactoryBot.define do
+  factory :webhook_event do
+    provider { 'revenuecat' }
+    sequence(:external_event_id) { |n| "evt_#{n}" }
+    event_type { 'INITIAL_PURCHASE' }
+    received_at { Time.current }
+    status { 'pending' }
+    payload { { event: { id: external_event_id, type: event_type } } }
+
+    trait :processed do
+      status { 'processed' }
+      processed_at { Time.current }
+    end
+
+    trait :failed do
+      status { 'failed' }
+      error_message { 'something went wrong' }
+    end
+
+    trait :skipped do
+      status { 'skipped' }
+    end
+  end
+end

--- a/spec/jobs/revenue_cat_webhook_job_spec.rb
+++ b/spec/jobs/revenue_cat_webhook_job_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe RevenueCatWebhookJob, type: :job do
+  let(:webhook_event) { create(:webhook_event) }
+
+  describe '#perform' do
+    it 'RevenueCatWebhookProcessor#process を呼び出す' do
+      processor = instance_double(RevenueCatWebhookProcessor, process: nil)
+      allow(RevenueCatWebhookProcessor).to receive(:new).with(webhook_event).and_return(processor)
+
+      described_class.new.perform(webhook_event.id)
+      expect(processor).to have_received(:process)
+    end
+
+    context 'webhook_event が見つからないとき' do
+      it '例外を raise しない（DB 競合や手動削除に備える）' do
+        expect do
+          described_class.new.perform(0)
+        end.not_to raise_error
+      end
+    end
+  end
+
+  describe 'retry 設定' do
+    it 'StandardError で exponential backoff、最大 5 回リトライする' do
+      # ActiveJob はクラス変数 retry_jitter / executions_for に直接アクセスできないため、
+      # rescue_handlers 経由で設定済みであることだけ確認する。
+      handlers = described_class.rescue_handlers
+      standard_error_handler = handlers.find { |klass, _| klass == 'StandardError' }
+      expect(standard_error_handler).to be_present
+    end
+  end
+
+  describe 'queue' do
+    it 'default キューに enqueue される' do
+      expect(described_class.new.queue_name).to eq('default')
+    end
+  end
+end

--- a/spec/models/webhook_event_spec.rb
+++ b/spec/models/webhook_event_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+RSpec.describe WebhookEvent, type: :model do
+  describe '.find_or_create_pending!' do
+    let(:event_id) { 'evt_abc123' }
+    let(:payload) { { event: { id: event_id, type: 'INITIAL_PURCHASE' } } }
+
+    context '同一 provider × external_event_id が未登録のとき' do
+      it 'pending 状態で新規レコードを返す' do
+        result = described_class.find_or_create_pending!(
+          provider: 'revenuecat',
+          external_event_id: event_id,
+          event_type: 'INITIAL_PURCHASE',
+          payload:
+        )
+
+        expect(result).to be_persisted
+        expect(result.status).to eq('pending')
+        expect(result.received_at).to be_within(1.second).of(Time.current)
+        expect(result.payload['event']['id']).to eq(event_id)
+      end
+    end
+
+    context '同一 provider × external_event_id が既に存在するとき' do
+      let!(:existing) do
+        create(:webhook_event,
+               provider: 'revenuecat',
+               external_event_id: event_id,
+               status: 'processed',
+               processed_at: 1.hour.ago)
+      end
+
+      it '既存レコードを返し、status を pending に書き換えない' do
+        result = described_class.find_or_create_pending!(
+          provider: 'revenuecat',
+          external_event_id: event_id,
+          event_type: 'INITIAL_PURCHASE',
+          payload:
+        )
+
+        expect(result.id).to eq(existing.id)
+        expect(result.status).to eq('processed')
+      end
+    end
+  end
+
+  describe '#mark_processed!' do
+    let(:webhook_event) { create(:webhook_event) }
+
+    it 'status を processed に更新し、processed_at を現在時刻にする' do
+      webhook_event.mark_processed!
+      webhook_event.reload
+      expect(webhook_event.status).to eq('processed')
+      expect(webhook_event.processed_at).to be_within(1.second).of(Time.current)
+      expect(webhook_event.error_message).to be_nil
+    end
+  end
+
+  describe '#mark_failed!' do
+    let(:webhook_event) { create(:webhook_event) }
+
+    it 'status を failed に更新し、error_message を保存する' do
+      webhook_event.mark_failed!('boom')
+      expect(webhook_event.reload).to have_attributes(
+        status: 'failed',
+        error_message: 'boom'
+      )
+    end
+
+    it 'error_message が nil なら例外メッセージなしで failed に更新する' do
+      webhook_event.mark_failed!(nil)
+      expect(webhook_event.reload).to have_attributes(
+        status: 'failed',
+        error_message: nil
+      )
+    end
+  end
+
+  describe '#pending?' do
+    it 'status が pending のとき true を返す' do
+      expect(build(:webhook_event, status: 'pending')).to be_pending
+    end
+
+    it 'status が processed のとき false を返す' do
+      expect(build(:webhook_event, status: 'processed')).not_to be_pending
+    end
+  end
+end

--- a/spec/requests/api/v1/webhooks/revenuecat_spec.rb
+++ b/spec/requests/api/v1/webhooks/revenuecat_spec.rb
@@ -1,34 +1,105 @@
 require 'rails_helper'
 
 RSpec.describe 'Api::V1::Webhooks::Revenuecat', type: :request do
-  # 本 Issue ではスタブ実装で 200 を返すだけ。
-  # 署名検証 (X-RevenueCat-Signature の HMAC 照合) と payload 解釈・状態遷移は #318 で実装する。
-  # スタブ段階でも RevenueCat 側のリトライを抑止するため、どんな入力でも 200 を返すことを保証する。
+  let(:secret) { 'rc_test_secret_xyz' }
+  let(:auth_header) { { 'Authorization' => "Bearer #{secret}" } }
+  let(:event_id) { 'evt_initial_purchase_001' }
+  let(:payload) do
+    {
+      event: {
+        id: event_id,
+        type: 'INITIAL_PURCHASE',
+        app_user_id: 'user_1'
+      }
+    }
+  end
+
+  before do
+    # 本実装後は ENV['REVENUECAT_WEBHOOK_SECRET'] を参照して HMAC 照合する。
+    # 個別 spec が ENV 全体に干渉しないよう、Authorization ヘッダで使う secret だけスタブする。
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('REVENUECAT_WEBHOOK_SECRET', any_args).and_return(secret)
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('REVENUECAT_WEBHOOK_SECRET').and_return(secret)
+  end
+
   describe 'POST /api/v1/webhooks/revenuecat' do
-    it 'returns 200 for a normal RevenueCat-shaped JSON payload' do
-      post '/api/v1/webhooks/revenuecat',
-           params: { event: { type: 'INITIAL_PURCHASE', app_user_id: 'user_1' } },
-           as: :json
-      expect(response).to have_http_status(:ok)
+    context '署名（Authorization Bearer）が一致するとき' do
+      it '200 を返し、pending な WebhookEvent を作成して Job を enqueue する' do
+        expect do
+          post '/api/v1/webhooks/revenuecat', params: payload, headers: auth_header, as: :json
+        end.to have_enqueued_job(RevenueCatWebhookJob).exactly(:once)
+
+        expect(response).to have_http_status(:ok)
+        event = WebhookEvent.find_by(provider: 'revenuecat', external_event_id: event_id)
+        expect(event).to be_present
+        expect(event.status).to eq('pending')
+        expect(event.event_type).to eq('INITIAL_PURCHASE')
+      end
+
+      context '同一 event_id を 2 回送信したとき' do
+        it '2 回目は Job を enqueue しない（冪等性）' do
+          post '/api/v1/webhooks/revenuecat', params: payload, headers: auth_header, as: :json
+
+          expect do
+            post '/api/v1/webhooks/revenuecat', params: payload, headers: auth_header, as: :json
+          end.not_to have_enqueued_job(RevenueCatWebhookJob)
+
+          expect(response).to have_http_status(:ok)
+          expect(WebhookEvent.where(provider: 'revenuecat', external_event_id: event_id).count).to eq(1)
+        end
+      end
     end
 
-    it 'returns 200 for an empty JSON body' do
-      post '/api/v1/webhooks/revenuecat', params: {}, as: :json
-      expect(response).to have_http_status(:ok)
+    context '署名が一致しないとき' do
+      it '401 を返し、WebhookEvent を作らず Job も enqueue しない' do
+        expect do
+          post '/api/v1/webhooks/revenuecat',
+               params: payload,
+               headers: { 'Authorization' => 'Bearer wrong-secret' },
+               as: :json
+        end.not_to have_enqueued_job(RevenueCatWebhookJob)
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(WebhookEvent.count).to eq(0)
+      end
     end
 
-    it 'returns 200 even without Content-Type header' do
-      post '/api/v1/webhooks/revenuecat'
-      expect(response).to have_http_status(:ok)
+    context 'Authorization ヘッダ自体がないとき' do
+      it '401 を返す' do
+        post '/api/v1/webhooks/revenuecat', params: payload, as: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
 
-    it 'returns 200 for a raw text body that is not valid JSON' do
-      # RevenueCat の Retry / Probe 等で payload が想定外でも 4xx を返してはならない。
-      # #318 実装時はここを「署名 NG なら 401、payload 不正なら 422」に切り替える設計を検討する。
-      post '/api/v1/webhooks/revenuecat',
-           params: 'not-a-json',
-           headers: { 'CONTENT_TYPE' => 'text/plain' }
-      expect(response).to have_http_status(:ok)
+    context 'payload に event.id が無いとき' do
+      it '422 を返し、Sentry に通知する' do
+        allow(Sentry).to receive(:capture_message)
+
+        post '/api/v1/webhooks/revenuecat',
+             params: { event: { type: 'INITIAL_PURCHASE' } },
+             headers: auth_header,
+             as: :json
+
+        expect(Sentry).to have_received(:capture_message).with(
+          a_string_including('event.id missing'),
+          hash_including(level: :warning)
+        )
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(WebhookEvent.count).to eq(0)
+      end
+    end
+
+    context 'WebhookEvent の作成中に DB エラーが発生したとき' do
+      it 'Sentry に通知し、500 を返す（RevenueCat 側の自動リトライに任せる）' do
+        allow(WebhookEvent).to receive(:find_or_create_pending!).and_raise(ActiveRecord::ConnectionNotEstablished, 'db down')
+        allow(Sentry).to receive(:capture_exception)
+
+        post '/api/v1/webhooks/revenuecat', params: payload, headers: auth_header, as: :json
+
+        expect(Sentry).to have_received(:capture_exception)
+        expect(response).to have_http_status(:internal_server_error)
+      end
     end
   end
 end

--- a/spec/services/revenue_cat_webhook_processor_spec.rb
+++ b/spec/services/revenue_cat_webhook_processor_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+
+RSpec.describe RevenueCatWebhookProcessor do
+  let(:event_id) { 'evt_initial_purchase_001' }
+  let(:payload) do
+    {
+      'event' => {
+        'id' => event_id,
+        'type' => 'INITIAL_PURCHASE',
+        'app_user_id' => 'user_1'
+      }
+    }
+  end
+  let(:webhook_event) do
+    create(:webhook_event,
+           provider: 'revenuecat',
+           external_event_id: event_id,
+           event_type: 'INITIAL_PURCHASE',
+           payload:)
+  end
+
+  describe '#process' do
+    subject(:process!) { described_class.new(webhook_event).process }
+
+    context 'webhook_event がまだ pending のとき' do
+      it 'status を processed に更新する' do
+        expect { process! }.to change { webhook_event.reload.status }.from('pending').to('processed')
+      end
+
+      it 'processed_at をセットする' do
+        process!
+        expect(webhook_event.reload.processed_at).to be_within(1.second).of(Time.current)
+      end
+    end
+
+    context 'webhook_event が既に processed のとき' do
+      let(:webhook_event) { create(:webhook_event, :processed, provider: 'revenuecat', external_event_id: event_id) }
+
+      it '冪等性のため処理を実行しない（status を変えない）' do
+        original_processed_at = webhook_event.processed_at
+        process!
+        expect(webhook_event.reload.processed_at).to be_within(1.second).of(original_processed_at)
+      end
+    end
+
+    context 'handler 実装中に例外が発生したとき' do
+      let(:processor) { described_class.new(webhook_event) }
+
+      before do
+        allow(processor).to receive(:handle_event).and_raise(StandardError, 'boom')
+        allow(Sentry).to receive(:capture_exception)
+      end
+
+      it 'webhook_event を failed 状態に遷移させて Sentry に通知し、例外を再 raise する' do
+        expect { processor.process }.to raise_error(StandardError, 'boom')
+
+        expect(Sentry).to have_received(:capture_exception).with(
+          instance_of(StandardError),
+          hash_including(tags: hash_including(source: 'revenuecat_webhook'))
+        )
+        expect(webhook_event.reload.status).to eq('failed')
+        expect(webhook_event.error_message).to include('boom')
+      end
+    end
+
+    context '未知の event_type を受信したとき' do
+      let(:payload) do
+        {
+          'event' => {
+            'id' => event_id,
+            'type' => 'UNKNOWN_EVENT_TYPE',
+            'app_user_id' => 'user_1'
+          }
+        }
+      end
+      let(:webhook_event) do
+        create(:webhook_event,
+               provider: 'revenuecat',
+               external_event_id: event_id,
+               event_type: 'UNKNOWN_EVENT_TYPE',
+               payload:)
+      end
+
+      it 'Sentry に warning を残しつつ processed として記録する（未対応イベントもキャッシュに残す）' do
+        allow(Sentry).to receive(:capture_message)
+
+        process!
+
+        expect(Sentry).to have_received(:capture_message).with(
+          a_string_including('UNKNOWN_EVENT_TYPE'),
+          hash_including(level: :warning)
+        )
+        expect(webhook_event.reload.status).to eq('processed')
+      end
+    end
+  end
+end


### PR DESCRIPTION
親 Issue: ippei-shimizu/buzzbase#345
Phase: B（バックエンド実装）/ #318 の前提基盤

## Summary

#318 課金フロー実装の前提となる Webhook 受信基盤を TDD で整備する。Solid Queue による非同期処理、Flipper による段階リリース基盤、Stripe SDK 初期化を同時に導入する。

各イベント（`INITIAL_PURCHASE` / `RENEWAL` / `CANCELLATION` 等）の本処理は #346 で実装する。本 PR では冪等性・署名検証・エラーハンドリング・Sentry 通知の責務だけを完成させる。

## 変更点

### Gemfile
- \`solid_queue\` / \`stripe\` / \`flipper\` / \`flipper-active_record\` を追加

### マイグレーション
- \`solid_queue\` 11 テーブル（同 DB 運用、別 DB ではない）
- \`flipper\` 2 テーブル
- \`webhook_events.error_message\` カラム追加

### 設定
- \`config/application.rb\`: \`active_job.queue_adapter = :solid_queue\` を全環境共通設定
- \`Procfile\`: \`worker: bin/jobs\` を追加（Heroku worker dyno 起動）
- \`config/environments/production.rb\`: \`solid_queue:install\` が gsub で追加した \`connects_to\` を削除（同 DB 運用のため）
- \`config/initializers/stripe.rb\`: \`USE_STRIPE_TEST_MODE\` で test/prod 切替
- \`config/initializers/flipper.rb\`: \`pro_features\` / \`cancellation_survey\` のキー予約

### ロジック層（TDD：red → green → refactor で実装）

- **WebhookEvent モデル拡張**: \`find_or_create_pending!\` / \`mark_processed!\` / \`mark_failed!\` / \`pending?\` 系の predicate
- **RevenueCatWebhookProcessor**: 既処理スキップ、例外時 Sentry 通知、未知 event_type の warning 記録
- **RevenueCatWebhookJob**: 失敗時 \`retry_on StandardError, wait: :polynomially_longer, attempts: 5\`
- **RevenuecatController 本実装**: \`Authorization: Bearer <secret>\` の \`secure_compare\` 検証、新規作成時のみ Job 化、エラー時 Sentry + 500 返却

## 環境変数（本 PR では設定不要、リリース時に Heroku に追加）

- \`REVENUECAT_WEBHOOK_SECRET\`
- \`STRIPE_SECRET_KEY\` / \`STRIPE_SECRET_KEY_TEST\`
- \`STRIPE_PUBLISHABLE_KEY\` / \`STRIPE_WEBHOOK_SECRET\`
- \`STRIPE_PRICE_ID_MONTHLY\` / \`STRIPE_PRICE_ID_YEARLY\`

## Test plan

- [x] \`docker compose exec back bundle exec rspec\` → 672 examples, 0 failures
- [x] \`docker compose exec back bundle exec rubocop\` → 263 files, 0 offenses
- [x] Solid Queue / Flipper / Stripe の \`defined?\` チェックで読み込み確認
- [x] WebhookEvent モデルの冪等性 spec
- [x] Processor の例外ハンドリング / 未知イベント spec
- [x] Job の retry 設定 spec
- [x] Controller の署名検証 / 冪等性 / 422・500 系 spec
- [ ] CI が green になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)