### PR TITLE
Add: Stripe Checkout + 解約 + プラン変更 + Stripe Webhook (#347)

### DIFF
--- a/app/controllers/api/v1/pro/checkout_controller.rb
+++ b/app/controllers/api/v1/pro/checkout_controller.rb
@@ -20,6 +20,11 @@ module Api
           render json: { error: 'already_subscribed' }, status: :conflict
         rescue App::Stripe::CheckoutSessionBuilder::InvalidPlanError
           render json: { error: 'invalid_plan' }, status: :unprocessable_entity
+        rescue ::Stripe::StripeError => e
+          # Stripe API 側の障害（一時的ネットワーク・キー誤設定・商品ID不正など）。
+          # ユーザーには「決済プロバイダ側の問題」を示し、詳細は Sentry で追えるようにする。
+          Sentry.capture_exception(e, tags: { source: 'pro_checkout_controller' })
+          render json: { error: 'stripe_api_error' }, status: :bad_gateway
         end
       end
     end

--- a/app/controllers/api/v1/pro/checkout_controller.rb
+++ b/app/controllers/api/v1/pro/checkout_controller.rb
@@ -1,0 +1,27 @@
+module Api
+  module V1
+    module Pro
+      # POST /api/v1/pro/checkout
+      # Web 加入用の Stripe Checkout Session を生成して checkout_url を返す。
+      # 実際の状態遷移は Stripe → RevenueCat → Webhook 経由で行われるため、ここでは local 状態を触らない。
+      class CheckoutController < ApplicationController
+        before_action :authenticate_api_v1_user!
+
+        def create
+          session = App::Stripe::CheckoutSessionBuilder.new(
+            user: current_api_v1_user,
+            plan: params[:plan],
+            success_url: params[:success_url],
+            cancel_url: params[:cancel_url]
+          ).call
+
+          render json: { checkout_url: session.url }
+        rescue App::Stripe::CheckoutSessionBuilder::AlreadySubscribedError
+          render json: { error: 'already_subscribed' }, status: :conflict
+        rescue App::Stripe::CheckoutSessionBuilder::InvalidPlanError
+          render json: { error: 'invalid_plan' }, status: :unprocessable_entity
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/pro/subscription_controller.rb
+++ b/app/controllers/api/v1/pro/subscription_controller.rb
@@ -1,0 +1,28 @@
+module Api
+  module V1
+    module Pro
+      # DELETE /api/v1/pro/subscription : Web で解約申請（cancel_at_period_end）
+      # PATCH  /api/v1/pro/subscription : 月額↔年額のプラン変更
+      # local 状態は Webhook 経由で正規化されるため、ここでは Stripe API 呼び出しのみ行う。
+      class SubscriptionController < ApplicationController
+        before_action :authenticate_api_v1_user!
+
+        def update
+          App::Stripe::SubscriptionUpdater.new(current_api_v1_user).change_plan(params[:plan])
+          head :ok
+        rescue App::Stripe::SubscriptionUpdater::NoStripeSubscriptionError
+          render json: { error: 'no_active_subscription' }, status: :unprocessable_entity
+        rescue App::Stripe::SubscriptionUpdater::InvalidPlanError
+          render json: { error: 'invalid_plan' }, status: :unprocessable_entity
+        end
+
+        def destroy
+          App::Stripe::SubscriptionUpdater.new(current_api_v1_user).cancel_at_period_end
+          head :ok
+        rescue App::Stripe::SubscriptionUpdater::NoStripeSubscriptionError
+          render json: { error: 'no_active_subscription' }, status: :unprocessable_entity
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/pro/subscription_controller.rb
+++ b/app/controllers/api/v1/pro/subscription_controller.rb
@@ -9,18 +9,24 @@ module Api
 
         def update
           App::Stripe::SubscriptionUpdater.new(current_api_v1_user).change_plan(params[:plan])
-          head :ok
+          render json: { message: 'プラン変更を受け付けました' }, status: :ok
         rescue App::Stripe::SubscriptionUpdater::NoStripeSubscriptionError
           render json: { error: 'no_active_subscription' }, status: :unprocessable_entity
         rescue App::Stripe::SubscriptionUpdater::InvalidPlanError
           render json: { error: 'invalid_plan' }, status: :unprocessable_entity
+        rescue ::Stripe::StripeError => e
+          Sentry.capture_exception(e, tags: { source: 'pro_subscription_controller', action: 'update' })
+          render json: { error: 'stripe_api_error' }, status: :bad_gateway
         end
 
         def destroy
           App::Stripe::SubscriptionUpdater.new(current_api_v1_user).cancel_at_period_end
-          head :ok
+          render json: { message: '解約申請を受け付けました' }, status: :ok
         rescue App::Stripe::SubscriptionUpdater::NoStripeSubscriptionError
           render json: { error: 'no_active_subscription' }, status: :unprocessable_entity
+        rescue ::Stripe::StripeError => e
+          Sentry.capture_exception(e, tags: { source: 'pro_subscription_controller', action: 'destroy' })
+          render json: { error: 'stripe_api_error' }, status: :bad_gateway
         end
       end
     end

--- a/app/controllers/api/v1/webhooks/stripe_controller.rb
+++ b/app/controllers/api/v1/webhooks/stripe_controller.rb
@@ -1,0 +1,43 @@
+module Api
+  module V1
+    module Webhooks
+      # POST /api/v1/webhooks/stripe
+      # 10 秒以内に 200 を返す必要があるため、受信時は WebhookEvent への記録だけ済ませてジョブに委譲する。
+      # 冪等性は webhook_events の (provider, external_event_id) UNIQUE 制約に委ねる。
+      class StripeController < ApplicationController
+        skip_before_action :verify_authenticity_token, raise: false
+
+        def create
+          event = verify_and_parse_event
+          return head :unauthorized unless event
+
+          webhook_event = WebhookEvent.find_or_create_pending!(
+            provider: 'stripe',
+            external_event_id: event.id,
+            event_type: event.type,
+            payload: event.to_hash
+          )
+
+          # 既存レコードが返ったときはジョブも enqueue 済みなので新規作成時のみ起動する。
+          App::Stripe::WebhookJob.perform_later(webhook_event.id) if webhook_event.previously_new_record?
+          head :ok
+        rescue StandardError => e
+          Sentry.capture_exception(e, tags: { source: 'stripe_webhook_controller' })
+          head :internal_server_error
+        end
+
+        private
+
+        # ::Stripe::Webhook.construct_event は raw body と Stripe-Signature ヘッダを必要とする。
+        # 検証失敗は SignatureVerificationError、JSON 不正は JSON::ParserError を投げる。
+        def verify_and_parse_event
+          payload = request.body.read
+          sig_header = request.headers['Stripe-Signature']
+          ::Stripe::Webhook.construct_event(payload, sig_header, ENV.fetch('STRIPE_WEBHOOK_SECRET'))
+        rescue ::Stripe::SignatureVerificationError, JSON::ParserError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/webhooks/stripe_controller.rb
+++ b/app/controllers/api/v1/webhooks/stripe_controller.rb
@@ -30,7 +30,9 @@ module Api
 
         # ::Stripe::Webhook.construct_event は raw body と Stripe-Signature ヘッダを必要とする。
         # 検証失敗は SignatureVerificationError、JSON 不正は JSON::ParserError を投げる。
+        # Rails のミドルウェアが先に body を読み終えているケースに備えて rewind を前置する。
         def verify_and_parse_event
+          request.body.rewind
           payload = request.body.read
           sig_header = request.headers['Stripe-Signature']
           ::Stripe::Webhook.construct_event(payload, sig_header, ENV.fetch('STRIPE_WEBHOOK_SECRET'))

--- a/app/jobs/app/stripe/webhook_job.rb
+++ b/app/jobs/app/stripe/webhook_job.rb
@@ -1,0 +1,22 @@
+module App
+  module Stripe
+    # Webhook 受信時の 10 秒制限を満たすため、本処理は本ジョブに非同期化する。
+    class WebhookJob < ApplicationJob
+      queue_as :default
+
+      # 指数バックオフで最大 5 回リトライ。ApplicationJob の rescue_from で Sentry 通知される。
+      retry_on StandardError, wait: :polynomially_longer, attempts: 5
+
+      # DB から webhook_event が消えていても落とさない（手動削除や DB 競合に備える）。
+      def perform(webhook_event_id)
+        webhook_event = WebhookEvent.find_by(id: webhook_event_id)
+        unless webhook_event
+          Rails.logger.warn("App::Stripe::WebhookJob: webhook_event not found (id=#{webhook_event_id})")
+          return
+        end
+
+        App::Stripe::WebhookProcessor.new(webhook_event).process
+      end
+    end
+  end
+end

--- a/app/services/app/stripe/checkout_session_builder.rb
+++ b/app/services/app/stripe/checkout_session_builder.rb
@@ -1,0 +1,59 @@
+module App
+  module Stripe
+    # Stripe Checkout Session を生成するサービス。
+    # ・既加入ガード
+    # ・plan 妥当性チェック
+    # ・TrialDaysCalculator を参照して trial_period_days を決定
+    # を一手に引き受け、Controller を薄く保つ。
+    class CheckoutSessionBuilder
+      AlreadySubscribedError = Class.new(StandardError)
+      InvalidPlanError = Class.new(StandardError)
+
+      VALID_PLANS = %w[monthly yearly].freeze
+
+      def initialize(user:, plan:, success_url:, cancel_url:)
+        @user = user
+        @plan = plan
+        @success_url = success_url
+        @cancel_url = cancel_url
+      end
+
+      def call
+        raise InvalidPlanError unless VALID_PLANS.include?(@plan)
+        raise AlreadySubscribedError if @user.subscription_or_default.pro_active?
+
+        ::Stripe::Checkout::Session.create(checkout_params)
+      end
+
+      private
+
+      def checkout_params
+        {
+          mode: 'subscription',
+          customer_email: @user.email,
+          line_items: [{ price: stripe_price_id, quantity: 1 }],
+          subscription_data:,
+          success_url: @success_url,
+          cancel_url: @cancel_url
+        }
+      end
+
+      # trial_period_days は 0 なら Stripe に渡さない（compact で除去）。
+      # 0 のまま渡すと「即時課金」ではなく「0日トライアル後課金」と解釈される可能性があるため。
+      def subscription_data
+        trial_days = TrialDaysCalculator.for(@user)
+        {
+          trial_period_days: trial_days.positive? ? trial_days : nil,
+          metadata: { user_id: @user.id.to_s, plan: @plan }
+        }.compact
+      end
+
+      def stripe_price_id
+        case @plan
+        when 'monthly' then ENV.fetch('STRIPE_PRICE_ID_MONTHLY')
+        when 'yearly'  then ENV.fetch('STRIPE_PRICE_ID_YEARLY')
+        end
+      end
+    end
+  end
+end

--- a/app/services/app/stripe/event_dispatcher.rb
+++ b/app/services/app/stripe/event_dispatcher.rb
@@ -1,0 +1,18 @@
+module App
+  module Stripe
+    # event_type → Handler クラスのマッピング。新 event 対応時はここに 1 行追加するだけ。
+    # 未対応 event は UnhandledEventHandler に流して受信記録のみとする。
+    module EventDispatcher
+      HANDLERS = {
+        'checkout.session.completed' => Handlers::CheckoutSessionCompletedHandler
+      }.freeze
+
+      module_function
+
+      def handler_for(payload)
+        handler_class = HANDLERS.fetch(payload.event_type, Handlers::UnhandledEventHandler)
+        handler_class.new(payload)
+      end
+    end
+  end
+end

--- a/app/services/app/stripe/handlers/base_handler.rb
+++ b/app/services/app/stripe/handlers/base_handler.rb
@@ -1,0 +1,20 @@
+module App
+  module Stripe
+    module Handlers
+      # 全 event handler の共通基底。各サブクラスは `call` だけ実装する。
+      class BaseHandler
+        def initialize(payload)
+          @payload = payload
+        end
+
+        def call
+          raise NotImplementedError, "#{self.class.name} must implement #call"
+        end
+
+        protected
+
+        attr_reader :payload
+      end
+    end
+  end
+end

--- a/app/services/app/stripe/handlers/checkout_session_completed_handler.rb
+++ b/app/services/app/stripe/handlers/checkout_session_completed_handler.rb
@@ -1,0 +1,40 @@
+module App
+  module Stripe
+    module Handlers
+      # checkout.session.completed: Web 加入完了時に Stripe ID 2 つを Subscription に紐付ける。
+      # status / plan_type 等の状態遷移は RevenueCat 経由で更新されるため、ここでは Stripe ID のみ保存する。
+      class CheckoutSessionCompletedHandler < BaseHandler
+        def call
+          user_id = payload.metadata[:user_id] || payload.metadata['user_id']
+          return notify_missing_user_id if user_id.blank?
+
+          user = User.find_by(id: user_id)
+          return notify_unknown_user(user_id) unless user
+
+          user.subscription_or_default.update!(
+            stripe_customer_id: payload.customer_id,
+            stripe_subscription_id: payload.subscription_id
+          )
+        end
+
+        private
+
+        def notify_missing_user_id
+          Sentry.capture_message(
+            'Stripe checkout.session.completed: metadata.user_id is missing',
+            level: :warning
+          )
+          nil
+        end
+
+        def notify_unknown_user(user_id)
+          Sentry.capture_message(
+            "Stripe checkout.session.completed: user not found for user_id=#{user_id.inspect}",
+            level: :warning
+          )
+          nil
+        end
+      end
+    end
+  end
+end

--- a/app/services/app/stripe/handlers/checkout_session_completed_handler.rb
+++ b/app/services/app/stripe/handlers/checkout_session_completed_handler.rb
@@ -5,7 +5,7 @@ module App
       # status / plan_type 等の状態遷移は RevenueCat 経由で更新されるため、ここでは Stripe ID のみ保存する。
       class CheckoutSessionCompletedHandler < BaseHandler
         def call
-          user_id = payload.metadata[:user_id] || payload.metadata['user_id']
+          user_id = payload.metadata[:user_id]
           return notify_missing_user_id if user_id.blank?
 
           user = User.find_by(id: user_id)

--- a/app/services/app/stripe/handlers/unhandled_event_handler.rb
+++ b/app/services/app/stripe/handlers/unhandled_event_handler.rb
@@ -1,0 +1,15 @@
+module App
+  module Stripe
+    module Handlers
+      # 未対応の event_type を受信したときのフォールバック。
+      # webhook 自体は processed として記録し、Stripe 側の再送ループを防ぐ。
+      # 状態遷移は RevenueCat 経由が主信号のため、Stripe Webhook では受信記録のみとする。
+      class UnhandledEventHandler < BaseHandler
+        def call
+          # 受信記録のみ。Sentry 通知も不要（想定通りの挙動のため）。
+          nil
+        end
+      end
+    end
+  end
+end

--- a/app/services/app/stripe/subscription_updater.rb
+++ b/app/services/app/stripe/subscription_updater.rb
@@ -1,0 +1,52 @@
+module App
+  module Stripe
+    # Stripe Subscription を更新する API ラッパー（解約 / プラン変更）。
+    # local 状態の更新は Webhook 経由で正規化されるため、ここでは Stripe API 呼び出しに専念する。
+    class SubscriptionUpdater
+      NoStripeSubscriptionError = Class.new(StandardError)
+      InvalidPlanError = Class.new(StandardError)
+
+      VALID_PLANS = %w[monthly yearly].freeze
+
+      def initialize(user)
+        @user = user
+      end
+
+      # 解約申請。期限まで Pro 機能利用可（cancel_at_period_end）。
+      def cancel_at_period_end
+        ::Stripe::Subscription.update(stripe_subscription_id!, cancel_at_period_end: true)
+      end
+
+      # プラン変更（月額↔年額）。proration_behavior は Stripe の差額計算に任せる。
+      def change_plan(new_plan)
+        raise InvalidPlanError unless VALID_PLANS.include?(new_plan)
+
+        # stripe_item_id を保持していないため都度 retrieve で取得する（シンプルさ優先）。
+        sub = ::Stripe::Subscription.retrieve(stripe_subscription_id!)
+        item_id = sub.items.data.first.id
+
+        ::Stripe::Subscription.update(
+          stripe_subscription_id!,
+          items: [{ id: item_id, price: stripe_price_id(new_plan) }],
+          proration_behavior: 'create_prorations'
+        )
+      end
+
+      private
+
+      def stripe_subscription_id!
+        id = @user.subscription_or_default.stripe_subscription_id
+        raise NoStripeSubscriptionError if id.blank?
+
+        id
+      end
+
+      def stripe_price_id(plan)
+        case plan
+        when 'monthly' then ENV.fetch('STRIPE_PRICE_ID_MONTHLY')
+        when 'yearly'  then ENV.fetch('STRIPE_PRICE_ID_YEARLY')
+        end
+      end
+    end
+  end
+end

--- a/app/services/app/stripe/webhook_payload.rb
+++ b/app/services/app/stripe/webhook_payload.rb
@@ -1,0 +1,44 @@
+module App
+  module Stripe
+    # Stripe Event オブジェクトを薄くラップした値オブジェクト。
+    # gem の Stripe::Event 直接アクセスを各所で散らばらせないため、必要な getter をここに集約する。
+    class WebhookPayload
+      def initialize(stripe_event)
+        @event = stripe_event
+      end
+
+      def event_id
+        @event.id
+      end
+
+      def event_type
+        @event.type
+      end
+
+      # data.object の中身を Hash 風アクセスで返す。
+      # Stripe::StripeObject は OpenStruct 的に [:key] / .key の両方に応答する。
+      def data_object
+        @event.data&.object || {}
+      end
+
+      # data.object.metadata を Hash として返す。未設定時は空 Hash で安全に扱えるようにする。
+      def metadata
+        meta = data_object.respond_to?(:metadata) ? data_object.metadata : nil
+        meta.respond_to?(:to_h) ? meta.to_h : {}
+      end
+
+      def customer_id
+        data_object.respond_to?(:customer) ? data_object.customer : nil
+      end
+
+      def subscription_id
+        data_object.respond_to?(:subscription) ? data_object.subscription : nil
+      end
+
+      # UserSubscriptionEvent#raw_payload や webhook_events.payload に保存する素の Hash を返す。
+      def to_h
+        @event.to_hash
+      end
+    end
+  end
+end

--- a/app/services/app/stripe/webhook_payload.rb
+++ b/app/services/app/stripe/webhook_payload.rb
@@ -21,10 +21,11 @@ module App
         @event.data&.object || {}
       end
 
-      # data.object.metadata を Hash として返す。未設定時は空 Hash で安全に扱えるようにする。
+      # data.object.metadata を HashWithIndifferentAccess として返す。
+      # Stripe 直送（Symbol キー）と DB 経由（JSON → String キー）の両方を統一して扱えるようにする。
       def metadata
         meta = data_object.respond_to?(:metadata) ? data_object.metadata : nil
-        meta.respond_to?(:to_h) ? meta.to_h : {}
+        (meta.respond_to?(:to_h) ? meta.to_h : {}).with_indifferent_access
       end
 
       def customer_id

--- a/app/services/app/stripe/webhook_processor.rb
+++ b/app/services/app/stripe/webhook_processor.rb
@@ -1,0 +1,25 @@
+module App
+  module Stripe
+    # Stripe Webhook 処理のエントリポイント。
+    # 冪等性ガード・例外時の失敗マーク + Sentry 通知の責務だけ持ち、
+    # event_type 別の本処理は EventDispatcher 経由で各 Handler に委譲する。
+    class WebhookProcessor
+      def initialize(webhook_event)
+        @webhook_event = webhook_event
+        @payload = WebhookPayload.new(::Stripe::Event.construct_from(webhook_event.payload || {}))
+      end
+
+      # failed のレコードは手動で再 enqueue されたとき再処理する設計のため processed のみガードする。
+      def process
+        return if @webhook_event.processed?
+
+        EventDispatcher.handler_for(@payload).call
+        @webhook_event.mark_processed!
+      rescue StandardError => e
+        @webhook_event.mark_failed!(e.message)
+        Sentry.capture_exception(e, tags: { source: 'stripe_webhook' })
+        raise
+      end
+    end
+  end
+end

--- a/app/services/app/stripe/webhook_processor.rb
+++ b/app/services/app/stripe/webhook_processor.rb
@@ -16,9 +16,19 @@ module App
         EventDispatcher.handler_for(@payload).call
         @webhook_event.mark_processed!
       rescue StandardError => e
-        @webhook_event.mark_failed!(e.message)
+        # mark_failed! 自体が例外で落ちると元の e が握り潰されるため、
+        # 内側を rescue で守って元例外を必ず Sentry に届ける。
+        safely_mark_failed(e.message)
         Sentry.capture_exception(e, tags: { source: 'stripe_webhook' })
         raise
+      end
+
+      private
+
+      def safely_mark_failed(message)
+        @webhook_event.mark_failed!(message)
+      rescue StandardError => e
+        Sentry.capture_exception(e, tags: { source: 'stripe_webhook_mark_failed' })
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -155,10 +155,13 @@ Rails.application.routes.draw do
         resource :status, only: %i[show], controller: 'status'
         resource :sync, only: %i[create], controller: 'sync'
         resources :entitlements, only: %i[index]
+        resource :checkout, only: %i[create], controller: 'checkout'
+        resource :subscription, only: %i[destroy update], controller: 'subscription'
       end
 
       namespace :webhooks do
         resource :revenuecat, only: %i[create], controller: 'revenuecat'
+        resource :stripe, only: %i[create], controller: 'stripe'
       end
 
       namespace :admin do

--- a/db/migrate/20260524111501_add_stripe_columns_to_subscriptions.rb
+++ b/db/migrate/20260524111501_add_stripe_columns_to_subscriptions.rb
@@ -1,0 +1,14 @@
+class AddStripeColumnsToSubscriptions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :subscriptions, :stripe_customer_id, :string
+    add_column :subscriptions, :stripe_subscription_id, :string
+
+    # 値があるレコードだけ一意性を担保したい（多くのユーザーは Stripe を使わないため nil 重複が大量に発生する）。
+    add_index :subscriptions, :stripe_customer_id,
+              unique: true,
+              where: 'stripe_customer_id IS NOT NULL'
+    add_index :subscriptions, :stripe_subscription_id,
+              unique: true,
+              where: 'stripe_subscription_id IS NOT NULL'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_23_220003) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_24_111501) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -497,9 +497,13 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_23_220003) do
     t.datetime "last_synced_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "stripe_customer_id"
