### PR TITLE
Add: 解約引き止め + アンケート (Flipper 制御) (#349)

### DIFF
--- a/app/controllers/api/v1/pro/cancellation_feedbacks_controller.rb
+++ b/app/controllers/api/v1/pro/cancellation_feedbacks_controller.rb
@@ -10,10 +10,16 @@ module Api
         def create
           return head :not_found unless Flipper.enabled?(:cancellation_survey, current_api_v1_user)
 
+          # enum 範囲外の値は build 時に ArgumentError を投げるため、事前にホワイトリストで弾いて
+          # 422 invalid_reason に揃える。nil / blank は通常の presence バリデーションに任せる。
+          reason = feedback_params[:reason]
+          if reason.present? && CancellationFeedback::REASONS.exclude?(reason)
+            return render json: { error: 'invalid_reason' }, status: :unprocessable_entity
+          end
+
           feedback = current_api_v1_user.cancellation_feedbacks.build(
             subscription: current_api_v1_user.subscription,
-            reason: params[:reason],
-            note: params[:note]
+            **feedback_params.to_h.symbolize_keys
           )
 
           if feedback.save
@@ -21,12 +27,13 @@ module Api
           else
             render json: { error: error_code_for(feedback) }, status: :unprocessable_entity
           end
-        rescue ArgumentError
-          # enum 外の値が来ると ArgumentError になるため、422 + invalid_reason として返す。
-          render json: { error: 'invalid_reason' }, status: :unprocessable_entity
         end
 
         private
+
+        def feedback_params
+          params.permit(:reason, :note)
+        end
 
         # クライアントへ「何が原因で失敗したか」をシンプルなコード文字列で返す。
         # i18n 化されたエラーメッセージに依存せず、属性値で reason の状態を判定する。

--- a/app/controllers/api/v1/pro/cancellation_feedbacks_controller.rb
+++ b/app/controllers/api/v1/pro/cancellation_feedbacks_controller.rb
@@ -1,0 +1,44 @@
+module Api
+  module V1
+    module Pro
+      # POST /api/v1/pro/cancellation_feedbacks
+      # 解約直後の引き止めモーダル後のアンケート回答を保存する。
+      # Flipper :cancellation_survey で機能フラグ制御（無効時はエンドポイント自体を隠す）。
+      class CancellationFeedbacksController < ApplicationController
+        before_action :authenticate_api_v1_user!
+
+        def create
+          return head :not_found unless Flipper.enabled?(:cancellation_survey, current_api_v1_user)
+
+          feedback = current_api_v1_user.cancellation_feedbacks.build(
+            subscription: current_api_v1_user.subscription,
+            reason: params[:reason],
+            note: params[:note]
+          )
+
+          if feedback.save
+            render json: { id: feedback.id }, status: :created
+          else
+            render json: { error: error_code_for(feedback) }, status: :unprocessable_entity
+          end
+        rescue ArgumentError
+          # enum 外の値が来ると ArgumentError になるため、422 + invalid_reason として返す。
+          render json: { error: 'invalid_reason' }, status: :unprocessable_entity
+        end
+
+        private
+
+        # クライアントへ「何が原因で失敗したか」をシンプルなコード文字列で返す。
+        # i18n 化されたエラーメッセージに依存せず、属性値で reason の状態を判定する。
+        def error_code_for(feedback)
+          if feedback.errors[:reason].any?
+            return feedback.reason.blank? ? 'reason_required' : 'invalid_reason'
+          end
+          return 'note_too_long' if feedback.errors[:note].any?
+
+          'invalid'
+        end
+      end
+    end
+  end
+end

--- a/app/models/cancellation_feedback.rb
+++ b/app/models/cancellation_feedback.rb
@@ -4,9 +4,11 @@ class CancellationFeedback < ApplicationRecord
   belongs_to :user
   belongs_to :subscription, optional: true
 
+  # 範囲外の値は enum が ArgumentError で先に弾くため、inclusion バリデーションは不要。
+  # presence のみでよい（nil / blank は presence で、範囲外は enum で弾かれる）。
   REASONS = %w[expensive less_usage feature_missing competitor other].freeze
   enum reason: REASONS.index_with(&:itself), _prefix: :reason
 
-  validates :reason, presence: true, inclusion: { in: REASONS }
+  validates :reason, presence: true
   validates :note, length: { maximum: 1000 }, allow_blank: true
 end

--- a/app/models/cancellation_feedback.rb
+++ b/app/models/cancellation_feedback.rb
@@ -1,0 +1,12 @@
+# 解約理由アンケートの回答を保存する。
+# Flipper :cancellation_survey で有効化されているユーザーからの POST のみを受け取る。
+class CancellationFeedback < ApplicationRecord
+  belongs_to :user
+  belongs_to :subscription, optional: true
+
+  REASONS = %w[expensive less_usage feature_missing competitor other].freeze
+  enum reason: REASONS.index_with(&:itself), _prefix: :reason
+
+  validates :reason, presence: true, inclusion: { in: REASONS }
+  validates :note, length: { maximum: 1000 }, allow_blank: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ActiveRecord::Base
   mount_uploader :image, AvatarUploader
   has_one :subscription, dependent: :destroy
   has_many :user_subscription_events, dependent: :destroy
+  has_many :cancellation_feedbacks, dependent: :destroy
   has_many :user_positions, dependent: :destroy
   has_many :positions, through: :user_positions
   belongs_to :team, foreign_key: 'user_id', primary_key: 'id', optional: true, inverse_of: :user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,7 @@ Rails.application.routes.draw do
         resources :entitlements, only: %i[index]
         resource :checkout, only: %i[create], controller: 'checkout'
         resource :subscription, only: %i[destroy update], controller: 'subscription'
+        resources :cancellation_feedbacks, only: %i[create]
       end
 
       namespace :webhooks do

--- a/db/migrate/20260525222301_create_cancellation_feedbacks.rb
+++ b/db/migrate/20260525222301_create_cancellation_feedbacks.rb
@@ -1,0 +1,12 @@
+class CreateCancellationFeedbacks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :cancellation_feedbacks do |t|
+      t.references :user, null: false, foreign_key: true
+      # subscription が消えても feedback は保持したいので nullable + on_delete: :nullify。
+      t.references :subscription, foreign_key: { on_delete: :nullify }
+      t.string :reason, null: false
+      t.text :note
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_24_111501) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_25_222301) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -142,6 +142,17 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_24_111501) do
     t.integer "sacrifice_fly"
     t.index ["game_result_id"], name: "index_batting_averages_on_game_result_id", unique: true
     t.index ["user_id"], name: "index_batting_averages_on_user_id"
