### PR TITLE
Add: 通知ジョブで Apple private relay メールをスキップ + 3 ジョブに Push 追加

### DIFF
--- a/app/jobs/billing_issue_notification_job.rb
+++ b/app/jobs/billing_issue_notification_job.rb
@@ -6,7 +6,7 @@ class BillingIssueNotificationJob < ApplicationJob
     user = User.find_by(id: user_id)
     return unless user
 
-    SubscriptionMailer.billing_issue(user).deliver_now
+    SubscriptionMailer.billing_issue(user).deliver_now if user.email_deliverable?
     PushNotificationService.send_to_user(
       user,
       title: '【BUZZ BASE Pro】決済情報を確認してください',

--- a/app/jobs/pro_expiring_reminder_job.rb
+++ b/app/jobs/pro_expiring_reminder_job.rb
@@ -15,7 +15,7 @@ class ProExpiringReminderJob < ApplicationJob
   private
 
   def notify(subscription)
-    SubscriptionMailer.pro_expiring_soon(subscription.user).deliver_now
+    SubscriptionMailer.pro_expiring_soon(subscription.user).deliver_now if subscription.user.email_deliverable?
     PushNotificationService.send_to_user(
       subscription.user,
       title: '【BUZZ BASE Pro】Pro 期間終了 3 日前',

--- a/app/jobs/recovered_notification_job.rb
+++ b/app/jobs/recovered_notification_job.rb
@@ -1,6 +1,5 @@
-# 課金失敗（billing_issue）から復帰したことをメール通知する。
-# Push は送らない: 復帰は決済プロバイダ側の自動リトライ成功による「良いニュース」で、
-# ユーザーが即時のアクションを取る必要が無いためメールで十分。
+# 課金失敗（billing_issue）から復帰したことをメール + Push で通知する。
+# Apple Sign-In + private relay のユーザーはメールが届かないため、Push を主チャネルとして送る。
 class RecoveredNotificationJob < ApplicationJob
   queue_as :default
 
@@ -8,7 +7,12 @@ class RecoveredNotificationJob < ApplicationJob
     user = User.find_by(id: user_id)
     return unless user
 
-    SubscriptionMailer.recovered(user).deliver_now
+    SubscriptionMailer.recovered(user).deliver_now if user.email_deliverable?
+    PushNotificationService.send_to_user(
+      user,
+      title: '【BUZZ BASE Pro】決済が復旧しました',
+      body: '自動更新が正常に再開されました。引き続き Pro 機能をご利用いただけます。'
+    )
   rescue StandardError => e
     Sentry.capture_exception(
       e,

--- a/app/jobs/refund_notification_job.rb
+++ b/app/jobs/refund_notification_job.rb
@@ -1,6 +1,6 @@
-# 返金完了時にメール通知する。
-# Push は送らない: 返金はユーザーが Apple/Stripe で申請した結果であり、
-# それぞれの決済プロバイダから別途通知が届くため二重通知を避ける。
+# 返金完了時にメール + Push で通知する。
+# Apple Sign-In + private relay のユーザーはメールが届かないため、Push を主チャネルとして送る。
+# 決済プロバイダ側からも通知が出るが、BUZZ BASE 側でも結果を必ず把握できるよう二重で送信する。
 class RefundNotificationJob < ApplicationJob
   queue_as :default
 
@@ -8,7 +8,12 @@ class RefundNotificationJob < ApplicationJob
     user = User.find_by(id: user_id)
     return unless user
 
-    SubscriptionMailer.refunded(user).deliver_now
+    SubscriptionMailer.refunded(user).deliver_now if user.email_deliverable?
+    PushNotificationService.send_to_user(
+      user,
+      title: '【BUZZ BASE Pro】返金処理が完了しました',
+      body: 'ご返金が完了しました。詳細は決済プロバイダのご利用明細をご確認ください。'
+    )
   rescue StandardError => e
     Sentry.capture_exception(
       e,

--- a/app/jobs/subscription_cancelled_notification_job.rb
+++ b/app/jobs/subscription_cancelled_notification_job.rb
@@ -1,6 +1,6 @@
-# Pro 解約申請完了時にユーザーへメール通知する。
+# Pro 解約申請完了時にユーザーへメール + Push 通知する。
 # 同期呼び出し (perform_now) されることがあるため、例外を握り潰し Webhook 全体を巻き込まない設計とする。
-# Push は送らない: 解約はユーザー起点の能動操作なので、結果の即時通知は不要（メールの確認で十分）。
+# Apple Sign-In + private relay のユーザーはメールが事実上届かないため、Push を主チャネルとして送る。
 class SubscriptionCancelledNotificationJob < ApplicationJob
   queue_as :default
 
@@ -8,7 +8,12 @@ class SubscriptionCancelledNotificationJob < ApplicationJob
     user = User.find_by(id: user_id)
     return unless user
 
-    SubscriptionMailer.cancelled(user).deliver_now
+    SubscriptionMailer.cancelled(user).deliver_now if user.email_deliverable?
+    PushNotificationService.send_to_user(
+      user,
+      title: '【BUZZ BASE Pro】解約手続きを受け付けました',
+      body: '次回課金日まで Pro 機能を引き続きご利用いただけます。'
+    )
   rescue StandardError => e
     Sentry.capture_exception(
       e,

--- a/app/jobs/subscription_expired_notification_job.rb
+++ b/app/jobs/subscription_expired_notification_job.rb
@@ -6,7 +6,7 @@ class SubscriptionExpiredNotificationJob < ApplicationJob
     user = User.find_by(id: user_id)
     return unless user
 
-    SubscriptionMailer.expired(user).deliver_now
+    SubscriptionMailer.expired(user).deliver_now if user.email_deliverable?
     PushNotificationService.send_to_user(
       user,
       title: '【BUZZ BASE Pro】Pro 期間が終了しました',

--- a/app/jobs/trial_expiring_reminder_job.rb
+++ b/app/jobs/trial_expiring_reminder_job.rb
@@ -14,7 +14,7 @@ class TrialExpiringReminderJob < ApplicationJob
   private
 
   def notify(user)
-    SubscriptionMailer.trial_expiring_soon(user).deliver_now
+    SubscriptionMailer.trial_expiring_soon(user).deliver_now if user.email_deliverable?
     PushNotificationService.send_to_user(
       user,
       title: '【BUZZ BASE Pro】トライアル終了 3 日前',

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -96,15 +96,11 @@ class User < ActiveRecord::Base
     provider == 'apple'
   end
 
-  # 通常メール送信の対象とすべきユーザーかを判定する。
-  # Apple Sign-In で「Hide My Email」を選んだユーザーには privaterelay.appleid.com のランダム
-  # アドレスが入る。本来は Apple がフォワードするが、ユーザーが普段見るメールボックスに
-  # 入らず実質「捨てメアド」化するうえ、Gmail SMTP の月次送信上限を浪費するため送信しない。
-  # Push 通知は本メソッドの結果に関わらず別途送る前提（呼び出し側で gate しない）。
+  # Apple private relay (@privaterelay.appleid.com) はフォワード不達 + SMTP 上限浪費のため対象外とする。
   def email_deliverable?
     return false if email.blank?
 
-    !email.end_with?('@privaterelay.appleid.com')
+    !email.downcase.end_with?('@privaterelay.appleid.com')
   end
 
   scope :active, -> { where(suspended_at: nil, deleted_at: nil) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -96,6 +96,17 @@ class User < ActiveRecord::Base
     provider == 'apple'
   end
 
+  # 通常メール送信の対象とすべきユーザーかを判定する。
+  # Apple Sign-In で「Hide My Email」を選んだユーザーには privaterelay.appleid.com のランダム
+  # アドレスが入る。本来は Apple がフォワードするが、ユーザーが普段見るメールボックスに
+  # 入らず実質「捨てメアド」化するうえ、Gmail SMTP の月次送信上限を浪費するため送信しない。
+  # Push 通知は本メソッドの結果に関わらず別途送る前提（呼び出し側で gate しない）。
+  def email_deliverable?
+    return false if email.blank?
+
+    !email.end_with?('@privaterelay.appleid.com')
+  end
+
   scope :active, -> { where(suspended_at: nil, deleted_at: nil) }
   scope :suspended, -> { where.not(suspended_at: nil).where(deleted_at: nil) }
   scope :soft_deleted, -> { where.not(deleted_at: nil) }

--- a/spec/jobs/billing_issue_notification_job_spec.rb
+++ b/spec/jobs/billing_issue_notification_job_spec.rb
@@ -18,6 +18,17 @@ RSpec.describe BillingIssueNotificationJob, type: :job do
       expect(PushNotificationService).to have_received(:send_to_user)
     end
 
+    context 'Apple private relay のユーザー' do
+      let(:user) { create(:user, email: 'abc.def@privaterelay.appleid.com') }
+
+      it 'メールはスキップし Push のみ送信する' do
+        described_class.new.perform(user.id)
+
+        expect(SubscriptionMailer).not_to have_received(:billing_issue)
+        expect(PushNotificationService).to have_received(:send_to_user)
+      end
+    end
+
     context 'user_id が見つからないとき' do
       it '例外を投げず処理を終える' do
         expect { described_class.new.perform(0) }.not_to raise_error

--- a/spec/jobs/pro_expiring_reminder_job_spec.rb
+++ b/spec/jobs/pro_expiring_reminder_job_spec.rb
@@ -28,6 +28,20 @@ RSpec.describe ProExpiringReminderJob, type: :job do
       end
     end
 
+    context '3 日後に期限切れる cancelled ユーザーが private relay アドレスのとき' do
+      let!(:relay_user) do
+        user = create(:user, email: 'abc.def@privaterelay.appleid.com')
+        user.subscription.update!(status: 'cancelled', expires_at: 3.days.from_now.beginning_of_day + 6.hours, cancelled_at: 2.days.ago)
+        user
+      end
+
+      it 'メールはスキップし Push のみ送信する' do
+        job.perform
+        expect(SubscriptionMailer).not_to have_received(:pro_expiring_soon)
+        expect(PushNotificationService).to have_received(:send_to_user).with(relay_user, hash_including(:title, :body))
+      end
+    end
+
     context '3 日後に期限切れる billing_issue ユーザー' do
       let!(:billing_issue_user) do
         user = create(:user)

--- a/spec/jobs/recovered_notification_job_spec.rb
+++ b/spec/jobs/recovered_notification_job_spec.rb
@@ -4,15 +4,30 @@ RSpec.describe RecoveredNotificationJob, type: :job do
   let(:user) { create(:user) }
 
   describe '#perform' do
-    it 'SubscriptionMailer.recovered を deliver_now で送信する（Push なし）' do
-      mail = instance_double(ActionMailer::MessageDelivery, deliver_now: nil)
+    let(:mail) { instance_double(ActionMailer::MessageDelivery, deliver_now: nil) }
+
+    before do
       allow(SubscriptionMailer).to receive(:recovered).with(user).and_return(mail)
       allow(PushNotificationService).to receive(:send_to_user)
+    end
 
+    it 'メール + Push 通知を同期送信する' do
       described_class.new.perform(user.id)
 
       expect(mail).to have_received(:deliver_now)
-      expect(PushNotificationService).not_to have_received(:send_to_user)
+      expect(PushNotificationService).to have_received(:send_to_user)
+        .with(user, hash_including(:title, :body))
+    end
+
+    context 'Apple private relay のユーザー' do
+      let(:user) { create(:user, email: 'abc.def@privaterelay.appleid.com') }
+
+      it 'メールはスキップし Push のみ送信する' do
+        described_class.new.perform(user.id)
+
+        expect(SubscriptionMailer).not_to have_received(:recovered)
+        expect(PushNotificationService).to have_received(:send_to_user)
+      end
     end
 
     context 'user_id が見つからないとき' do

--- a/spec/jobs/refund_notification_job_spec.rb
+++ b/spec/jobs/refund_notification_job_spec.rb
@@ -4,15 +4,30 @@ RSpec.describe RefundNotificationJob, type: :job do
   let(:user) { create(:user) }
 
   describe '#perform' do
-    it 'SubscriptionMailer.refunded を deliver_now で送信する（Push なし）' do
-      mail = instance_double(ActionMailer::MessageDelivery, deliver_now: nil)
+    let(:mail) { instance_double(ActionMailer::MessageDelivery, deliver_now: nil) }
+
+    before do
       allow(SubscriptionMailer).to receive(:refunded).with(user).and_return(mail)
       allow(PushNotificationService).to receive(:send_to_user)
+    end
 
+    it 'メール + Push 通知を同期送信する' do
       described_class.new.perform(user.id)
 
       expect(mail).to have_received(:deliver_now)
-      expect(PushNotificationService).not_to have_received(:send_to_user)
+      expect(PushNotificationService).to have_received(:send_to_user)
+        .with(user, hash_including(:title, :body))
+    end
+
+    context 'Apple private relay のユーザー' do
+      let(:user) { create(:user, email: 'abc.def@privaterelay.appleid.com') }
+
+      it 'メールはスキップし Push のみ送信する' do
+        described_class.new.perform(user.id)
+
+        expect(SubscriptionMailer).not_to have_received(:refunded)
+        expect(PushNotificationService).to have_received(:send_to_user)
+      end
     end
 
     context 'user_id が見つからないとき' do

--- a/spec/jobs/subscription_cancelled_notification_job_spec.rb
+++ b/spec/jobs/subscription_cancelled_notification_job_spec.rb
@@ -4,14 +4,30 @@ RSpec.describe SubscriptionCancelledNotificationJob, type: :job do
   let(:user) { create(:user) }
 
   describe '#perform' do
-    it 'SubscriptionMailer.cancelled を deliver_now で送信する' do
-      mail = instance_double(ActionMailer::MessageDelivery, deliver_now: nil)
-      allow(SubscriptionMailer).to receive(:cancelled).with(user).and_return(mail)
+    let(:mail) { instance_double(ActionMailer::MessageDelivery, deliver_now: nil) }
 
+    before do
+      allow(SubscriptionMailer).to receive(:cancelled).with(user).and_return(mail)
+      allow(PushNotificationService).to receive(:send_to_user)
+    end
+
+    it 'メール + Push 通知を同期送信する' do
       described_class.new.perform(user.id)
 
-      expect(SubscriptionMailer).to have_received(:cancelled).with(user)
       expect(mail).to have_received(:deliver_now)
+      expect(PushNotificationService).to have_received(:send_to_user)
+        .with(user, hash_including(:title, :body))
+    end
+
+    context 'Apple private relay のユーザー' do
+      let(:user) { create(:user, email: 'abc.def@privaterelay.appleid.com') }
+
+      it 'メールはスキップし Push のみ送信する' do
+        described_class.new.perform(user.id)
+
+        expect(SubscriptionMailer).not_to have_received(:cancelled)
+        expect(PushNotificationService).to have_received(:send_to_user)
+      end
     end
 
     context 'user_id が見つからないとき' do

--- a/spec/jobs/subscription_expired_notification_job_spec.rb
+++ b/spec/jobs/subscription_expired_notification_job_spec.rb
@@ -19,6 +19,17 @@ RSpec.describe SubscriptionExpiredNotificationJob, type: :job do
         .with(user, hash_including(:title, :body))
     end
 
+    context 'Apple private relay のユーザー' do
+      let(:user) { create(:user, email: 'abc.def@privaterelay.appleid.com') }
+
+      it 'メールはスキップし Push のみ送信する' do
+        described_class.new.perform(user.id)
+
+        expect(SubscriptionMailer).not_to have_received(:expired)
+        expect(PushNotificationService).to have_received(:send_to_user)
+      end
+    end
+
     context 'user_id が見つからないとき' do
       it '例外を投げず処理を終える' do
         expect { described_class.new.perform(0) }.not_to raise_error

--- a/spec/jobs/trial_expiring_reminder_job_spec.rb
+++ b/spec/jobs/trial_expiring_reminder_job_spec.rb
@@ -25,6 +25,20 @@ RSpec.describe TrialExpiringReminderJob, type: :job do
       end
     end
 
+    context '3 日後ピッタリに期限切れる trial ユーザーが private relay アドレスのとき' do
+      let!(:relay_user) do
+        user = create(:user, email: 'abc.def@privaterelay.appleid.com')
+        user.subscription.update!(status: 'trial', expires_at: 3.days.from_now.beginning_of_day + 12.hours)
+        user
+      end
+
+      it 'メールはスキップし Push のみ送信する' do
+        job.perform
+        expect(SubscriptionMailer).not_to have_received(:trial_expiring_soon)
+        expect(PushNotificationService).to have_received(:send_to_user).with(relay_user, hash_including(:title, :body))
+      end
+    end
+
     context '期限が 3 日後の範囲外のとき' do
       before do
         create(:user).subscription.update!(status: 'trial', expires_at: 5.days.from_now)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -444,6 +444,14 @@ RSpec.describe User, type: :model do
       end
     end
 
+    context 'Apple private relay のメールアドレス（大文字混在）' do
+      let(:email) { 'AbC.DeF@PrivateRelay.AppleID.com' }
+
+      it 'false を返す（大文字小文字を区別しない）' do
+        expect(user.email_deliverable?).to be false
+      end
+    end
+
     context 'email が空文字' do
       let(:email) { '' }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -425,6 +425,50 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#email_deliverable?' do
+    let(:user) { build(:user, email:) }
+
+    context '通常のメールアドレス' do
+      let(:email) { 'taro@example.com' }
+
+      it 'true を返す' do
+        expect(user.email_deliverable?).to be true
+      end
+    end
+
+    context 'Apple private relay のメールアドレス' do
+      let(:email) { 'abc123.def456@privaterelay.appleid.com' }
+
+      it 'false を返す' do
+        expect(user.email_deliverable?).to be false
+      end
+    end
+
+    context 'email が空文字' do
+      let(:email) { '' }
+
+      it 'false を返す' do
+        expect(user.email_deliverable?).to be false
+      end
+    end
+
+    context 'email が nil' do
+      let(:email) { nil }
+
+      it 'false を返す' do
+        expect(user.email_deliverable?).to be false
+      end
+    end
+
+    context '通常の iCloud メールアドレス（Apple Sign-In で本来メールを共有したケース）' do
+      let(:email) { 'ippei@icloud.com' }
+
+      it 'true を返す（@icloud.com は relay ドメインではない）' do
+        expect(user.email_deliverable?).to be true
+      end
+    end
+  end
+
   describe 'has_many :cancellation_feedbacks (dependent: :destroy)' do
     let(:user) { create(:user) }
 


### PR DESCRIPTION
## Summary

- 親 Issue: ippei-shimizu/buzzbase#318（Pro リリース）
- Apple Sign-In で「Hide My Email」を使った private relay ユーザーへの **メール送信をスキップ** し、不足していた 3 ジョブに **Push 通知を追加** することで、メールが届かないケースの通知到達を担保する

## 背景

| 問題 | 影響 |
|---|---|
| Apple `Hide My Email` で `@privaterelay.appleid.com` のランダムアドレスが DB に保存される | フォワード経由で届く前提だが、SPF/DKIM 認証が通らないと silently drop。届いても普段のメールボックスに入らず実質「捨てメアド」化 |
| Gmail SMTP の月次送信上限 | private relay 宛の無駄送信が上限を浪費 |
| recovered / refund / subscription_cancelled の 3 ジョブが **メールのみ** | private relay ユーザーは通知が全く届かない |

## 変更内容

### `User#email_deliverable?` を追加

`app/models/user.rb`:
```ruby
def email_deliverable?
  return false if email.blank?
  !email.end_with?('@privaterelay.appleid.com')
end
```

- mailer 呼び出し直前のガード用
- Push 通知側は本メソッドの結果に関わらず別途送る

### 7 ジョブの mailer 呼び出しに email_deliverable? ガード追加
- `billing_issue_notification_job`
- `recovered_notification_job`
- `refund_notification_job`
- `subscription_cancelled_notification_job`
- `subscription_expired_notification_job`
- `pro_expiring_reminder_job`
- `trial_expiring_reminder_job`

### 不足 3 ジョブに Push 通知を追加（既存 4 ジョブと同じパターン）

| Job | Push 文言 |
|---|---|
| recovered_notification | 「決済が復旧しました / 自動更新が再開」 |
| refund_notification | 「返金処理が完了しました」 |
| subscription_cancelled_notification | 「解約手続きを受け付けました / 次回課金日まで Pro 利用可」 |

旧コメント「Push は送らない理由: ...」は、private relay 対策を踏まえて全面的に書き換え。

## テスト

| Spec | 追加内容 |
|---|---|
| `user_spec.rb` | `#email_deliverable?` 5 例（通常 / private relay / blank / nil / @icloud.com） |
| 各 `*_notification_job_spec.rb` | 「private relay ユーザーはメールスキップ・Push のみ」context を追加 |
| `trial_expiring_reminder_job_spec.rb` / `pro_expiring_reminder_job_spec.rb` | 同上 |

## 動作確認

- [x] `docker compose exec back bundle exec rspec` — **900 examples / 0 failures**
- [x] `docker compose exec back bundle exec rubocop` — **333 files / 0 offenses**

## 設計判断のメモ

- private relay 判定は **メアド末尾チェック 1 つに集約**（provider カラム参照しない）。理由: Apple Sign-In でも本来メールを共有したユーザー（`@icloud.com` 等）には通常通り送れる
- 「メール + Push 両方送る」を基本とし、Push 拒否ユーザーへの最後の砦としてメールを残す（private relay 以外）
- `subscription_cancelled` 等で旧コメント「ユーザー起点なので Push 不要」と書かれていたが、private relay 対策で **Apple ユーザーは Push が唯一の到達手段** となるため設計変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)