+    t.string "stripe_subscription_id"
     t.index ["expires_at"], name: "index_subscriptions_on_expires_at"
     t.index ["revenuecat_user_id"], name: "index_subscriptions_on_revenuecat_user_id", unique: true
     t.index ["status"], name: "index_subscriptions_on_status"
+    t.index ["stripe_customer_id"], name: "index_subscriptions_on_stripe_customer_id", unique: true, where: "(stripe_customer_id IS NOT NULL)"
+    t.index ["stripe_subscription_id"], name: "index_subscriptions_on_stripe_subscription_id", unique: true, where: "(stripe_subscription_id IS NOT NULL)"
     t.index ["user_id"], name: "index_subscriptions_on_user_id", unique: true
   end
 

--- a/spec/fixtures/stripe/checkout_session_completed.json
+++ b/spec/fixtures/stripe/checkout_session_completed.json
@@ -1,0 +1,22 @@
+{
+  "id": "evt_test_checkout_completed_001",
+  "object": "event",
+  "api_version": "2024-06-20",
+  "type": "checkout.session.completed",
+  "created": 1748761200,
+  "data": {
+    "object": {
+      "id": "cs_test_abc123",
+      "object": "checkout.session",
+      "customer": "cus_test_abc123",
+      "subscription": "sub_test_abc123",
+      "customer_email": "user@example.com",
+      "mode": "subscription",
+      "payment_status": "paid",
+      "metadata": {
+        "user_id": "1",
+        "plan": "monthly"
+      }
+    }
+  }
+}