+  end
+
+  create_table "cancellation_feedbacks", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "subscription_id"
+    t.string "reason", null: false
+    t.text "note"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["subscription_id"], name: "index_cancellation_feedbacks_on_subscription_id"
+    t.index ["user_id"], name: "index_cancellation_feedbacks_on_user_id"
   end
 
   create_table "device_tokens", force: :cascade do |t|
@@ -626,6 +637,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_24_111501) do
   add_foreign_key "admin_refresh_tokens", "admin_users"
   add_foreign_key "baseball_notes", "users"
   add_foreign_key "batting_averages", "users"
+  add_foreign_key "cancellation_feedbacks", "subscriptions", on_delete: :nullify
+  add_foreign_key "cancellation_feedbacks", "users"
   add_foreign_key "device_tokens", "users"
   add_foreign_key "game_results", "batting_averages"
   add_foreign_key "game_results", "match_results", on_delete: :cascade

--- a/spec/factories/cancellation_feedbacks.rb
+++ b/spec/factories/cancellation_feedbacks.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :cancellation_feedback do
+    association :user
+    subscription { user.subscription }
+    reason { 'expensive' }
+    note { nil }
+
+    trait :with_note do
+      note { 'もう少し安ければ続けたかった' }
+    end
+  end
+end

--- a/spec/factories/cancellation_feedbacks.rb
+++ b/spec/factories/cancellation_feedbacks.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :cancellation_feedback do
-    association :user
+    user
     subscription { user.subscription }
     reason { 'expensive' }
     note { nil }

--- a/spec/jobs/pro_expiring_reminder_job_spec.rb
+++ b/spec/jobs/pro_expiring_reminder_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ProExpiringReminderJob, type: :job do
     context '3 日後に期限切れる cancelled ユーザー' do
       let!(:cancelled_user) do
         user = create(:user)
