### PR TITLE
Add: Feature Flag API (mobile / front 用) #350

### DIFF
--- a/app/controllers/api/v1/feature_flags_controller.rb
+++ b/app/controllers/api/v1/feature_flags_controller.rb
@@ -1,8 +1,6 @@
 module Api
   module V1
     # GET /api/v1/feature_flags?keys[]=pro_features&keys[]=cancellation_survey
-    # mobile / front が UI の出し分け（Pro 機能表示・解約アンケート表示など）を行うため、
-    # Flipper の判定結果を current_api_v1_user 単位で返す。
     class FeatureFlagsController < ApplicationController
       before_action :authenticate_api_v1_user!
 
@@ -11,7 +9,7 @@ module Api
       PUBLIC_KEYS = %w[pro_features cancellation_survey].freeze
 
       def index
-        requested = Array(filter_params[:keys]).map(&:to_s) & PUBLIC_KEYS
+        requested = Array(filter_params[:keys]) & PUBLIC_KEYS
         render json: requested.index_with { |key| Flipper.enabled?(key.to_sym, current_api_v1_user) }
       end
 

--- a/app/controllers/api/v1/feature_flags_controller.rb
+++ b/app/controllers/api/v1/feature_flags_controller.rb
@@ -1,0 +1,25 @@
+module Api
+  module V1
+    # GET /api/v1/feature_flags?keys[]=pro_features&keys[]=cancellation_survey
+    # mobile / front が UI の出し分け（Pro 機能表示・解約アンケート表示など）を行うため、
+    # Flipper の判定結果を current_api_v1_user 単位で返す。
+    class FeatureFlagsController < ApplicationController
+      before_action :authenticate_api_v1_user!
+
+      # クライアントに公開してよい flag のホワイトリスト。
+      # Flipper の予約済みキー（社内検証用 flag 等）と切り離す目的で controller 側に持たせる。
+      PUBLIC_KEYS = %w[pro_features cancellation_survey].freeze
+
+      def index
+        requested = Array(filter_params[:keys]).map(&:to_s) & PUBLIC_KEYS
+        render json: requested.index_with { |key| Flipper.enabled?(key.to_sym, current_api_v1_user) }
+      end
+
+      private
+
+      def filter_params
+        params.permit(keys: [])
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -151,6 +151,8 @@ Rails.application.routes.draw do
 
       resources :management_notices, only: %i[index show]
 
+      resources :feature_flags, only: %i[index]
+
       namespace :pro do
         resource :status, only: %i[show], controller: 'status'
         resource :sync, only: %i[create], controller: 'sync'