--- a/spec/fixtures/stripe/customer_subscription_deleted.json
+++ b/spec/fixtures/stripe/customer_subscription_deleted.json
@@ -1,0 +1,15 @@
+{
+  "id": "evt_test_subscription_deleted_001",
+  "object": "event",
+  "api_version": "2024-06-20",
+  "type": "customer.subscription.deleted",
+  "created": 1748761300,
+  "data": {
+    "object": {
+      "id": "sub_test_abc123",
+      "object": "subscription",
+      "customer": "cus_test_abc123",
+      "status": "canceled"
+    }
+  }
+}

--- a/spec/jobs/app/stripe/webhook_job_spec.rb
+++ b/spec/jobs/app/stripe/webhook_job_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe App::Stripe::WebhookJob, type: :job do
+  let(:webhook_event) { create(:webhook_event, provider: 'stripe') }
+
+  describe '#perform' do
+    it 'App::Stripe::WebhookProcessor#process を呼び出す' do
+      processor = instance_double(App::Stripe::WebhookProcessor, process: nil)
+      allow(App::Stripe::WebhookProcessor).to receive(:new).with(webhook_event).and_return(processor)
+
+      described_class.new.perform(webhook_event.id)
+      expect(processor).to have_received(:process)
+    end
+
+    context 'webhook_event が見つからないとき' do
+      it '例外を raise しない（DB 競合や手動削除に備える）' do
+        expect { described_class.new.perform(0) }.not_to raise_error
+      end
+    end
+  end
+
+  describe 'retry / queue 設定' do
+    it 'StandardError で exponential backoff のリトライ設定がある' do
+      handlers = described_class.rescue_handlers
+      expect(handlers.find { |klass, _| klass == 'StandardError' }).to be_present
+    end
+
+    it 'default キューに enqueue される' do
+      expect(described_class.new.queue_name).to eq('default')
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,6 +29,7 @@ RSpec.configure do |config|
   config.include ActiveJob::TestHelper, type: :job
   config.include ActiveJob::TestHelper, type: :model
   config.include ActiveJob::TestHelper, type: :request