-        user.subscription.update!(status: 'cancelled', expires_at: 3.days.from_now + 6.hours, cancelled_at: 2.days.ago)
+        user.subscription.update!(status: 'cancelled', expires_at: 3.days.from_now.beginning_of_day + 6.hours, cancelled_at: 2.days.ago)
         user
       end
 
@@ -31,7 +31,8 @@ RSpec.describe ProExpiringReminderJob, type: :job do
     context '3 日後に期限切れる billing_issue ユーザー' do
       let!(:billing_issue_user) do
         user = create(:user)
-        user.subscription.update!(status: 'billing_issue', expires_at: 3.days.from_now + 8.hours, billing_issue_at: 1.day.ago)
+        user.subscription.update!(status: 'billing_issue', expires_at: 3.days.from_now.beginning_of_day + 8.hours,
+                                  billing_issue_at: 1.day.ago)
         user
       end
 

--- a/spec/jobs/trial_expiring_reminder_job_spec.rb
+++ b/spec/jobs/trial_expiring_reminder_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe TrialExpiringReminderJob, type: :job do
     context '3 日後ピッタリに期限切れる trial ユーザーが居るとき' do
       let!(:target_user) do
         user = create(:user)
-        user.subscription.update!(status: 'trial', expires_at: 3.days.from_now + 12.hours)
+        user.subscription.update!(status: 'trial', expires_at: 3.days.from_now.beginning_of_day + 12.hours)
         user
       end
 
@@ -52,12 +52,12 @@ RSpec.describe TrialExpiringReminderJob, type: :job do
     context '1 ユーザーへの送信が例外を投げたとき' do
       let!(:failing_user) do
         user = create(:user)
-        user.subscription.update!(status: 'trial', expires_at: 3.days.from_now + 12.hours)
+        user.subscription.update!(status: 'trial', expires_at: 3.days.from_now.beginning_of_day + 12.hours)
         user
       end
       let!(:other_user) do
         user = create(:user)
-        user.subscription.update!(status: 'trial', expires_at: 3.days.from_now + 13.hours)
+        user.subscription.update!(status: 'trial', expires_at: 3.days.from_now.beginning_of_day + 13.hours)
         user
       end
 

--- a/spec/models/cancellation_feedback_spec.rb
+++ b/spec/models/cancellation_feedback_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe CancellationFeedback, type: :model do
+  let(:user) { create(:user) }
+
+  describe 'バリデーション' do
+    it '最小構成（user + reason）で valid' do
+      expect(described_class.new(user:, reason: 'expensive')).to be_valid
+    end
+
+    it 'user が無いと invalid' do
+      record = described_class.new(reason: 'expensive')
+      expect(record).not_to be_valid
+      expect(record.errors[:user]).to be_present
+    end
+
+    it 'subscription は optional（nil でも valid）' do
+      expect(described_class.new(user:, subscription: nil, reason: 'expensive')).to be_valid
+    end
+
+    it 'reason が nil だと invalid' do
+      record = described_class.new(user:, reason: nil)
+      expect(record).not_to be_valid
+      expect(record.errors[:reason]).to be_present
+    end
+
+    described_class::REASONS.each do |valid_reason|
+      it "reason: #{valid_reason} は valid" do
+        expect(described_class.new(user:, reason: valid_reason)).to be_valid
+      end
+    end
+
+    it '範囲外の reason は ArgumentError（enum 仕様）' do
+      expect { described_class.new(user:, reason: 'invalid_value') }
+        .to raise_error(ArgumentError)
+    end
+
+    it 'note が 1000 文字なら valid' do
+      record = described_class.new(user:, reason: 'other', note: 'a' * 1000)
+      expect(record).to be_valid
+    end
+
+    it 'note が 1001 文字だと invalid' do
+      record = described_class.new(user:, reason: 'other', note: 'a' * 1001)
+      expect(record).not_to be_valid
+      expect(record.errors[:note]).to be_present
+    end
+
+    it 'note が nil でも valid（任意項目）' do
+      expect(described_class.new(user:, reason: 'expensive', note: nil)).to be_valid
+    end
+  end
+
+  describe 'enum predicate' do
+    it 'reason_expensive? が true / false を返す' do
+      feedback = described_class.new(user:, reason: 'expensive')
+      expect(feedback.reason_expensive?).to be(true)
+      expect(feedback.reason_other?).to be(false)
+    end
+  end
+
+  describe '関連' do
+    it 'user に belongs_to' do
+      feedback = create(:cancellation_feedback, user:)
+      expect(feedback.user).to eq(user)
+    end
+
+    it 'subscription は optional（nil 許容）' do
+      feedback = described_class.create!(user:, subscription: nil, reason: 'other')
+      expect(feedback).to be_persisted
+      expect(feedback.subscription).to be_nil
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -425,6 +425,19 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe 'has_many :cancellation_feedbacks (dependent: :destroy)' do
+    let(:user) { create(:user) }
+
+    before do
+      create(:cancellation_feedback, user:, reason: 'expensive')
+      create(:cancellation_feedback, user:, reason: 'other')
+    end
+
+    it 'User を destroy すると関連する cancellation_feedbacks も削除される' do
+      expect { user.destroy }.to change { CancellationFeedback.where(user_id: user.id).count }.from(2).to(0)
+    end
+  end
+
   describe '#prevent_destroy_if_pro_active (before_destroy)' do
     let(:user) { create(:user) }
 