--- a/spec/requests/api/v1/feature_flags_spec.rb
+++ b/spec/requests/api/v1/feature_flags_spec.rb
@@ -1,0 +1,121 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::FeatureFlags', type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+
+  after do
+    Flipper.disable(:pro_features)
+    Flipper.disable(:cancellation_survey)
+  end
+
+  describe 'GET /api/v1/feature_flags' do
+    context '未認証のとき' do
+      it '401 を返す' do
+        get '/api/v1/feature_flags', params: { keys: ['pro_features'] }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '認証済み + keys 未指定のとき' do
+      it '200 + 空オブジェクトを返す' do
+        get '/api/v1/feature_flags', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to eq({})
+      end
+    end
+
+    context '認証済み + keys が空配列のとき' do
+      it '200 + 空オブジェクトを返す' do
+        get '/api/v1/feature_flags', params: { keys: [] }, headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to eq({})
+      end
+    end
+
+    context 'Flipper が全体 disabled のとき' do
+      it 'すべての flag が false で返る' do
+        get '/api/v1/feature_flags',
+            params: { keys: %w[pro_features cancellation_survey] },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to eq(
+          'pro_features' => false,
+          'cancellation_survey' => false
+        )
+      end
+    end
+
+    context 'actor 単位で enable されているとき' do
+      before { Flipper.enable_actor(:pro_features, user) }
+
+      it '対象 user は true を取得する' do
+        get '/api/v1/feature_flags',
+            params: { keys: ['pro_features'] },
+            headers: auth_headers_for(user)
+
+        expect(response.parsed_body).to eq('pro_features' => true)
+      end
+
+      it '他ユーザーは false を取得する' do
+        get '/api/v1/feature_flags',
+            params: { keys: ['pro_features'] },
+            headers: auth_headers_for(other_user)
+
+        expect(response.parsed_body).to eq('pro_features' => false)
+      end
+    end
+
+    context 'boolean で全体 enable されているとき' do
+      before { Flipper.enable(:pro_features) }
+
+      it '誰でも true を取得する' do
+        get '/api/v1/feature_flags',
+            params: { keys: ['pro_features'] },
+            headers: auth_headers_for(other_user)
+
+        expect(response.parsed_body).to eq('pro_features' => true)
+      end
+    end
+
+    context '両キー指定 + 片方のみ actor enable' do
+      before { Flipper.enable_actor(:pro_features, user) }
+
+      it '対応するキーのみ true で返る' do
+        get '/api/v1/feature_flags',
+            params: { keys: %w[pro_features cancellation_survey] },
+            headers: auth_headers_for(user)
+
+        expect(response.parsed_body).to eq(
+          'pro_features' => true,
+          'cancellation_survey' => false
+        )
+      end
+    end
+
+    context '未知 key を含めて要求したとき' do
+      it '未知 key はレスポンスに含めない' do
+        get '/api/v1/feature_flags',
+            params: { keys: %w[pro_features unknown_flag pro_test_mode] },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to eq('pro_features' => false)
+      end
+    end
+
+    context '同一 key を重複して指定したとき' do
+      it '重複は 1 件に集約されて返る' do
+        get '/api/v1/feature_flags',
+            params: { keys: %w[pro_features pro_features] },
+            headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to eq('pro_features' => false)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/feature_flags_spec.rb
+++ b/spec/requests/api/v1/feature_flags_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe 'Api::V1::FeatureFlags', type: :request do
   let(:other_user) { create(:user) }
 
   after do
-    Flipper.disable(:pro_features)
-    Flipper.disable(:cancellation_survey)
+    Api::V1::FeatureFlagsController::PUBLIC_KEYS.each { |key| Flipper.disable(key.to_sym) }
   end
 
   describe 'GET /api/v1/feature_flags' do


### PR DESCRIPTION
## Summary
- mobile / front から Flipper の判定結果を `current_api_v1_user` 単位で取得できる軽量 endpoint を追加
- 親 Issue: ippei-shimizu/buzzbase#318 / 本 Issue: ippei-shimizu/buzzbase#350 / 依存: #345 (B1 Flipper 導入)
- F1 (#351 解約アンケート UI) や mobile の Pro UI が依存解除される

## 追加されたエンドポイント
```
GET /api/v1/feature_flags?keys[]=pro_features&keys[]=cancellation_survey
```
レスポンス（フラット形式、Issue 本文準拠）:
```json
{ "pro_features": true, "cancellation_survey": false }
```

## 仕様
| 項目 | 採用 |
|---|---|
| 認証 | 必須（401） |
| keys 未指定 / 空配列 | `{}` を 200 で返却 |
| 未知 key | レスポンスから除外（controller の `PUBLIC_KEYS` ホワイトリスト） |
| actor / group / boolean enable | `Flipper.enabled?(key, current_api_v1_user)` で正しく判定 |
| 重複 key | `index_with` で 1 件に集約 |

## 設計判断
- Flipper 予約キー（initializer で `Flipper.add` 済みの社内検証 flag 含む）と「クライアントに公開するキー」を分離するため、controller 側に `PUBLIC_KEYS` 定数を置く（allowlist 方式）
- params は `params.permit(keys: [])` で Strong Parameters 規約に従う

## Test plan
- [x] `docker compose exec back bundle exec rspec spec/requests/api/v1/feature_flags_spec.rb` → 10/10 green
- [x] フル rspec: 888 examples / 0 failures（追加 +10）
- [x] RuboCop: 333 files / 0 offenses（`rubocop:disable` 不使用）

## 後続マイルストーン
- リリース当初は `Flipper.disable(:pro_features)` / `Flipper.disable(:cancellation_survey)` で全員 false → 段階的に `enable_actor` から開放
- F1 (#351) の front 側がこの API を叩いて UI 出し分けを実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)