+  config.include ActiveSupport::Testing::TimeHelpers
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/requests/api/v1/pro/checkout_spec.rb
+++ b/spec/requests/api/v1/pro/checkout_spec.rb
@@ -20,10 +20,9 @@ RSpec.describe 'Api::V1::Pro::Checkout', type: :request do
 
     context '認証済みかつ未加入のとき' do
       let(:stripe_session) { instance_double(Stripe::Checkout::Session, url: 'https://checkout.stripe.com/c/pay/sess_abc') }
+      let(:builder) { instance_double(App::Stripe::CheckoutSessionBuilder, call: stripe_session) }
 
-      before do
-        allow_any_instance_of(App::Stripe::CheckoutSessionBuilder).to receive(:call).and_return(stripe_session)
-      end
+      before { allow(App::Stripe::CheckoutSessionBuilder).to receive(:new).and_return(builder) }
 
       it 'checkout_url を含む 200 レスポンスを返す' do
         post '/api/v1/pro/checkout', params:, headers: auth_headers_for(user), as: :json
@@ -33,10 +32,11 @@ RSpec.describe 'Api::V1::Pro::Checkout', type: :request do
     end
 
     context '既加入で AlreadySubscribedError が起きるとき' do
+      let(:builder) { instance_double(App::Stripe::CheckoutSessionBuilder) }
+
       before do
-        allow_any_instance_of(App::Stripe::CheckoutSessionBuilder)
-          .to receive(:call)
-          .and_raise(App::Stripe::CheckoutSessionBuilder::AlreadySubscribedError)
+        allow(App::Stripe::CheckoutSessionBuilder).to receive(:new).and_return(builder)
+        allow(builder).to receive(:call).and_raise(App::Stripe::CheckoutSessionBuilder::AlreadySubscribedError)
       end
 
       it '409 + error: already_subscribed を返す' do
@@ -47,10 +47,11 @@ RSpec.describe 'Api::V1::Pro::Checkout', type: :request do
     end
 
     context '不正な plan で InvalidPlanError が起きるとき' do
+      let(:builder) { instance_double(App::Stripe::CheckoutSessionBuilder) }
+
       before do
-        allow_any_instance_of(App::Stripe::CheckoutSessionBuilder)
-          .to receive(:call)
-          .and_raise(App::Stripe::CheckoutSessionBuilder::InvalidPlanError)
+        allow(App::Stripe::CheckoutSessionBuilder).to receive(:new).and_return(builder)
+        allow(builder).to receive(:call).and_raise(App::Stripe::CheckoutSessionBuilder::InvalidPlanError)
       end
 
       it '422 + error: invalid_plan を返す' do

--- a/spec/requests/api/v1/pro/checkout_spec.rb
+++ b/spec/requests/api/v1/pro/checkout_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Pro::Checkout', type: :request do
+  let(:user) { create(:user) }
+  let(:params) do
+    {
+      plan: 'monthly',
+      success_url: 'https://buzzbase.jp/pro/success',
+      cancel_url: 'https://buzzbase.jp/pro/cancel'
+    }
+  end
+
+  describe 'POST /api/v1/pro/checkout' do
+    context '未認証のとき' do
+      it '401 を返す' do
+        post '/api/v1/pro/checkout', params:, as: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '認証済みかつ未加入のとき' do
+      let(:stripe_session) { instance_double(Stripe::Checkout::Session, url: 'https://checkout.stripe.com/c/pay/sess_abc') }
+
+      before do
+        allow_any_instance_of(App::Stripe::CheckoutSessionBuilder).to receive(:call).and_return(stripe_session)
+      end
+
+      it 'checkout_url を含む 200 レスポンスを返す' do
+        post '/api/v1/pro/checkout', params:, headers: auth_headers_for(user), as: :json
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['checkout_url']).to eq('https://checkout.stripe.com/c/pay/sess_abc')
+      end
+    end
+
+    context '既加入で AlreadySubscribedError が起きるとき' do
+      before do
+        allow_any_instance_of(App::Stripe::CheckoutSessionBuilder)
+          .to receive(:call)
+          .and_raise(App::Stripe::CheckoutSessionBuilder::AlreadySubscribedError)
+      end
+
+      it '409 + error: already_subscribed を返す' do
+        post '/api/v1/pro/checkout', params:, headers: auth_headers_for(user), as: :json
+        expect(response).to have_http_status(:conflict)
+        expect(response.parsed_body['error']).to eq('already_subscribed')
+      end
+    end
+
+    context '不正な plan で InvalidPlanError が起きるとき' do
+      before do
+        allow_any_instance_of(App::Stripe::CheckoutSessionBuilder)
+          .to receive(:call)
+          .and_raise(App::Stripe::CheckoutSessionBuilder::InvalidPlanError)
+      end
+
+      it '422 + error: invalid_plan を返す' do
+        post '/api/v1/pro/checkout', params: params.merge(plan: 'lifetime'),
+                                     headers: auth_headers_for(user), as: :json
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']).to eq('invalid_plan')
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/pro/checkout_spec.rb
+++ b/spec/requests/api/v1/pro/checkout_spec.rb
@@ -61,5 +61,22 @@ RSpec.describe 'Api::V1::Pro::Checkout', type: :request do
         expect(response.parsed_body['error']).to eq('invalid_plan')
       end
     end
+
+    context 'Stripe API エラー（API キー誤設定・ネット障害等）が起きるとき' do
+      let(:builder) { instance_double(App::Stripe::CheckoutSessionBuilder) }
+
+      before do
+        allow(App::Stripe::CheckoutSessionBuilder).to receive(:new).and_return(builder)
+        allow(builder).to receive(:call).and_raise(Stripe::APIConnectionError.new('connection refused'))
+        allow(Sentry).to receive(:capture_exception)
+      end
+
+      it '502 + error: stripe_api_error を返し、Sentry に通知する' do
+        post '/api/v1/pro/checkout', params:, headers: auth_headers_for(user), as: :json
+        expect(response).to have_http_status(:bad_gateway)
+        expect(response.parsed_body['error']).to eq('stripe_api_error')
+        expect(Sentry).to have_received(:capture_exception).with(be_a(Stripe::StripeError), anything)
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/pro/subscription_spec.rb
+++ b/spec/requests/api/v1/pro/subscription_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Pro::Subscription', type: :request do
+  let(:user) { create(:user) }
+
+  describe 'DELETE /api/v1/pro/subscription' do
+    context '未認証のとき' do
+      it '401 を返す' do
+        delete '/api/v1/pro/subscription', as: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '認証済みかつ Stripe Subscription 紐付け済み' do
+      before do
+        user.subscription.update!(stripe_subscription_id: 'sub_test_abc')
+        allow_any_instance_of(App::Stripe::SubscriptionUpdater).to receive(:cancel_at_period_end)
+      end
+
+      it '200 を返す' do
+        delete '/api/v1/pro/subscription', headers: auth_headers_for(user), as: :json
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'Stripe Subscription 未紐付' do
+      before do
+        allow_any_instance_of(App::Stripe::SubscriptionUpdater)
+          .to receive(:cancel_at_period_end)
+          .and_raise(App::Stripe::SubscriptionUpdater::NoStripeSubscriptionError)
+      end
+
+      it '422 + error: no_active_subscription を返す' do
+        delete '/api/v1/pro/subscription', headers: auth_headers_for(user), as: :json
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']).to eq('no_active_subscription')
+      end
+    end
+  end
+
+  describe 'PATCH /api/v1/pro/subscription' do
+    context '未認証のとき' do
+      it '401 を返す' do
+        patch '/api/v1/pro/subscription', params: { plan: 'yearly' }, as: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '正常なプラン変更リクエスト' do
+      before do
+        user.subscription.update!(stripe_subscription_id: 'sub_test_abc')
+        allow_any_instance_of(App::Stripe::SubscriptionUpdater).to receive(:change_plan).with('yearly')
+      end
+
+      it '200 を返す' do
+        patch '/api/v1/pro/subscription', params: { plan: 'yearly' },
+                                          headers: auth_headers_for(user), as: :json
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context '不正な plan' do
+      before do
+        allow_any_instance_of(App::Stripe::SubscriptionUpdater)
+          .to receive(:change_plan)
+          .and_raise(App::Stripe::SubscriptionUpdater::InvalidPlanError)
+      end
+
+      it '422 + error: invalid_plan を返す' do
+        patch '/api/v1/pro/subscription', params: { plan: 'lifetime' },
+                                          headers: auth_headers_for(user), as: :json
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']).to eq('invalid_plan')
+      end
+    end
+
+    context 'Stripe Subscription 未紐付' do
+      before do
+        allow_any_instance_of(App::Stripe::SubscriptionUpdater)
+          .to receive(:change_plan)
+          .and_raise(App::Stripe::SubscriptionUpdater::NoStripeSubscriptionError)
+      end
+
+      it '422 + error: no_active_subscription を返す' do
+        patch '/api/v1/pro/subscription', params: { plan: 'yearly' },
+                                          headers: auth_headers_for(user), as: :json
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']).to eq('no_active_subscription')
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/pro/subscription_spec.rb
+++ b/spec/requests/api/v1/pro/subscription_spec.rb
@@ -2,6 +2,11 @@ require 'rails_helper'
 
 RSpec.describe 'Api::V1::Pro::Subscription', type: :request do
   let(:user) { create(:user) }