--- a/spec/requests/api/v1/pro/cancellation_feedbacks_spec.rb
+++ b/spec/requests/api/v1/pro/cancellation_feedbacks_spec.rb
@@ -1,0 +1,113 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Pro::CancellationFeedbacks', type: :request do
+  let(:user) { create(:user) }
+
+  describe 'POST /api/v1/pro/cancellation_feedbacks' do
+    context '未認証のとき' do
+      it '401 を返す' do
+        post '/api/v1/pro/cancellation_feedbacks', params: { reason: 'expensive' }, as: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'Flipper :cancellation_survey が無効のとき' do
+      before { Flipper.disable(:cancellation_survey) }
+
+      it '404 を返し、レコードを作成しない' do
+        expect do
+          post '/api/v1/pro/cancellation_feedbacks',
+               params: { reason: 'expensive' },
+               headers: auth_headers_for(user), as: :json
+        end.not_to(change(CancellationFeedback, :count))
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'Flipper :cancellation_survey が enabled のとき' do
+      before { Flipper.enable_actor(:cancellation_survey, user) }
+      after { Flipper.disable(:cancellation_survey) }
+
+      context '正常な reason のみで送信' do
+        it '201 + 作成された feedback の id を返す' do
+          expect do
+            post '/api/v1/pro/cancellation_feedbacks',
+                 params: { reason: 'expensive' },
+                 headers: auth_headers_for(user), as: :json
+          end.to change(CancellationFeedback, :count).by(1)
+
+          expect(response).to have_http_status(:created)
+          expect(response.parsed_body['id']).to be_present
+        end
+
+        it 'current_user.subscription が自動で紐付く' do
+          post '/api/v1/pro/cancellation_feedbacks',
+               params: { reason: 'expensive' },
+               headers: auth_headers_for(user), as: :json
+
+          feedback = CancellationFeedback.last
+          expect(feedback.user).to eq(user)
+          expect(feedback.subscription_id).to eq(user.subscription.id)
+        end
+      end
+
+      context 'reason + note で送信' do
+        it '201 を返し note も保存される' do
+          post '/api/v1/pro/cancellation_feedbacks',
+               params: { reason: 'other', note: 'もっと安ければ続けたかった' },
+               headers: auth_headers_for(user), as: :json
+
+          expect(response).to have_http_status(:created)
+          expect(CancellationFeedback.last.note).to eq('もっと安ければ続けたかった')
+        end
+      end
+
+      context 'reason が欠落しているとき' do
+        it '422 + error: reason_required を返す' do
+          post '/api/v1/pro/cancellation_feedbacks',
+               params: { reason: nil },
+               headers: auth_headers_for(user), as: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body['error']).to eq('reason_required')
+        end
+      end
+
+      context 'reason が範囲外のとき' do
+        it '422 + error: invalid_reason を返す' do
+          post '/api/v1/pro/cancellation_feedbacks',
+               params: { reason: 'lifetime' },
+               headers: auth_headers_for(user), as: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body['error']).to eq('invalid_reason')
+        end
+      end
+
+      context 'note が 1001 文字以上のとき' do
+        it '422 + error: note_too_long を返す' do
+          post '/api/v1/pro/cancellation_feedbacks',
+               params: { reason: 'other', note: 'a' * 1001 },
+               headers: auth_headers_for(user), as: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body['error']).to eq('note_too_long')
+        end
+      end
+
+      context '同一ユーザーが 2 回送信したとき' do
+        it '両方 201 で受け付ける（重複制約なし）' do
+          2.times do
+            post '/api/v1/pro/cancellation_feedbacks',
+                 params: { reason: 'expensive' },
+                 headers: auth_headers_for(user), as: :json
+            expect(response).to have_http_status(:created)
+          end
+
+          expect(user.cancellation_feedbacks.count).to eq(2)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
親 Issue: ippei-shimizu/buzzbase#349
Phase: B（バックエンド実装）
依存: #345 (B1 = Flipper 導入) マージ済み

