### PR TITLE
Chore: CI workflow の対象ブランチに release/* を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, stg]
+    branches: [main, stg, 'release/*']
   push:
-    branches: [stg]
+    branches: [stg, 'release/*']
 
 jobs:
   rspec:


### PR DESCRIPTION
## Summary

CI workflow の pull_request / push トリガーに \`release/*\` を追加し、リリースブランチ上での PR・push でも CI が走るようにする。

これまでは release/pro-202605 を base とする PR では CI が起動しなかったため、Pro リリース開発中の品質保証が脆弱になっていた。

## 変更

- \`.github/workflows/ci.yml\` の \`on.pull_request.branches\` と \`on.push.branches\` に \`'release/*'\` を追加

## Test plan

- [x] YAML 構文に問題なし
- [ ] この PR 自体が release/pro-202605 を base にしているため、マージ後の release ブランチへの push で CI が起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)