+  let(:updater) { instance_double(App::Stripe::SubscriptionUpdater) }
+
+  before do
+    allow(App::Stripe::SubscriptionUpdater).to receive(:new).and_return(updater)
+  end
 
   describe 'DELETE /api/v1/pro/subscription' do
     context '未認証のとき' do
@@ -14,7 +19,7 @@ RSpec.describe 'Api::V1::Pro::Subscription', type: :request do
     context '認証済みかつ Stripe Subscription 紐付け済み' do
       before do
         user.subscription.update!(stripe_subscription_id: 'sub_test_abc')
-        allow_any_instance_of(App::Stripe::SubscriptionUpdater).to receive(:cancel_at_period_end)
+        allow(updater).to receive(:cancel_at_period_end)
       end
 
       it '200 を返す' do
@@ -25,9 +30,7 @@ RSpec.describe 'Api::V1::Pro::Subscription', type: :request do
 
     context 'Stripe Subscription 未紐付' do
       before do
-        allow_any_instance_of(App::Stripe::SubscriptionUpdater)
-          .to receive(:cancel_at_period_end)
-          .and_raise(App::Stripe::SubscriptionUpdater::NoStripeSubscriptionError)
+        allow(updater).to receive(:cancel_at_period_end).and_raise(App::Stripe::SubscriptionUpdater::NoStripeSubscriptionError)
       end
 
       it '422 + error: no_active_subscription を返す' do
@@ -49,7 +52,7 @@ RSpec.describe 'Api::V1::Pro::Subscription', type: :request do
     context '正常なプラン変更リクエスト' do
       before do
         user.subscription.update!(stripe_subscription_id: 'sub_test_abc')
-        allow_any_instance_of(App::Stripe::SubscriptionUpdater).to receive(:change_plan).with('yearly')
+        allow(updater).to receive(:change_plan).with('yearly')
       end
 
       it '200 を返す' do
@@ -61,9 +64,7 @@ RSpec.describe 'Api::V1::Pro::Subscription', type: :request do
 
     context '不正な plan' do
       before do
-        allow_any_instance_of(App::Stripe::SubscriptionUpdater)
-          .to receive(:change_plan)
-          .and_raise(App::Stripe::SubscriptionUpdater::InvalidPlanError)
+        allow(updater).to receive(:change_plan).and_raise(App::Stripe::SubscriptionUpdater::InvalidPlanError)
       end
 
       it '422 + error: invalid_plan を返す' do
@@ -76,9 +77,7 @@ RSpec.describe 'Api::V1::Pro::Subscription', type: :request do
 
     context 'Stripe Subscription 未紐付' do
       before do
-        allow_any_instance_of(App::Stripe::SubscriptionUpdater)
-          .to receive(:change_plan)
-          .and_raise(App::Stripe::SubscriptionUpdater::NoStripeSubscriptionError)
+        allow(updater).to receive(:change_plan).and_raise(App::Stripe::SubscriptionUpdater::NoStripeSubscriptionError)
       end
 
       it '422 + error: no_active_subscription を返す' do

--- a/spec/requests/api/v1/pro/subscription_spec.rb
+++ b/spec/requests/api/v1/pro/subscription_spec.rb
@@ -22,9 +22,10 @@ RSpec.describe 'Api::V1::Pro::Subscription', type: :request do
         allow(updater).to receive(:cancel_at_period_end)
       end
 
-      it '200 を返す' do
+      it '200 + 解約申請メッセージを返す' do
         delete '/api/v1/pro/subscription', headers: auth_headers_for(user), as: :json
         expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['message']).to eq('解約申請を受け付けました')
       end
     end
 
@@ -37,6 +38,20 @@ RSpec.describe 'Api::V1::Pro::Subscription', type: :request do
         delete '/api/v1/pro/subscription', headers: auth_headers_for(user), as: :json
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body['error']).to eq('no_active_subscription')
+      end
+    end
+
+    context 'Stripe API エラーが起きるとき' do
+      before do
+        allow(updater).to receive(:cancel_at_period_end).and_raise(Stripe::APIConnectionError.new('boom'))
+        allow(Sentry).to receive(:capture_exception)
+      end
+
+      it '502 + error: stripe_api_error を返し Sentry 通知' do
+        delete '/api/v1/pro/subscription', headers: auth_headers_for(user), as: :json
+        expect(response).to have_http_status(:bad_gateway)
+        expect(response.parsed_body['error']).to eq('stripe_api_error')
+        expect(Sentry).to have_received(:capture_exception)
       end
     end
   end
@@ -55,10 +70,11 @@ RSpec.describe 'Api::V1::Pro::Subscription', type: :request do
         allow(updater).to receive(:change_plan).with('yearly')
       end
 
-      it '200 を返す' do
+      it '200 + プラン変更メッセージを返す' do
         patch '/api/v1/pro/subscription', params: { plan: 'yearly' },
                                           headers: auth_headers_for(user), as: :json
         expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['message']).to eq('プラン変更を受け付けました')
       end
     end
 
@@ -85,6 +101,21 @@ RSpec.describe 'Api::V1::Pro::Subscription', type: :request do
                                           headers: auth_headers_for(user), as: :json
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body['error']).to eq('no_active_subscription')
+      end
+    end
+
+    context 'Stripe API エラーが起きるとき' do
+      before do
+        allow(updater).to receive(:change_plan).and_raise(Stripe::APIConnectionError.new('boom'))
+        allow(Sentry).to receive(:capture_exception)
+      end
+
+      it '502 + error: stripe_api_error を返し Sentry 通知' do
+        patch '/api/v1/pro/subscription', params: { plan: 'yearly' },
+                                          headers: auth_headers_for(user), as: :json
+        expect(response).to have_http_status(:bad_gateway)
+        expect(response.parsed_body['error']).to eq('stripe_api_error')
+        expect(Sentry).to have_received(:capture_exception)
       end
     end
   end