## Summary

Pro 解約フローに「引き止め → 解約理由アンケート」を追加する back 側の受信 API を TDD で実装。Flipper `:cancellation_survey` で機能フラグ制御し、リリース当初は無効・F1 完成後に enable する運用。

## 実装内容

### DB
- マイグレーション: `cancellation_feedbacks` テーブル
  - `user_id` (null:false, foreign_key)
  - `subscription_id` (foreign_key, nullable + on_delete: :nullify)
  - `reason` (string, null:false)
  - `note` (text)

### Model
- `CancellationFeedback`: enum reason (`expensive / less_usage / feature_missing / competitor / other`), note 1000 文字制限
- `User#has_many :cancellation_feedbacks, dependent: :destroy`

### Controller / Routes
- `Api::V1::Pro::CancellationFeedbacksController#create`:
  - 認証必須（既存 Pro 系コントローラと同様）
  - **Flipper :cancellation_survey 無効時は 404** で隠す
  - subscription_id は `current_api_v1_user.subscription` を自動補完（クライアントからは受け取らない）
- `POST /api/v1/pro/cancellation_feedbacks` を routes に追加

### エラーレスポンス
| 状況 | HTTP | error コード |
|---|---|---|
| 未認証 | 401 | （devise） |
| Flipper 無効 | 404 | （body なし） |
| 正常 | 201 | `{ id: ... }` |
| reason 欠落 | 422 | `reason_required` |
| reason 範囲外 | 422 | `invalid_reason` |
| note 1001 文字以上 | 422 | `note_too_long` |

## 設計判断

- **subscription_id をクライアントから受け取らない**: 他人の subscription_id を入れた偽造を防ぐ
- **重複送信を許可**: cancelled → expired → 再加入 → 再 cancelled の繰り返しで複数アンケートが発生し得る
- **Flipper 無効時は 404**: エンドポイント自体の存在を隠す
- **`enum reason: REASONS.index_with(&:itself), _prefix: :reason`**: Subscription 等の既存 enum 規約に揃える

## マージ後の運用

リリース当初は無効化、F1 (#351) で front 側のアンケート UI 完成後に enable:

```ruby
# 個別有効化（ippei テスト）
Flipper.enable_actor(:cancellation_survey, User.find(1))

# 全員開放
Flipper.enable(:cancellation_survey)
```

## 副次的修正

既存の TrialExpiringReminderJob / ProExpiringReminderJob の spec で時刻依存（`3.days.from_now + 12.hours` が日付境界をまたぐ）が不安定だったため、`3.days.from_now.beginning_of_day + N.hours` に修正して 3 日後の特定時刻に固定。

## Test plan

- [x] `docker compose exec back bundle exec rspec` → 878 examples / 0 failures（B4 完了時 852 から +26）
- [x] `docker compose exec back bundle exec rubocop` → 331 files / 0 offenses（`rubocop:disable` 不使用）
- [x] バリデーション・enum・関連 (model spec) / 認証・Flipper ゲート・エラー分岐 (request spec) を TDD で網羅
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