--- a/spec/requests/api/v1/webhooks/stripe_spec.rb
+++ b/spec/requests/api/v1/webhooks/stripe_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Webhooks::Stripe', type: :request do
+  let(:secret) { 'whsec_test_xyz' }
+  let(:raw_payload) do
+    Rails.root.join('spec/fixtures/stripe/checkout_session_completed.json').read
+  end
+  let(:event_id) { 'evt_test_checkout_completed_001' }
+
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('STRIPE_WEBHOOK_SECRET').and_return(secret)
+  end
+
+  # construct_event をスタブして、本物の Stripe::Event を返す or 例外を投げる
+  def stub_event_construction(success:)
+    if success
+      event = Stripe::Event.construct_from(JSON.parse(raw_payload))
+      allow(Stripe::Webhook).to receive(:construct_event).and_return(event)
+    else
+      allow(Stripe::Webhook).to receive(:construct_event)
+        .and_raise(Stripe::SignatureVerificationError.new('invalid sig', 'sig_header'))
+    end
+  end
+
+  describe 'POST /api/v1/webhooks/stripe' do
+    context '署名検証通過 + 新規 event のとき' do
+      before { stub_event_construction(success: true) }
+
+      it '200 を返し、WebhookEvent を作成して Job を enqueue する' do
+        expect do
+          post '/api/v1/webhooks/stripe',
+               params: raw_payload,
+               headers: { 'CONTENT_TYPE' => 'application/json', 'Stripe-Signature' => 't=1,v1=abc' }
+        end.to have_enqueued_job(App::Stripe::WebhookJob).exactly(:once)
+
+        expect(response).to have_http_status(:ok)
+        event = WebhookEvent.find_by(provider: 'stripe', external_event_id: event_id)
+        expect(event).to be_present
+        expect(event.status).to eq('pending')
+      end
+
+      context '同一 event_id を 2 回送信したとき' do
+        it '2 回目は Job を enqueue しない（冪等性）' do
+          post '/api/v1/webhooks/stripe',
+               params: raw_payload,
+               headers: { 'CONTENT_TYPE' => 'application/json', 'Stripe-Signature' => 't=1,v1=abc' }
+
+          expect do
+            post '/api/v1/webhooks/stripe',
+                 params: raw_payload,
+                 headers: { 'CONTENT_TYPE' => 'application/json', 'Stripe-Signature' => 't=1,v1=abc' }
+          end.not_to have_enqueued_job(App::Stripe::WebhookJob)
+
+          expect(response).to have_http_status(:ok)
+          expect(WebhookEvent.where(provider: 'stripe', external_event_id: event_id).count).to eq(1)
+        end
+      end
+    end
+
+    context '署名検証失敗のとき' do
+      before { stub_event_construction(success: false) }
+
+      it '401 を返し、Job を enqueue しない' do
+        expect do
+          post '/api/v1/webhooks/stripe',
+               params: raw_payload,
+               headers: { 'CONTENT_TYPE' => 'application/json', 'Stripe-Signature' => 'invalid' }
+        end.not_to have_enqueued_job(App::Stripe::WebhookJob)
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(WebhookEvent.count).to eq(0)
+      end
+    end
+
+    context 'WebhookEvent の作成中に DB エラーが発生したとき' do
+      before do
+        stub_event_construction(success: true)
+        allow(WebhookEvent).to receive(:find_or_create_pending!).and_raise(ActiveRecord::ConnectionNotEstablished, 'db down')
+        allow(Sentry).to receive(:capture_exception)
+      end
+
+      it 'Sentry 通知 + 500 を返す（Stripe 側の自動リトライに任せる）' do
+        post '/api/v1/webhooks/stripe',
+             params: raw_payload,
+             headers: { 'CONTENT_TYPE' => 'application/json', 'Stripe-Signature' => 't=1,v1=abc' }
+
+        expect(Sentry).to have_received(:capture_exception)
+        expect(response).to have_http_status(:internal_server_error)
+      end
+    end
+  end
+end

--- a/spec/services/app/stripe/checkout_session_builder_spec.rb
+++ b/spec/services/app/stripe/checkout_session_builder_spec.rb
@@ -106,10 +106,10 @@ RSpec.describe App::Stripe::CheckoutSessionBuilder do
   end
 
   def travel_to_inside_early_window
-    allow(Time).to receive(:current).and_return(Time.zone.parse('2026-06-01 12:00 JST'))
+    travel_to Time.zone.parse('2026-06-01 12:00 JST')
   end
 
   def travel_to_outside_early_window
-    allow(Time).to receive(:current).and_return(Time.zone.parse('2026-08-01 12:00 JST'))
+    travel_to Time.zone.parse('2026-08-01 12:00 JST')
   end
 end

--- a/spec/services/app/stripe/checkout_session_builder_spec.rb
+++ b/spec/services/app/stripe/checkout_session_builder_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+RSpec.describe App::Stripe::CheckoutSessionBuilder do
+  let(:user) { create(:user) }
+  let(:plan) { 'monthly' }
+  let(:success_url) { 'https://buzzbase.jp/pro/success' }
+  let(:cancel_url) { 'https://buzzbase.jp/pro/cancel' }
+  let(:builder) { described_class.new(user:, plan:, success_url:, cancel_url:) }
+  let(:stripe_session) { instance_double(Stripe::Checkout::Session, url: 'https://checkout.stripe.com/c/pay/xxx') }
+
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('STRIPE_PRICE_ID_MONTHLY').and_return('price_monthly_test_123')
+    allow(ENV).to receive(:fetch).with('STRIPE_PRICE_ID_YEARLY').and_return('price_yearly_test_456')
+    allow(ENV).to receive(:fetch).with('EARLY_SUBSCRIBER_WINDOW_START', any_args).and_call_original
+    allow(ENV).to receive(:fetch).with('EARLY_SUBSCRIBER_WINDOW_END', any_args).and_call_original
+    allow(Stripe::Checkout::Session).to receive(:create).and_return(stripe_session)
+  end
+
+  describe '#call' do
+    context '通常ケース（has_used_trial=false、早期特典期間外）' do
+      before { travel_to_outside_early_window }
+
+      it 'Stripe::Checkout::Session.create を期待値で呼び出す' do
+        builder.call
+        expect(Stripe::Checkout::Session).to have_received(:create) do |args|
+          expect(args[:mode]).to eq('subscription')
+          expect(args[:customer_email]).to eq(user.email)
+          expect(args[:line_items]).to eq([{ price: 'price_monthly_test_123', quantity: 1 }])
+          expect(args[:subscription_data][:trial_period_days]).to eq(7)
+          expect(args[:subscription_data][:metadata]).to eq(user_id: user.id.to_s, plan: 'monthly')
+          expect(args[:success_url]).to eq(success_url)
+          expect(args[:cancel_url]).to eq(cancel_url)
+        end
+      end
+
+      it 'Stripe Session を返す' do
+        expect(builder.call).to eq(stripe_session)
+      end
+    end
+
+    context '早期特典期間内' do
+      before { travel_to_inside_early_window }
+
+      it 'trial_period_days: 30 で呼び出す' do
+        builder.call
+        expect(Stripe::Checkout::Session).to have_received(:create) do |args|
+          expect(args[:subscription_data][:trial_period_days]).to eq(30)
+        end
+      end
+    end
+
+    context '再加入（has_used_trial=true）' do
+      before do
+        user.subscription.update!(has_used_trial: true)
+        travel_to_inside_early_window
+      end
+
+      it 'trial_period_days を渡さない（即時課金）' do
+        builder.call
+        expect(Stripe::Checkout::Session).to have_received(:create) do |args|
+          expect(args[:subscription_data]).not_to have_key(:trial_period_days)
+        end
+      end
+    end
+
+    context 'yearly プラン指定時' do
+      let(:plan) { 'yearly' }
+
+      it 'STRIPE_PRICE_ID_YEARLY を line_items に渡す' do
+        builder.call
+        expect(Stripe::Checkout::Session).to have_received(:create) do |args|
+          expect(args[:line_items]).to eq([{ price: 'price_yearly_test_456', quantity: 1 }])
+        end
+      end
+    end
+
+    context '既加入（pro_active）のとき' do
+      before do
+        user.subscription.update!(
+          status: 'active',
+          plan_type: 'monthly',
+          platform: 'ios',
+          expires_at: 30.days.from_now,
+          has_used_trial: true
+        )
+      end
+
+      it 'AlreadySubscribedError を raise する' do
+        expect { builder.call }.to raise_error(described_class::AlreadySubscribedError)
+      end
+
+      it 'Stripe API を呼ばない' do
+        expect { builder.call }.to raise_error(described_class::AlreadySubscribedError)
+        expect(Stripe::Checkout::Session).not_to have_received(:create)
+      end
+    end
+
+    context '不正な plan のとき' do
+      let(:plan) { 'lifetime' }
+
+      it 'InvalidPlanError を raise する' do
+        expect { builder.call }.to raise_error(described_class::InvalidPlanError)
+      end
+    end
+  end
+
+  def travel_to_inside_early_window
+    allow(Time).to receive(:current).and_return(Time.zone.parse('2026-06-01 12:00 JST'))
+  end
+
+  def travel_to_outside_early_window
+    allow(Time).to receive(:current).and_return(Time.zone.parse('2026-08-01 12:00 JST'))
+  end
+end

--- a/spec/services/app/stripe/event_dispatcher_spec.rb
+++ b/spec/services/app/stripe/event_dispatcher_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe App::Stripe::EventDispatcher do
+  def payload_for(event_type)
+    App::Stripe::WebhookPayload.new(
+      Stripe::Event.construct_from(id: 'evt_x', type: event_type, data: { object: {} })
+    )
+  end
+
+  describe '.handler_for' do
+    it 'checkout.session.completed を CheckoutSessionCompletedHandler に dispatch する' do
+      handler = described_class.handler_for(payload_for('checkout.session.completed'))
+      expect(handler).to be_an_instance_of(App::Stripe::Handlers::CheckoutSessionCompletedHandler)
+    end
+
+    it '未対応の event_type は UnhandledEventHandler に fallback する' do
+      handler = described_class.handler_for(payload_for('invoice.payment_failed'))
+      expect(handler).to be_an_instance_of(App::Stripe::Handlers::UnhandledEventHandler)
+    end
+  end
+end

--- a/spec/services/app/stripe/handlers/checkout_session_completed_handler_spec.rb
+++ b/spec/services/app/stripe/handlers/checkout_session_completed_handler_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe App::Stripe::Handlers::CheckoutSessionCompletedHandler do
+  let(:user) { create(:user) }
+  let(:fixture) do
+    JSON.parse(Rails.root.join('spec/fixtures/stripe/checkout_session_completed.json').read).tap do |data|
+      data['data']['object']['metadata']['user_id'] = user.id.to_s
+    end
+  end
+  let(:event) { Stripe::Event.construct_from(fixture) }
+  let(:payload) { App::Stripe::WebhookPayload.new(event) }
+  let(:handler) { described_class.new(payload) }
+
+  describe '#call' do
+    context '正常系（metadata.user_id から User を解決できる）' do
+      it 'Subscription に stripe_customer_id / stripe_subscription_id を保存する' do
+        handler.call
+        subscription = user.reload.subscription
+        expect(subscription.stripe_customer_id).to eq('cus_test_abc123')
+        expect(subscription.stripe_subscription_id).to eq('sub_test_abc123')
+      end
+
+      it 'status / plan_type 等は触らない（RevenueCat 経由で更新される）' do
+        original_status = user.subscription.status
+        handler.call
+        expect(user.reload.subscription.status).to eq(original_status)
+      end
+    end
+
+    context 'metadata に user_id が無いとき' do
+      before { fixture['data']['object']['metadata'] = {} }
+
+      it 'Sentry warning + 処理スキップ' do
+        allow(Sentry).to receive(:capture_message)
+        handler.call
+        expect(Sentry).to have_received(:capture_message).with(
+          a_string_including('user_id'),
+          hash_including(level: :warning)
+        )
+      end
+    end
+
+    context '未知の user_id のとき' do
+      before { fixture['data']['object']['metadata']['user_id'] = '99999999' }
+
+      it 'Sentry warning + Subscription 更新せず' do
+        allow(Sentry).to receive(:capture_message)
+        handler.call
+        expect(Sentry).to have_received(:capture_message).with(
+          a_string_including('user not found'),
+          hash_including(level: :warning)
+        )
+      end
+    end
+  end
+end

--- a/spec/services/app/stripe/subscription_updater_spec.rb
+++ b/spec/services/app/stripe/subscription_updater_spec.rb
@@ -32,7 +32,10 @@ RSpec.describe App::Stripe::SubscriptionUpdater do
 
   describe '#change_plan' do
     let(:stripe_subscription_item) { instance_double(Stripe::SubscriptionItem, id: 'si_test_abc') }
-    let(:stripe_subscription) { instance_double(Stripe::Subscription, items: double(data: [stripe_subscription_item])) }
+    # Stripe::ListObject#data は method_missing 経由のため verified double できない。
+    # 必要なインターフェース (.data) のみ持つ軽量 Struct で代替する。
+    let(:stripe_items) { Struct.new(:data).new([stripe_subscription_item]) }
+    let(:stripe_subscription) { instance_double(Stripe::Subscription, items: stripe_items) }
 
     context 'stripe_subscription_id が紐付いていないとき' do
       it 'NoStripeSubscriptionError を raise する' do

--- a/spec/services/app/stripe/subscription_updater_spec.rb
+++ b/spec/services/app/stripe/subscription_updater_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe App::Stripe::SubscriptionUpdater do
+  let(:user) { create(:user) }
+  let(:updater) { described_class.new(user) }
+
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('STRIPE_PRICE_ID_MONTHLY').and_return('price_monthly')
+    allow(ENV).to receive(:fetch).with('STRIPE_PRICE_ID_YEARLY').and_return('price_yearly')
+  end
+
+  describe '#cancel_at_period_end' do
+    context 'stripe_subscription_id が紐付いていないとき' do
+      it 'NoStripeSubscriptionError を raise する' do
+        expect { updater.cancel_at_period_end }.to raise_error(described_class::NoStripeSubscriptionError)
+      end
+    end
+
+    context 'stripe_subscription_id が紐付いているとき' do
+      before do
+        user.subscription.update!(stripe_subscription_id: 'sub_test_abc123')
+        allow(Stripe::Subscription).to receive(:update)
+      end
+
+      it 'Stripe::Subscription.update で cancel_at_period_end: true を呼び出す' do
+        updater.cancel_at_period_end
+        expect(Stripe::Subscription).to have_received(:update).with('sub_test_abc123', cancel_at_period_end: true)
+      end
+    end
+  end
+
+  describe '#change_plan' do
+    let(:stripe_subscription_item) { instance_double(Stripe::SubscriptionItem, id: 'si_test_abc') }
+    let(:stripe_subscription) { instance_double(Stripe::Subscription, items: double(data: [stripe_subscription_item])) }
+
+    context 'stripe_subscription_id が紐付いていないとき' do
+      it 'NoStripeSubscriptionError を raise する' do
+        expect { updater.change_plan('yearly') }.to raise_error(described_class::NoStripeSubscriptionError)
+      end
+    end
+
+    context '不正な plan のとき' do
+      before { user.subscription.update!(stripe_subscription_id: 'sub_test_abc123') }
+
+      it 'InvalidPlanError を raise する' do
+        expect { updater.change_plan('lifetime') }.to raise_error(described_class::InvalidPlanError)
+      end
+    end
+
+    context '正常時' do
+      before do
+        user.subscription.update!(stripe_subscription_id: 'sub_test_abc123')
+        allow(Stripe::Subscription).to receive(:retrieve).with('sub_test_abc123').and_return(stripe_subscription)
+        allow(Stripe::Subscription).to receive(:update)
+      end
+
+      it 'プラン変更 API を期待値で呼ぶ（proration 有効）' do
+        updater.change_plan('yearly')
+        expect(Stripe::Subscription).to have_received(:update).with(
+          'sub_test_abc123',
+          items: [{ id: 'si_test_abc', price: 'price_yearly' }],
+          proration_behavior: 'create_prorations'
+        )
+      end
+    end
+  end
+end

--- a/spec/services/app/stripe/webhook_payload_spec.rb
+++ b/spec/services/app/stripe/webhook_payload_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe App::Stripe::WebhookPayload do
+  let(:fixture) do
+    JSON.parse(Rails.root.join('spec/fixtures/stripe/checkout_session_completed.json').read)
+  end
+  let(:event) { Stripe::Event.construct_from(fixture) }
+  let(:payload) { described_class.new(event) }
+
+  describe 'event metadata getters' do
+    it 'event_id を返す' do
+      expect(payload.event_id).to eq('evt_test_checkout_completed_001')
+    end
+
+    it 'event_type を返す' do
+      expect(payload.event_type).to eq('checkout.session.completed')
+    end
+  end
+
+  describe '#data_object' do
+    it 'data.object を Hash 風に返す' do
+      expect(payload.data_object[:id]).to eq('cs_test_abc123')
+      expect(payload.data_object[:customer]).to eq('cus_test_abc123')
+    end
+  end
+
+  describe '#metadata' do
+    it 'data.object.metadata を返す' do
+      expect(payload.metadata[:user_id]).to eq('1')
+      expect(payload.metadata[:plan]).to eq('monthly')
+    end
+
+    context 'metadata が空のとき' do
+      let(:fixture) do
+        base = JSON.parse(Rails.root.join('spec/fixtures/stripe/customer_subscription_deleted.json').read)
+        base
+      end
+
+      it '空ハッシュを返す（nil safety）' do
+        expect(payload.metadata).to eq({})
+      end
+    end
+  end
+
+  describe '#customer_id / #subscription_id' do
+    it 'data.object から取得する' do
+      expect(payload.customer_id).to eq('cus_test_abc123')
+      expect(payload.subscription_id).to eq('sub_test_abc123')
+    end
+  end
+
+  describe '#to_h' do
+    it '元 event の to_hash を返す' do
+      hash = payload.to_h
+      expect(hash[:id]).to eq('evt_test_checkout_completed_001')
+      expect(hash[:type]).to eq('checkout.session.completed')
+    end
+  end
+end

--- a/spec/services/app/stripe/webhook_processor_spec.rb
+++ b/spec/services/app/stripe/webhook_processor_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+RSpec.describe App::Stripe::WebhookProcessor do
+  let(:user) { create(:user) }
+  let(:fixture) do
+    JSON.parse(Rails.root.join('spec/fixtures/stripe/checkout_session_completed.json').read).tap do |data|
+      data['data']['object']['metadata']['user_id'] = user.id.to_s
+    end
+  end
+  let(:event) { Stripe::Event.construct_from(fixture) }
+  let(:webhook_event) do
+    create(:webhook_event,
+           provider: 'stripe',
+           external_event_id: event.id,
+           event_type: event.type,
+           payload: event.to_hash)
+  end
+
+  describe '#process' do
+    subject(:process!) { described_class.new(webhook_event).process }
+
+    context 'webhook_event がまだ pending のとき' do
+      it 'status を processed に更新する' do
+        expect { process! }.to change { webhook_event.reload.status }.from('pending').to('processed')
+      end
+
+      it 'CheckoutSessionCompletedHandler#call が呼ばれ、Subscription に Stripe ID が保存される' do
+        process!
+        expect(user.reload.subscription.stripe_customer_id).to eq('cus_test_abc123')
+      end
+    end
+
+    context 'webhook_event が既に processed のとき' do
+      let(:webhook_event) do
+        create(:webhook_event, :processed,
+               provider: 'stripe',
+               external_event_id: event.id,
+               event_type: event.type,
+               payload: event.to_hash)
+      end
+
+      it '冪等性のため再処理しない' do
+        original_processed_at = webhook_event.processed_at
+        process!
+        expect(webhook_event.reload.processed_at).to be_within(1.second).of(original_processed_at)
+      end
+    end
+
+    context 'handler が例外を投げたとき' do
+      let(:failing_handler) { instance_double(App::Stripe::Handlers::CheckoutSessionCompletedHandler) }
+
+      before do
+        allow(failing_handler).to receive(:call).and_raise(StandardError, 'boom')
+        allow(App::Stripe::EventDispatcher).to receive(:handler_for).and_return(failing_handler)
+        allow(Sentry).to receive(:capture_exception)
+      end
+
+      it 'webhook_event を failed に遷移させ Sentry 通知し再 raise する' do
+        expect { process! }.to raise_error(StandardError, 'boom')
+        expect(Sentry).to have_received(:capture_exception).with(
+          instance_of(StandardError),
+          hash_including(tags: hash_including(source: 'stripe_webhook'))
+        )
+        expect(webhook_event.reload.status).to eq('failed')
+        expect(webhook_event.error_message).to include('boom')
+      end
+    end
+
+    context '未対応 event_type のとき' do
+      let(:other_event) do
+        Stripe::Event.construct_from(
+          id: 'evt_unhandled',
+          type: 'invoice.payment_failed',
+          data: { object: {} }
+        )
+      end
+      let(:webhook_event) do
+        create(:webhook_event,
+               provider: 'stripe',
+               external_event_id: other_event.id,
+               event_type: other_event.type,
+               payload: other_event.to_hash)
+      end
+
+      it 'processed 扱いにし、状態は触らない（受信記録のみ）' do
+        process!
+        expect(webhook_event.reload.status).to eq('processed')
+      end
+    end
+  end
+end

--- a/spec/services/app/stripe/webhook_processor_spec.rb
+++ b/spec/services/app/stripe/webhook_processor_spec.rb
@@ -64,6 +64,25 @@ RSpec.describe App::Stripe::WebhookProcessor do
         expect(webhook_event.reload.status).to eq('failed')
         expect(webhook_event.error_message).to include('boom')
       end
+
+      context '更に mark_failed! 自体も例外で落ちるとき' do
+        before do
+          allow(webhook_event).to receive(:mark_failed!).and_raise(StandardError, 'db down')
+        end
+
+        it '元の handler 例外を必ず Sentry に届け、mark_failed! の例外も別タグで通知する' do
+          expect { process! }.to raise_error(StandardError, 'boom')
+
+          expect(Sentry).to have_received(:capture_exception).with(
+            instance_of(StandardError),
+            hash_including(tags: hash_including(source: 'stripe_webhook_mark_failed'))
+          )
+          expect(Sentry).to have_received(:capture_exception).with(
+            having_attributes(message: 'boom'),
+            hash_including(tags: hash_including(source: 'stripe_webhook'))
+          )
+        end
+      end
     end
 
     context '未対応 event_type のとき' do


### PR DESCRIPTION
親 Issue: ippei-shimizu/buzzbase#347
Phase: B（バックエンド実装）
依存: #345 (B1) / #346 (B2) マージ済み

## Summary

Web 経由の Pro 加入を Stripe Checkout で受け、解約・プラン変更も Stripe API 経由で提供する。Stripe Webhook は \`checkout.session.completed\` のみ本処理し、他イベントは受信記録のみ（状態遷移は RevenueCat 経由が主信号）。

## 追加した endpoint

- \`POST /api/v1/pro/checkout\`: Stripe Checkout Session を生成 → \`{ checkout_url }\` を返す
- \`DELETE /api/v1/pro/subscription\`: \`cancel_at_period_end: true\` で解約申請
- \`PATCH /api/v1/pro/subscription\`: 月額↔年額のプラン変更（\`proration_behavior: create_prorations\`）
- \`POST /api/v1/webhooks/stripe\`: Webhook 受信（署名検証 + 冪等性 + 非同期 Job 起動）

## 責務分離（App::Stripe 名前空間で gem 衝突回避）

\`app/services/app/stripe/\`:
- \`WebhookPayload\`: Stripe Event 値オブジェクト
- \`CheckoutSessionBuilder\`: 既加入ガード + TrialDaysCalculator 連携 + Checkout 生成
- \`SubscriptionUpdater\`: 解約 / プラン変更の Stripe API ラッパー
- \`WebhookProcessor\`: 冪等性 + 例外時 Sentry
- \`EventDispatcher\`: event_type → Handler ルックアップ
- \`Handlers::BaseHandler\` / \`CheckoutSessionCompletedHandler\` / \`UnhandledEventHandler\`

\`app/jobs/app/stripe/webhook_job.rb\`: \`retry_on StandardError, attempts: 5\`

## DB

- マイグレーション: \`subscriptions\` に \`stripe_customer_id\` / \`stripe_subscription_id\` 追加（partial unique index）
- \`CheckoutSessionCompletedHandler\` が Stripe ID 2 つを保存し、後続の \`cancel_at_period_end\` / \`change_plan\` API 呼び出しで参照

## 設計上の注意

- \`App::Stripe::*\` 内では gem の \`::Stripe::*\` を必ず先頭 \`::\` 付きで参照
- \`Stripe::Webhook.construct_event\` は raw body 必須のため \`request.body.read\` で取得
- 二重課金防止: Checkout Session 生成時に \`subscription_or_default.pro_active?\` で 409 返却
- 状態遷移は RevenueCat 経由で正規化 → Web 解約後の \`cancelled\` ステータスも RevenueCat の CANCELLATION Webhook で反映される

## 環境変数（リリース時に Heroku に設定）

- \`STRIPE_PUBLISHABLE_KEY\`
- \`STRIPE_WEBHOOK_SECRET\`
- \`STRIPE_PRICE_ID_MONTHLY\` / \`STRIPE_PRICE_ID_YEARLY\`

## Test plan

- [x] \`docker compose exec back bundle exec rspec\` → 777 examples / 0 failures（B2 完了時 727 から +50）
- [x] \`docker compose exec back bundle exec rubocop\` → 305 files / 0 offenses（\`rubocop:disable\` 不使用）
- [x] verified double / instance_double で書き、\`allow_any_instance_of\` も不使用
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)