### PR TITLE
Add: 打席記録API（v2/plate_appearances）拡張とマスタAPI追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, stg]
+    branches: [main, stg, "release/**"]
   push:
-    branches: [stg]
+    branches: [stg, "release/**"]
 
 jobs:
   rspec:

--- a/app/controllers/api/v2/application_controller.rb
+++ b/app/controllers/api/v2/application_controller.rb
@@ -24,11 +24,20 @@ module Api
       end
 
       # 非公開アカウントへのアクセスを 403 で拒否する共通ガード。
-      # 表示可能なら何もせず、そのまま続行する。
+      # 表示可能ならそのまま続行する。
+      #
+      # @param user [User] アクセス対象のユーザー
+      # @return [TrueClass, nil] 非公開で render した場合 truthy / 公開で何もしない場合 nil
+      #
+      # 呼び出し側は戻り値で短絡（early return）すること:
+      #   return if render_forbidden_if_private!(target_user)
+      #
+      # （`render` 後に追加の `render` を呼ぶと DoubleRenderError になるため）
       def render_forbidden_if_private!(user)
         return if user.profile_visible_to?(current_api_v1_user)
 
         render json: { error: 'このアカウントは非公開です' }, status: :forbidden
+        true
       end
     end
   end

--- a/app/controllers/api/v2/application_controller.rb
+++ b/app/controllers/api/v2/application_controller.rb
@@ -1,0 +1,35 @@
+module Api
+  module V2
+    # v2 API 共通基盤。
+    # 認証 (`authenticate_api_v1_user!`) は各 controller のポリシーが異なるため、
+    # 基底クラスでは強制せず、`paginated_response` などの共通ヘルパーのみ提供する。
+    class ApplicationController < ::ApplicationController
+      private
+
+      # kaminari でページネーションされた scope を共通 JSON 形式で返却する。
+      #
+      # @param scope [ActiveRecord::Relation] kaminari でページング済みのスコープ
+      # @param serializer [Class<ActiveModel::Serializer>] 各レコードのシリアライザ
+      # @return [Hash] `{ data: [...], pagination: { current_page:, per_page:, total_count:, total_pages: } }`
+      def paginated_response(scope, serializer)
+        {
+          data: ActiveModelSerializers::SerializableResource.new(scope, each_serializer: serializer),
+          pagination: {
+            current_page: scope.current_page,
+            per_page: scope.limit_value,
+            total_count: scope.total_count,
+            total_pages: scope.total_pages
+          }
+        }
+      end
+
+      # 非公開アカウントへのアクセスを 403 で拒否する共通ガード。
+      # 表示可能なら何もせず、そのまま続行する。
+      def render_forbidden_if_private!(user)
+        return if user.profile_visible_to?(current_api_v1_user)
+
+        render json: { error: 'このアカウントは非公開です' }, status: :forbidden
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/contact_qualities_controller.rb
+++ b/app/controllers/api/v2/contact_qualities_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  module V2
+    # 打球の質マスタ (5種) を display_order 昇順で返却する。
+    class ContactQualitiesController < Api::V2::ApplicationController
+      before_action :authenticate_api_v1_user!
+
+      def index
+        contact_qualities = ContactQuality.order(:display_order)
+        render json: {
+          contact_qualities: ActiveModelSerializers::SerializableResource.new(
+            contact_qualities, each_serializer: ::V2::ContactQualitySerializer
+          )
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/dashboards_controller.rb
+++ b/app/controllers/api/v2/dashboards_controller.rb
@@ -4,7 +4,7 @@ module Api
     #
     # ログインユーザーの直近試合結果・通算成績・グループ内ランキングを
     # 1リクエストで返却する。
-    class DashboardsController < ApplicationController
+    class DashboardsController < Api::V2::ApplicationController
       include Concerns::DashboardRankings
       include MatchTypeConvertible
 

--- a/app/controllers/api/v2/game_results_controller.rb
+++ b/app/controllers/api/v2/game_results_controller.rb
@@ -7,7 +7,7 @@ module Api
     # - フロントエンド側でN+1 HTTPリクエスト（チーム名・大会名・打席結果を個別取得）を不要にする
     # - シリアライザー(V2::GameResultSerializer)を使用してレスポンス形式を制御する
     # - ページネーション対応（kaminari）
-    class GameResultsController < ApplicationController
+    class GameResultsController < Api::V2::ApplicationController
       include MatchTypeConvertible
       before_action :authenticate_api_v1_user!, only: %i[index filtered_index show_user filtered_show_user]
 
@@ -73,20 +73,6 @@ module Api
         game_results = game_results.reorder(nil).apply_sort(params[:sort_by], params[:sort_order]) if params[:sort_by].present?
         game_results = game_results.page(params[:page]).per(params[:per_page])
         render json: paginated_response(game_results, ::V2::GameResultSerializer)
-      end
-
-      private
-
-      def paginated_response(game_results, serializer)
-        {
-          data: ActiveModelSerializers::SerializableResource.new(game_results, each_serializer: serializer),
-          pagination: {
-            current_page: game_results.current_page,
-            per_page: game_results.limit_value,
-            total_count: game_results.total_count,
-            total_pages: game_results.total_pages
-          }
-        }
       end
     end
   end

--- a/app/controllers/api/v2/hit_depths_controller.rb
+++ b/app/controllers/api/v2/hit_depths_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module V2
+    # 打球の深さマスタ (3種) を display_order 昇順で返却する。
+    class HitDepthsController < Api::V2::ApplicationController
+      before_action :authenticate_api_v1_user!
+
+      def index
+        hit_depths = HitDepth.order(:display_order)
+        render json: { hit_depths: ActiveModelSerializers::SerializableResource.new(hit_depths, each_serializer: ::V2::HitDepthSerializer) }
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/hit_directions_controller.rb
+++ b/app/controllers/api/v2/hit_directions_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  module V2
+    # 打球方向マスタ (13方向) を zone_polygon 込みで返却する。
+    # mobile クライアントはタップ座標から方向ID/深さIDを自動判定するためにゾーン定義を使用する。
+    # 既存の `stats#hit_directions`（分析API）とは別物。
+    class HitDirectionsController < Api::V2::ApplicationController
+      before_action :authenticate_api_v1_user!
+
+      def index
+        hit_directions = HitDirection.order(:display_order)
+        render json: { hit_directions: ActiveModelSerializers::SerializableResource.new(hit_directions,
+                                                                                        each_serializer: ::V2::HitDirectionSerializer) }
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/pitch_types_controller.rb
+++ b/app/controllers/api/v2/pitch_types_controller.rb
@@ -1,0 +1,14 @@
+module Api
+  module V2
+    # 球種マスタ (10種) を display_order 昇順で返却する。
+    class PitchTypesController < Api::V2::ApplicationController
+      before_action :authenticate_api_v1_user!
+
+      def index
+        pitch_types = PitchType.order(:display_order)
+        render json: { pitch_types: ActiveModelSerializers::SerializableResource.new(pitch_types,
+                                                                                     each_serializer: ::V2::PitchTypeSerializer) }
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/plate_appearances_controller.rb
+++ b/app/controllers/api/v2/plate_appearances_controller.rb
@@ -19,7 +19,7 @@ module Api
         plate_appearance.batting_result = ::Stats::BattingResultTextGenerator.generate(plate_appearance)
 
         if plate_appearance.save
-          recalculate_batting_average(plate_appearance.game_result_id)
+          recalculate_batting_average(plate_appearance.game_result_id, user_id: current_api_v1_user.id)
           render json: plate_appearance, serializer: ::V2::PlateAppearanceSerializer, status: :created
         else
           render json: { errors: plate_appearance.errors.full_messages }, status: :unprocessable_entity
@@ -33,7 +33,7 @@ module Api
         @plate_appearance.batting_result = ::Stats::BattingResultTextGenerator.generate(@plate_appearance)
 
         if @plate_appearance.save
-          recalculate_batting_average(@plate_appearance.game_result_id)
+          recalculate_batting_average(@plate_appearance.game_result_id, user_id: current_api_v1_user.id)
           render json: @plate_appearance, serializer: ::V2::PlateAppearanceSerializer
         else
           render json: { errors: @plate_appearance.errors.full_messages }, status: :unprocessable_entity
@@ -42,13 +42,18 @@ module Api
 
       def destroy
         game_result_id = @plate_appearance.game_result_id
+        # 削除する打席が新仕様だった場合、最後の1件であれば対応する batting_average も
+        # 削除する必要がある（孤立レコード防止）。was_new_format を Recalculator に渡して判断させる。
+        was_new_format = @plate_appearance.is_new_format
         @plate_appearance.destroy!
-        recalculate_batting_average(game_result_id)
+        recalculate_batting_average(game_result_id, user_id: current_api_v1_user.id, cleanup_orphan: was_new_format)
         render json: { message: '打席結果を削除しました' }
       end
 
       def by_game
         game_result = GameResult.find(params[:game_result_id])
+        # render_forbidden_if_private! は非公開アカウントへのアクセスを 403 で render し true を返す。
+        # 呼び出し側は戻り値で短絡（early return）して以降の処理をスキップする。
         return if render_forbidden_if_private!(game_result.user)
 
         plate_appearances = PlateAppearance.where(game_result_id: game_result.id)
@@ -83,8 +88,8 @@ module Api
         )
       end
 
-      def recalculate_batting_average(game_result_id)
-        ::Stats::BattingAverageRecalculator.new(game_result_id:).call
+      def recalculate_batting_average(game_result_id, user_id:, cleanup_orphan: false)
+        ::Stats::BattingAverageRecalculator.new(game_result_id:, user_id:, cleanup_orphan:).call
       end
     end
   end

--- a/app/controllers/api/v2/plate_appearances_controller.rb
+++ b/app/controllers/api/v2/plate_appearances_controller.rb
@@ -11,7 +11,10 @@ module Api
       before_action :load_plate_appearance, only: %i[update destroy]
 
       def create
-        plate_appearance = current_api_v1_user.plate_appearances.build(plate_appearance_params)
+        # game_result_id を current_api_v1_user 所有のものに限定し、IDOR を防ぐ。
+        game_result = current_api_v1_user.game_results.find(plate_appearance_params[:game_result_id])
+        plate_appearance = game_result.plate_appearances.build(plate_appearance_params.except(:game_result_id))
+        plate_appearance.user = current_api_v1_user
         plate_appearance.is_new_format = true
         plate_appearance.batting_result = ::Stats::BattingResultTextGenerator.generate(plate_appearance)
 
@@ -24,7 +27,8 @@ module Api
       end
 
       def update
-        @plate_appearance.assign_attributes(plate_appearance_params)
+        # 更新時は所属 game_result の付け替えを許さない（IDOR 防止）。
+        @plate_appearance.assign_attributes(plate_appearance_params.except(:game_result_id))
         @plate_appearance.is_new_format = true
         @plate_appearance.batting_result = ::Stats::BattingResultTextGenerator.generate(@plate_appearance)
 

--- a/app/controllers/api/v2/plate_appearances_controller.rb
+++ b/app/controllers/api/v2/plate_appearances_controller.rb
@@ -1,0 +1,87 @@
+module Api
+  module V2
+    # 打席記録 v2 CRUD（1打席ずつリアルタイム保存）
+    #
+    # - `is_new_format = true` を強制セットすることで「新仕様試合」とマークする
+    # - `batting_result` 表示テキストをサーバー側で自動生成
+    # - `batting_average` を `Stats::BattingAverageRecalculator` で自動再集計
+    # - v1 API は無修正、後方互換を保つ
+    class PlateAppearancesController < Api::V2::ApplicationController
+      before_action :authenticate_api_v1_user!
+      before_action :load_plate_appearance, only: %i[update destroy]
+
+      def create
+        plate_appearance = current_api_v1_user.plate_appearances.build(plate_appearance_params)
+        plate_appearance.is_new_format = true
+        plate_appearance.batting_result = ::Stats::BattingResultTextGenerator.generate(plate_appearance)
+
+        if plate_appearance.save
+          recalculate_batting_average(plate_appearance.game_result_id)
+          render json: plate_appearance, serializer: ::V2::PlateAppearanceSerializer, status: :created
+        else
+          render json: { errors: plate_appearance.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def update
+        @plate_appearance.assign_attributes(plate_appearance_params)
+        @plate_appearance.is_new_format = true
+        @plate_appearance.batting_result = ::Stats::BattingResultTextGenerator.generate(@plate_appearance)
+
+        if @plate_appearance.save
+          recalculate_batting_average(@plate_appearance.game_result_id)
+          render json: @plate_appearance, serializer: ::V2::PlateAppearanceSerializer
+        else
+          render json: { errors: @plate_appearance.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        game_result_id = @plate_appearance.game_result_id
+        @plate_appearance.destroy!
+        recalculate_batting_average(game_result_id)
+        render json: { message: '打席結果を削除しました' }
+      end
+
+      def by_game
+        game_result = GameResult.find(params[:game_result_id])
+        return if render_forbidden_if_private!(game_result.user)
+
+        plate_appearances = PlateAppearance.where(game_result_id: game_result.id)
+                                           .includes(:contact_quality, :timing, :pitch_type, :hit_depth)
+                                           .order(:batter_box_number)
+        render json: {
+          plate_appearances: ActiveModelSerializers::SerializableResource.new(
+            plate_appearances,
+            each_serializer: ::V2::PlateAppearanceSerializer
+          )
+        }
+      end
+
+      private
+
+      def load_plate_appearance
+        @plate_appearance = current_api_v1_user.plate_appearances.find(params[:id])
+      end
+
+      def plate_appearance_params
+        params.require(:plate_appearance).permit(
+          :game_result_id,
+          :batter_box_number,
+          :plate_result_id, :hit_direction_id, :batting_position_id,
+          :out_type, :hit_type,
+          :hit_location_x, :hit_location_y,
+          :rbi, :run_scored, :stolen_bases, :caught_stealing,
+          :final_balls, :final_strikes, :final_outs,
+          :first_pitch_swing, :runners_state, :inning,
+          :contact_quality_id, :timing_id, :pitch_type_id, :hit_depth_id,
+          :self_analysis_memo, :opponent_memo
+        )
+      end
+
+      def recalculate_batting_average(game_result_id)
+        ::Stats::BattingAverageRecalculator.new(game_result_id:).call
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/stadiums_controller.rb
+++ b/app/controllers/api/v2/stadiums_controller.rb
@@ -1,0 +1,33 @@
+module Api
+  module V2
+    # 球場マスタの取得と追加。
+    # ユーザー追加式（チームAPIと同様）で、create 時に `created_by_user_id` を自動付与する。
+    class StadiumsController < Api::V2::ApplicationController
+      before_action :authenticate_api_v1_user!
+
+      def index
+        stadiums = Stadium.includes(:prefecture)
+        stadiums = stadiums.where('name ILIKE ?', "%#{params[:q]}%") if params[:q].present?
+        stadiums = stadiums.where(prefecture_id: params[:prefecture_id]) if params[:prefecture_id].present?
+        stadiums = stadiums.order(:name).page(params[:page]).per(params[:per_page] || 20)
+
+        render json: paginated_response(stadiums, ::V2::StadiumSerializer)
+      end
+
+      def create
+        stadium = Stadium.new(stadium_params.merge(created_by_user: current_api_v1_user))
+        if stadium.save
+          render json: stadium, serializer: ::V2::StadiumSerializer, status: :created
+        else
+          render json: { errors: stadium.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def stadium_params
+        params.require(:stadium).permit(:name, :prefecture_id)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/stadiums_controller.rb
+++ b/app/controllers/api/v2/stadiums_controller.rb
@@ -5,11 +5,15 @@ module Api
     class StadiumsController < Api::V2::ApplicationController
       before_action :authenticate_api_v1_user!
 
+      # 1ページあたりの上限件数。クライアントから大きな値を渡されてもこの値で頭打ちにする。
+      MAX_PER_PAGE = 100
+      DEFAULT_PER_PAGE = 20
+
       def index
         stadiums = Stadium.includes(:prefecture)
         stadiums = stadiums.where('name ILIKE ?', "%#{params[:q]}%") if params[:q].present?
         stadiums = stadiums.where(prefecture_id: params[:prefecture_id]) if params[:prefecture_id].present?
-        stadiums = stadiums.order(:name).page(params[:page]).per(params[:per_page] || 20)
+        stadiums = stadiums.order(:name).page(params[:page]).per(per_page_size)
 
         render json: paginated_response(stadiums, ::V2::StadiumSerializer)
       end
@@ -27,6 +31,13 @@ module Api
 
       def stadium_params
         params.require(:stadium).permit(:name, :prefecture_id)
+      end
+
+      def per_page_size
+        requested = params[:per_page].to_i
+        return DEFAULT_PER_PAGE if requested <= 0
+
+        [requested, MAX_PER_PAGE].min
       end
     end
   end

--- a/app/controllers/api/v2/stats_controller.rb
+++ b/app/controllers/api/v2/stats_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V2
-    class StatsController < ApplicationController
+    class StatsController < Api::V2::ApplicationController
       include MatchTypeConvertible
       before_action :authenticate_api_v1_user!
 

--- a/app/controllers/api/v2/timings_controller.rb
+++ b/app/controllers/api/v2/timings_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module V2
+    # タイミングマスタ (3種) を display_order 昇順で返却する。
+    class TimingsController < Api::V2::ApplicationController
+      before_action :authenticate_api_v1_user!
+
+      def index
+        timings = Timing.order(:display_order)
+        render json: { timings: ActiveModelSerializers::SerializableResource.new(timings, each_serializer: ::V2::TimingSerializer) }
+      end
+    end
+  end
+end

--- a/app/serializers/v2/contact_quality_serializer.rb
+++ b/app/serializers/v2/contact_quality_serializer.rb
@@ -1,0 +1,5 @@
+module V2
+  class ContactQualitySerializer < ActiveModel::Serializer
+    attributes :id, :name, :display_order
+  end
+end

--- a/app/serializers/v2/hit_depth_serializer.rb
+++ b/app/serializers/v2/hit_depth_serializer.rb
@@ -1,0 +1,5 @@
+module V2
+  class HitDepthSerializer < ActiveModel::Serializer
+    attributes :id, :name, :display_order
+  end
+end

--- a/app/serializers/v2/hit_direction_serializer.rb
+++ b/app/serializers/v2/hit_direction_serializer.rb
@@ -1,0 +1,7 @@
+module V2
+  # 打球方向マスタ（13方向）。`zone_polygon` を含めて返却することで、
+  # mobile クライアントがタップ座標から方向IDを判定できるようにする。
+  class HitDirectionSerializer < ActiveModel::Serializer
+    attributes :id, :name, :display_order, :zone_polygon
+  end
+end

--- a/app/serializers/v2/pitch_type_serializer.rb
+++ b/app/serializers/v2/pitch_type_serializer.rb
@@ -1,0 +1,5 @@
+module V2
+  class PitchTypeSerializer < ActiveModel::Serializer
+    attributes :id, :name, :display_order
+  end
+end

--- a/app/serializers/v2/plate_appearance_serializer.rb
+++ b/app/serializers/v2/plate_appearance_serializer.rb
@@ -3,7 +3,38 @@ module V2
   #
   # v1ではフロントエンドが試合ごとに個別APIで打席結果を取得していた（N+1 HTTPリクエスト）。
   # v2ではGameResultSerializer経由でhas_manyとして一括返却する。
+  # issue #331 で新カラム群（打席状況・詳細データ・打球座標等）を露出するように拡張。
   class PlateAppearanceSerializer < ActiveModel::Serializer
-    attributes :id, :batter_box_number, :batting_result, :game_result_id, :batting_position_id, :plate_result_id
+    attributes :id, :game_result_id, :user_id,
+               :batter_box_number, :batting_result,
+               :plate_result_id, :hit_direction_id, :batting_position_id,
+               :out_type, :hit_type,
+               :hit_location_x, :hit_location_y,
+               :rbi, :run_scored, :stolen_bases, :caught_stealing,
+               :final_balls, :final_strikes, :final_outs,
+               :first_pitch_swing, :runners_state, :inning,
+               :self_analysis_memo, :opponent_memo,
+               :is_new_format, :has_detail_data,
+               :created_at, :updated_at
+
+    has_one :contact_quality, serializer: V2::ContactQualitySerializer
+    has_one :timing, serializer: V2::TimingSerializer
+    has_one :pitch_type, serializer: V2::PitchTypeSerializer
+    has_one :hit_depth, serializer: V2::HitDepthSerializer
+
+    # mobile 側で「詳細未入力」バッジを出すための boolean。
+    # 任意の詳細データ系カラム（マスタID・カウント・状況・メモ）のいずれかに値があれば true。
+    # JSON のキー名としてフロントが `has_detail_data` を参照する想定なので Naming/PredicateName を許容する。
+    def has_detail_data # rubocop:disable Naming/PredicateName
+      detail_attributes.any? { |attr| object.public_send(attr).present? }
+    end
+
+    private
+
+    def detail_attributes
+      %i[contact_quality_id timing_id pitch_type_id hit_depth_id
+         final_balls final_strikes final_outs first_pitch_swing
+         runners_state inning self_analysis_memo opponent_memo]
+    end
   end
 end

--- a/app/serializers/v2/prefecture_serializer.rb
+++ b/app/serializers/v2/prefecture_serializer.rb
@@ -1,0 +1,5 @@
+module V2
+  class PrefectureSerializer < ActiveModel::Serializer
+    attributes :id, :name
+  end
+end

--- a/app/serializers/v2/stadium_serializer.rb
+++ b/app/serializers/v2/stadium_serializer.rb
@@ -1,0 +1,7 @@
+module V2
+  class StadiumSerializer < ActiveModel::Serializer
+    attributes :id, :name
+
+    has_one :prefecture, serializer: V2::PrefectureSerializer
+  end
+end

--- a/app/serializers/v2/timing_serializer.rb
+++ b/app/serializers/v2/timing_serializer.rb
@@ -1,0 +1,5 @@
+module V2
+  class TimingSerializer < ActiveModel::Serializer
+    attributes :id, :name, :display_order
+  end
+end

--- a/app/services/stats/batting_average_recalculator.rb
+++ b/app/services/stats/batting_average_recalculator.rb
@@ -21,25 +21,47 @@ module Stats
     ERROR_ID = 5
 
     # @param game_result_id [Integer]
-    def initialize(game_result_id:)
+    # @param user_id [Integer, nil] batting_average を新規作成する際に使用。
+    #   nil の場合は GameResult から逆引きする（追加クエリ発生）。controller では既知の値を渡すのが望ましい。
+    # @param cleanup_orphan [Boolean] 新仕様試合でなくなった時に、孤立した batting_average を削除するか。
+    #   v2 で新仕様試合の最後の打席を削除した場合に true を指定する（旧仕様試合の batting_average は保護される）。
+    def initialize(game_result_id:, user_id: nil, cleanup_orphan: false)
       @game_result_id = game_result_id
+      @user_id = user_id
+      @cleanup_orphan = cleanup_orphan
     end
 
     # 対象試合が新仕様試合なら batting_average を再集計して保存する。
-    # 旧仕様試合の場合は何もしない（既存集計値を保持）。
+    # 新仕様試合でなく cleanup_orphan が true の場合、対応する batting_average を削除する
+    # （v2 で新仕様試合の最後の打席を削除した時の孤立レコード対策）。
+    # 旧仕様試合の場合（cleanup_orphan が false）は何もしない（既存集計値を保持）。
     #
-    # @return [BattingAverage, nil] 更新後のレコード。旧仕様試合の場合は nil
+    # @return [BattingAverage, nil] 更新後のレコード。再集計しない場合や削除した場合は nil
     def call
-      return nil unless new_format_game?
+      return recalculate_and_save if new_format_game?
+      return cleanup_orphaned_batting_average if @cleanup_orphan
 
+      nil
+    end
+
+    private
+
+    def recalculate_and_save
       batting_average = BattingAverage.find_or_initialize_by(game_result_id: @game_result_id)
-      batting_average.user_id ||= GameResult.find(@game_result_id).user_id
+      batting_average.user_id ||= resolve_user_id
       batting_average.assign_attributes(aggregate_stats)
       batting_average.save!
       batting_average
     end
 
-    private
+    def cleanup_orphaned_batting_average
+      BattingAverage.where(game_result_id: @game_result_id).destroy_all
+      nil
+    end
+
+    def resolve_user_id
+      @user_id || GameResult.find(@game_result_id).user_id
+    end
 
     # is_new_format フラグが立った打席が1件でもあれば新仕様試合
     def new_format_game?
@@ -50,11 +72,14 @@ module Stats
     def aggregate_stats # rubocop:disable Metrics/AbcSize
       scope = PlateAppearance.where(game_result_id: @game_result_id)
       with_plate_result = scope.joins(:plate_result)
+      # times_at_bat と at_bats は野球統計上は別概念（前者は打席数、後者は打数）だが、
+      # 本アプリでは既存集計テーブルに揃えて同一値で運用している（旧仕様 batting_average も同様）。
+      counted = with_plate_result.where(plate_results: { counted_in_at_bats: true }).count
 
       {
         plate_appearances: scope.count,
-        times_at_bat: with_plate_result.where(plate_results: { counted_in_at_bats: true }).count,
-        at_bats: with_plate_result.where(plate_results: { counted_in_at_bats: true }).count,
+        times_at_bat: counted,
+        at_bats: counted,
         hit: scope.where(plate_result_id: HIT_RESULT_IDS).count,
         two_base_hit: scope.where(plate_result_id: DOUBLE_HIT_ID).count,
         three_base_hit: scope.where(plate_result_id: TRIPLE_HIT_ID).count,

--- a/app/services/stats/batting_average_recalculator.rb
+++ b/app/services/stats/batting_average_recalculator.rb
@@ -1,0 +1,83 @@
+module Stats
+  # game_result 単位で batting_average レコードを再集計するサービス。
+  #
+  # 「新仕様試合」（is_new_format = true の plate_appearance が1件以上ある試合）のみを対象とする。
+  # 旧仕様試合（v1 で作成された既存試合）の batting_average は触らない。
+  #
+  # 計算ロジックは plate_result_id ベースで、mobile/constants/battingData.ts:109-162
+  # computeBattingStats と整合する結果になるよう設計されている（plate_results.counted_in_at_bats
+  # フラグおよび plate_result_id == 7,8,9,10 のヒット種別判定）。
+  class BattingAverageRecalculator
+    HIT_RESULT_IDS = [7, 8, 9, 10].freeze
+    SINGLE_HIT_ID = 7
+    DOUBLE_HIT_ID = 8
+    TRIPLE_HIT_ID = 9
+    HOME_RUN_ID = 10
+    SACRIFICE_HIT_ID = 11
+    SACRIFICE_FLY_ID = 12
+    STRIKE_OUT_IDS = [13, 14].freeze
+    BASE_ON_BALLS_ID = 15
+    HIT_BY_PITCH_ID = 16
+    ERROR_ID = 5
+
+    # @param game_result_id [Integer]
+    def initialize(game_result_id:)
+      @game_result_id = game_result_id
+    end
+
+    # 対象試合が新仕様試合なら batting_average を再集計して保存する。
+    # 旧仕様試合の場合は何もしない（既存集計値を保持）。
+    #
+    # @return [BattingAverage, nil] 更新後のレコード。旧仕様試合の場合は nil
+    def call
+      return nil unless new_format_game?
+
+      batting_average = BattingAverage.find_or_initialize_by(game_result_id: @game_result_id)
+      batting_average.user_id ||= GameResult.find(@game_result_id).user_id
+      batting_average.assign_attributes(aggregate_stats)
+      batting_average.save!
+      batting_average
+    end
+
+    private
+
+    # is_new_format フラグが立った打席が1件でもあれば新仕様試合
+    def new_format_game?
+      PlateAppearance.exists?(game_result_id: @game_result_id, is_new_format: true)
+    end
+
+    # 全カラム一気に組み立てる都合上 ABC が高くなるが、各行は独立した集計式で複雑度は低いため許容する。
+    def aggregate_stats # rubocop:disable Metrics/AbcSize
+      scope = PlateAppearance.where(game_result_id: @game_result_id)
+      with_plate_result = scope.joins(:plate_result)
+
+      {
+        plate_appearances: scope.count,
+        times_at_bat: with_plate_result.where(plate_results: { counted_in_at_bats: true }).count,
+        at_bats: with_plate_result.where(plate_results: { counted_in_at_bats: true }).count,
+        hit: scope.where(plate_result_id: HIT_RESULT_IDS).count,
+        two_base_hit: scope.where(plate_result_id: DOUBLE_HIT_ID).count,
+        three_base_hit: scope.where(plate_result_id: TRIPLE_HIT_ID).count,
+        home_run: scope.where(plate_result_id: HOME_RUN_ID).count,
+        total_bases: compute_total_bases(scope),
+        runs_batted_in: scope.sum(:rbi).to_i,
+        run: scope.sum(:run_scored).to_i,
+        strike_out: scope.where(plate_result_id: STRIKE_OUT_IDS).count,
+        base_on_balls: scope.where(plate_result_id: BASE_ON_BALLS_ID).count,
+        hit_by_pitch: scope.where(plate_result_id: HIT_BY_PITCH_ID).count,
+        sacrifice_hit: scope.where(plate_result_id: SACRIFICE_HIT_ID).count,
+        sacrifice_fly: scope.where(plate_result_id: SACRIFICE_FLY_ID).count,
+        stealing_base: scope.sum(:stolen_bases).to_i,
+        caught_stealing: scope.sum(:caught_stealing).to_i,
+        error: scope.where(plate_result_id: ERROR_ID).count
+      }
+    end
+
+    def compute_total_bases(scope)
+      scope.where(plate_result_id: SINGLE_HIT_ID).count +
+        (scope.where(plate_result_id: DOUBLE_HIT_ID).count * 2) +
+        (scope.where(plate_result_id: TRIPLE_HIT_ID).count * 3) +
+        (scope.where(plate_result_id: HOME_RUN_ID).count * 4)
+    end
+  end
+end

--- a/app/services/stats/batting_result_text_generator.rb
+++ b/app/services/stats/batting_result_text_generator.rb
@@ -1,0 +1,39 @@
+module Stats
+  # 打席結果の表示テキスト (例: "中安", "三ゴロ", "左本") をサーバー側で生成する。
+  #
+  # 旧仕様では mobile/constants/battingData.ts の getResultText でフロント生成していたが、
+  # v2 では plate_result_id と hit_direction_id（場合により out_type/hit_type）を組み合わせて
+  # サーバー側で一貫した文字列を生成・保存する。
+  class BattingResultTextGenerator
+    # mobile/constants/battingData.ts:81-98 の resultShortForms と完全一致させる
+    SHORT_FORMS = {
+      'ゴロ' => 'ゴ',
+      'フライ' => '飛',
+      'ファールフライ' => '邪飛',
+      'ライナー' => '直',
+      'エラー' => '失',
+      'フィルダースチョイス' => '野選',
+      'ヒット' => '安',
+      '二塁打' => '二',
+      '三塁打' => '三',
+      '本塁打' => '本',
+      '犠打' => '犠打',
+      '犠飛' => '犠飛',
+      '振り逃げ' => '振逃',
+      '打撃妨害' => '打妨',
+      '走塁妨害' => '走妨',
+      '併殺打' => '併'
+    }.freeze
+
+    # 打席結果テキストを生成する。
+    #
+    # @param plate_appearance [PlateAppearance] 対象の打席
+    # @return [String] 例: "中安"、"三ゴロ"、"左本"。打席方向が無い結果（三振/四球など）は短縮形のみ
+    def self.generate(plate_appearance)
+      direction_label = plate_appearance.hit_direction&.name.to_s
+      result_label = plate_appearance.plate_result&.name.to_s
+      short_form = SHORT_FORMS[result_label] || result_label
+      "#{direction_label}#{short_form}"
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -221,6 +221,18 @@ Rails.application.routes.draw do
         get :era_trend, on: :member
         get :game_summary, on: :member
       end
+
+      resources :plate_appearances, only: %i[create update destroy] do
+        collection do
+          get 'by_game/:game_result_id', action: :by_game
+        end
+      end
+      resources :stadiums, only: %i[index create]
+      resources :pitch_types, only: :index
+      resources :contact_qualities, only: :index
+      resources :timings, only: :index
+      resources :hit_depths, only: :index
+      resources :hit_directions, only: :index
     end
   end
 

--- a/db/migrate/20260531120000_add_is_new_format_to_plate_appearances.rb
+++ b/db/migrate/20260531120000_add_is_new_format_to_plate_appearances.rb
@@ -1,0 +1,6 @@
+class AddIsNewFormatToPlateAppearances < ActiveRecord::Migration[7.0]
+  def change
+    add_column :plate_appearances, :is_new_format, :boolean, default: false, null: false
+    add_index :plate_appearances, :is_new_format
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -8,9 +8,9 @@
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
-# It"s strongly recommended that you check this file into your version control system.
+# It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_260_530_120_008) do
+ActiveRecord::Schema[7.1].define(version: 20_260_531_120_000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -48,7 +48,7 @@ ActiveRecord::Schema[7.1].define(version: 20_260_530_120_008) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["month_start_date"], name: "index_admin_monthly_statistics_on_month_start_date"
-    t.index %w[year month], name: "index_admin_monthly_statistics_on_year_and_month", unique: true
+    t.index ["year", "month"], name: "index_admin_monthly_statistics_on_year_and_month", unique: true
   end
 
   create_table "admin_refresh_tokens", force: :cascade do |t|
@@ -58,7 +58,7 @@ ActiveRecord::Schema[7.1].define(version: 20_260_530_120_008) do
     t.datetime "revoked_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index %w[admin_user_id expires_at], name: "index_admin_refresh_tokens_on_admin_user_id_and_expires_at"
+    t.index ["admin_user_id", "expires_at"], name: "index_admin_refresh_tokens_on_admin_user_id_and_expires_at"
     t.index ["admin_user_id"], name: "index_admin_refresh_tokens_on_admin_user_id"
     t.index ["expires_at"], name: "index_admin_refresh_tokens_on_expires_at"
     t.index ["jti"], name: "index_admin_refresh_tokens_on_jti", unique: true
@@ -198,7 +198,7 @@ ActiveRecord::Schema[7.1].define(version: 20_260_530_120_008) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["code"], name: "index_group_invite_links_on_code", unique: true
-    t.index %w[group_id is_active], name: "index_group_invite_links_on_group_id_and_is_active"
+    t.index ["group_id", "is_active"], name: "index_group_invite_links_on_group_id_and_is_active"
     t.index ["group_id"], name: "index_group_invite_links_on_group_id"
     t.index ["inviter_id"], name: "index_group_invite_links_on_inviter_id"
   end
@@ -212,7 +212,7 @@ ActiveRecord::Schema[7.1].define(version: 20_260_530_120_008) do
     t.date "snapshot_date", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index %w[group_id user_id stat_type snapshot_date], name: "idx_group_ranking_snapshots_unique", unique: true
+    t.index ["group_id", "user_id", "stat_type", "snapshot_date"], name: "idx_group_ranking_snapshots_unique", unique: true
     t.index ["group_id"], name: "index_group_ranking_snapshots_on_group_id"
     t.index ["snapshot_date"], name: "index_group_ranking_snapshots_on_snapshot_date"
     t.index ["user_id"], name: "index_group_ranking_snapshots_on_user_id"
@@ -262,7 +262,7 @@ ActiveRecord::Schema[7.1].define(version: 20_260_530_120_008) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "notified_at"
-    t.index %w[status published_at], name: "index_management_notices_on_status_and_published_at"
+    t.index ["status", "published_at"], name: "index_management_notices_on_status_and_published_at"
   end
 
   create_table "match_results", force: :cascade do |t|
@@ -362,9 +362,11 @@ ActiveRecord::Schema[7.1].define(version: 20_260_530_120_008) do
     t.text "opponent_memo"
     t.decimal "hit_location_x", precision: 4, scale: 3
     t.decimal "hit_location_y", precision: 4, scale: 3
+    t.boolean "is_new_format", default: false, null: false
     t.index ["contact_quality_id"], name: "index_plate_appearances_on_contact_quality_id"
     t.index ["game_result_id"], name: "index_plate_appearances_on_game_result_id"
     t.index ["hit_depth_id"], name: "index_plate_appearances_on_hit_depth_id"
+    t.index ["is_new_format"], name: "index_plate_appearances_on_is_new_format"
     t.index ["pitch_type_id"], name: "index_plate_appearances_on_pitch_type_id"
     t.index ["timing_id"], name: "index_plate_appearances_on_timing_id"
     t.index ["user_id"], name: "index_plate_appearances_on_user_id"
@@ -402,7 +404,7 @@ ActiveRecord::Schema[7.1].define(version: 20_260_530_120_008) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "status", default: 1, null: false
-    t.index %w[followed_id status], name: "index_relationships_on_followed_id_and_status"
+    t.index ["followed_id", "status"], name: "index_relationships_on_followed_id_and_status"
     t.index ["followed_id"], name: "index_relationships_on_followed_id"
     t.index ["follower_id"], name: "index_relationships_on_follower_id"
   end
@@ -412,7 +414,7 @@ ActiveRecord::Schema[7.1].define(version: 20_260_530_120_008) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index %w[user_id name], name: "index_seasons_on_user_id_and_name", unique: true
+    t.index ["user_id", "name"], name: "index_seasons_on_user_id_and_name", unique: true
     t.index ["user_id"], name: "index_seasons_on_user_id"
   end
 
@@ -514,7 +516,7 @@ ActiveRecord::Schema[7.1].define(version: 20_260_530_120_008) do
     t.index ["last_login_at"], name: "index_users_on_last_login_at"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["suspended_at"], name: "index_users_on_suspended_at"
-    t.index %w[uid provider], name: "index_users_on_uid_and_provider", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
     t.index ["user_id"], name: "index_users_on_user_id", unique: true
   end
 

--- a/spec/db/migration_invariants_spec.rb
+++ b/spec/db/migration_invariants_spec.rb
@@ -38,26 +38,15 @@ RSpec.describe 'マイグレーション後の既存データ保全', type: :mod
 
     it '新カラムは NULL のまま残る' do
       plate_appearance.reload
-      expect(plate_appearance.out_type).to be_nil
-      expect(plate_appearance.hit_type).to be_nil
-      expect(plate_appearance.rbi).to be_nil
-      expect(plate_appearance.run_scored).to be_nil
-      expect(plate_appearance.stolen_bases).to be_nil
-      expect(plate_appearance.caught_stealing).to be_nil
-      expect(plate_appearance.final_balls).to be_nil
-      expect(plate_appearance.final_strikes).to be_nil
-      expect(plate_appearance.final_outs).to be_nil
-      expect(plate_appearance.first_pitch_swing).to be_nil
-      expect(plate_appearance.runners_state).to be_nil
-      expect(plate_appearance.inning).to be_nil
-      expect(plate_appearance.contact_quality_id).to be_nil
-      expect(plate_appearance.timing_id).to be_nil
-      expect(plate_appearance.pitch_type_id).to be_nil
-      expect(plate_appearance.hit_depth_id).to be_nil
-      expect(plate_appearance.self_analysis_memo).to be_nil
-      expect(plate_appearance.opponent_memo).to be_nil
-      expect(plate_appearance.hit_location_x).to be_nil
-      expect(plate_appearance.hit_location_y).to be_nil
+      new_columns = %i[out_type hit_type rbi run_scored stolen_bases caught_stealing
+                       final_balls final_strikes final_outs first_pitch_swing runners_state inning
+                       contact_quality_id timing_id pitch_type_id hit_depth_id
+                       self_analysis_memo opponent_memo hit_location_x hit_location_y]
+      aggregate_failures do
+        new_columns.each do |column|
+          expect(plate_appearance.public_send(column)).to be_nil, "expected #{column} to be nil"
+        end
+      end
     end
   end
 

--- a/spec/models/contact_quality_spec.rb
+++ b/spec/models/contact_quality_spec.rb
@@ -15,15 +15,15 @@ RSpec.describe ContactQuality, type: :model do
 
   describe 'seed data' do
     it '5種類の打球の質が投入されている' do
-      expect(ContactQuality.count).to be >= 5
+      expect(described_class.count).to be >= 5
     end
 
     it '固定IDで投入されている' do
-      expect(ContactQuality.find(1).name).to eq('真芯')
-      expect(ContactQuality.find(2).name).to eq('先っぽ')
-      expect(ContactQuality.find(3).name).to eq('詰まり')
-      expect(ContactQuality.find(4).name).to eq('擦り')
-      expect(ContactQuality.find(5).name).to eq('ドライブ')
+      expect(described_class.find(1).name).to eq('真芯')
+      expect(described_class.find(2).name).to eq('先っぽ')
+      expect(described_class.find(3).name).to eq('詰まり')
+      expect(described_class.find(4).name).to eq('擦り')
+      expect(described_class.find(5).name).to eq('ドライブ')
     end
   end
 end

--- a/spec/models/hit_depth_spec.rb
+++ b/spec/models/hit_depth_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe HitDepth, type: :model do
 
   describe 'seed data' do
     it '3種類の打球の深さが投入されている' do
-      expect(HitDepth.count).to be >= 3
+      expect(described_class.count).to be >= 3
     end
 
     it '固定IDで投入されている' do
-      expect(HitDepth.find(1).name).to eq('内野')
-      expect(HitDepth.find(2).name).to eq('外野')
-      expect(HitDepth.find(3).name).to eq('フェンス際')
+      expect(described_class.find(1).name).to eq('内野')
+      expect(described_class.find(2).name).to eq('外野')
+      expect(described_class.find(3).name).to eq('フェンス際')
     end
   end
 end

--- a/spec/models/hit_direction_spec.rb
+++ b/spec/models/hit_direction_spec.rb
@@ -15,27 +15,29 @@ RSpec.describe HitDirection, type: :model do
 
   describe 'seed data' do
     it '内野6方向 + 外野7方向の合計13方向が投入されている' do
-      expect(HitDirection.count).to be >= 13
+      expect(described_class.count).to be >= 13
     end
 
     it '既存IDの意味が維持されている（mobile/constants/battingData.ts と完全一致）' do
-      expect(HitDirection.find(1).name).to eq('投')
-      expect(HitDirection.find(2).name).to eq('捕')
-      expect(HitDirection.find(3).name).to eq('一')
-      expect(HitDirection.find(4).name).to eq('二')
-      expect(HitDirection.find(5).name).to eq('三')
-      expect(HitDirection.find(6).name).to eq('遊')
-      expect(HitDirection.find(7).name).to eq('左線')
-      expect(HitDirection.find(8).name).to eq('左')
-      expect(HitDirection.find(9).name).to eq('左中')
-      expect(HitDirection.find(10).name).to eq('中')
-      expect(HitDirection.find(11).name).to eq('右中')
-      expect(HitDirection.find(12).name).to eq('右')
-      expect(HitDirection.find(13).name).to eq('右線')
+      aggregate_failures do
+        expect(described_class.find(1).name).to eq('投')
+        expect(described_class.find(2).name).to eq('捕')
+        expect(described_class.find(3).name).to eq('一')
+        expect(described_class.find(4).name).to eq('二')
+        expect(described_class.find(5).name).to eq('三')
+        expect(described_class.find(6).name).to eq('遊')
+        expect(described_class.find(7).name).to eq('左線')
+        expect(described_class.find(8).name).to eq('左')
+        expect(described_class.find(9).name).to eq('左中')
+        expect(described_class.find(10).name).to eq('中')
+        expect(described_class.find(11).name).to eq('右中')
+        expect(described_class.find(12).name).to eq('右')
+        expect(described_class.find(13).name).to eq('右線')
+      end
     end
 
     it '内野ゾーンは depth: null の単一polygonを持つ' do
-      polygon = HitDirection.find(1).zone_polygon
+      polygon = described_class.find(1).zone_polygon
       expect(polygon).to be_a(Hash)
       expect(polygon['depth']).to be_nil
       expect(polygon['polygon']).to be_an(Array)
@@ -44,10 +46,10 @@ RSpec.describe HitDirection, type: :model do
     end
 
     it '外野ゾーンは depth_id 別の3つのpolygonを持つ' do
-      zones = HitDirection.find(10).zone_polygon
+      zones = described_class.find(10).zone_polygon
       expect(zones).to be_an(Array)
       expect(zones.size).to eq(3)
-      expect(zones.map { |z| z['depth_id'] }).to contain_exactly(1, 2, 3)
+      expect(zones.pluck('depth_id')).to contain_exactly(1, 2, 3)
       zones.each do |z|
         expect(z['polygon']).to be_an(Array)
         expect(z['polygon'].size).to eq(4)

--- a/spec/models/pitch_type_spec.rb
+++ b/spec/models/pitch_type_spec.rb
@@ -15,20 +15,22 @@ RSpec.describe PitchType, type: :model do
 
   describe 'seed data' do
     it '10種類の球種が投入されている' do
-      expect(PitchType.count).to be >= 10
+      expect(described_class.count).to be >= 10
     end
 
     it '固定IDで投入されている' do
-      expect(PitchType.find(1).name).to eq('ストレート系')
-      expect(PitchType.find(2).name).to eq('ツーシーム系')
-      expect(PitchType.find(3).name).to eq('カット系')
-      expect(PitchType.find(4).name).to eq('シュート系')
-      expect(PitchType.find(5).name).to eq('スライダー系')
-      expect(PitchType.find(6).name).to eq('カーブ系')
-      expect(PitchType.find(7).name).to eq('シンカー系')
-      expect(PitchType.find(8).name).to eq('フォーク系')
-      expect(PitchType.find(9).name).to eq('スプリット系')
-      expect(PitchType.find(10).name).to eq('チェンジアップ系')
+      aggregate_failures do
+        expect(described_class.find(1).name).to eq('ストレート系')
+        expect(described_class.find(2).name).to eq('ツーシーム系')
+        expect(described_class.find(3).name).to eq('カット系')
+        expect(described_class.find(4).name).to eq('シュート系')
+        expect(described_class.find(5).name).to eq('スライダー系')
+        expect(described_class.find(6).name).to eq('カーブ系')
+        expect(described_class.find(7).name).to eq('シンカー系')
+        expect(described_class.find(8).name).to eq('フォーク系')
+        expect(described_class.find(9).name).to eq('スプリット系')
+        expect(described_class.find(10).name).to eq('チェンジアップ系')
+      end
     end
   end
 end

--- a/spec/models/plate_appearance_spec.rb
+++ b/spec/models/plate_appearance_spec.rb
@@ -103,4 +103,22 @@ RSpec.describe PlateAppearance, type: :model do
       expect(pa).to be_valid
     end
   end
+
+  describe 'is_new_format フラグ' do
+    it 'デフォルトは false' do
+      plate_appearance = create(:plate_appearance)
+      expect(plate_appearance.is_new_format).to eq(false)
+    end
+
+    it 'true でセット可能' do
+      plate_appearance = create(:plate_appearance, is_new_format: true)
+      expect(plate_appearance.is_new_format).to eq(true)
+    end
+
+    it '既存レコード（旧仕様）は false のまま残る' do
+      plate_appearance = create(:plate_appearance)
+      plate_appearance.reload
+      expect(plate_appearance.is_new_format).to eq(false)
+    end
+  end
 end

--- a/spec/models/plate_appearance_spec.rb
+++ b/spec/models/plate_appearance_spec.rb
@@ -107,18 +107,18 @@ RSpec.describe PlateAppearance, type: :model do
   describe 'is_new_format フラグ' do
     it 'デフォルトは false' do
       plate_appearance = create(:plate_appearance)
-      expect(plate_appearance.is_new_format).to eq(false)
+      expect(plate_appearance.is_new_format).to be(false)
     end
 
     it 'true でセット可能' do
       plate_appearance = create(:plate_appearance, is_new_format: true)
-      expect(plate_appearance.is_new_format).to eq(true)
+      expect(plate_appearance.is_new_format).to be(true)
     end
 
     it '既存レコード（旧仕様）は false のまま残る' do
       plate_appearance = create(:plate_appearance)
       plate_appearance.reload
-      expect(plate_appearance.is_new_format).to eq(false)
+      expect(plate_appearance.is_new_format).to be(false)
     end
   end
 end

--- a/spec/models/plate_result_spec.rb
+++ b/spec/models/plate_result_spec.rb
@@ -15,38 +15,28 @@ RSpec.describe PlateResult, type: :model do
 
   describe 'seed data' do
     it '19種類の打席結果が投入されている' do
-      expect(PlateResult.count).to be >= 19
+      expect(described_class.count).to be >= 19
     end
 
     it '既存IDの意味が維持されている（mobile/constants/battingData.ts と完全一致）' do
-      expect(PlateResult.find(1).name).to eq('ゴロ')
-      expect(PlateResult.find(2).name).to eq('フライ')
-      expect(PlateResult.find(3).name).to eq('ファールフライ')
-      expect(PlateResult.find(4).name).to eq('ライナー')
-      expect(PlateResult.find(5).name).to eq('エラー')
-      expect(PlateResult.find(6).name).to eq('フィルダースチョイス')
-      expect(PlateResult.find(7).name).to eq('ヒット')
-      expect(PlateResult.find(8).name).to eq('二塁打')
-      expect(PlateResult.find(9).name).to eq('三塁打')
-      expect(PlateResult.find(10).name).to eq('本塁打')
-      expect(PlateResult.find(11).name).to eq('犠打')
-      expect(PlateResult.find(12).name).to eq('犠飛')
-      expect(PlateResult.find(13).name).to eq('三振')
-      expect(PlateResult.find(14).name).to eq('振り逃げ')
-      expect(PlateResult.find(15).name).to eq('四球')
-      expect(PlateResult.find(16).name).to eq('死球')
-      expect(PlateResult.find(17).name).to eq('打撃妨害')
-      expect(PlateResult.find(18).name).to eq('走塁妨害')
-      expect(PlateResult.find(19).name).to eq('併殺打')
+      expected = {
+        1 => 'ゴロ', 2 => 'フライ', 3 => 'ファールフライ', 4 => 'ライナー', 5 => 'エラー',
+        6 => 'フィルダースチョイス', 7 => 'ヒット', 8 => '二塁打', 9 => '三塁打', 10 => '本塁打',
+        11 => '犠打', 12 => '犠飛', 13 => '三振', 14 => '振り逃げ', 15 => '四球',
+        16 => '死球', 17 => '打撃妨害', 18 => '走塁妨害', 19 => '併殺打'
+      }
+      aggregate_failures do
+        expected.each { |id, name| expect(described_class.find(id).name).to eq(name) }
+      end
     end
 
     it '打数にカウントしない打席結果（四球/死球/犠打/犠飛/打撃妨害/走塁妨害）が正しく区別されている' do
-      not_counted = PlateResult.where(counted_in_at_bats: false).pluck(:name)
+      not_counted = described_class.where(counted_in_at_bats: false).pluck(:name)
       expect(not_counted).to match_array(%w[犠打 犠飛 四球 死球 打撃妨害 走塁妨害])
     end
 
     it '打球方向が不要な打席結果（三振/振り逃げ/四球/死球/打撃妨害/走塁妨害/併殺打）が正しく区別されている' do
-      no_direction = PlateResult.where(hit_direction_required: false).pluck(:name)
+      no_direction = described_class.where(hit_direction_required: false).pluck(:name)
       expect(no_direction).to match_array(%w[三振 振り逃げ 四球 死球 打撃妨害 走塁妨害 併殺打])
     end
   end

--- a/spec/models/timing_spec.rb
+++ b/spec/models/timing_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe Timing, type: :model do
 
   describe 'seed data' do
     it '3種類のタイミングが投入されている' do
-      expect(Timing.count).to be >= 3
+      expect(described_class.count).to be >= 3
     end
 
     it '固定IDで投入されている' do
-      expect(Timing.find(1).name).to eq('ドンピシャ')
-      expect(Timing.find(2).name).to eq('泳ぎ気味')
-      expect(Timing.find(3).name).to eq('遅れ気味')
+      expect(described_class.find(1).name).to eq('ドンピシャ')
+      expect(described_class.find(2).name).to eq('泳ぎ気味')
+      expect(described_class.find(3).name).to eq('遅れ気味')
     end
   end
 end

--- a/spec/requests/api/v2/contact_qualities_spec.rb
+++ b/spec/requests/api/v2/contact_qualities_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::ContactQualities', type: :request do
+  let(:user) { create(:user) }
+
+  describe 'GET /api/v2/contact_qualities' do
+    context 'when authenticated' do
+      it 'returns 200 with all contact qualities ordered by display_order' do
+        get '/api/v2/contact_qualities', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json).to have_key('contact_qualities')
+        expect(json['contact_qualities'].size).to eq(5)
+        expect(json['contact_qualities'].first).to include('id' => 1, 'name' => '真芯')
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v2/contact_qualities'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/data_integrity_spec.rb
+++ b/spec/requests/api/v2/data_integrity_spec.rb
@@ -11,14 +11,15 @@ RSpec.describe 'v2 経由打席操作の既存データ保全', type: :request d
 
   describe '旧仕様試合（is_new_format=false の打席のみ）の batting_average を v2 が改変しない' do
     let(:old_format_game) { create(:game_result, user:) }
-    let!(:old_plate_appearance) do
-      create(:plate_appearance, game_result: old_format_game, user:, plate_result_id: 7,
-                                hit_direction_id: 10, is_new_format: false, batting_result: '中安')
-    end
     let!(:old_batting_average) do
       # フロントから直接保存された既存値（サーバー計算とは異なる値を意図的に設定）
       create(:batting_average, game_result: old_format_game, user:,
                                at_bats: 99, hit: 88, total_bases: 77)
+    end
+
+    before do
+      create(:plate_appearance, game_result: old_format_game, user:, plate_result_id: 7,
+                                hit_direction_id: 10, is_new_format: false, batting_result: '中安')
     end
 
     it '別試合に v2 で新仕様の打席を作成しても、旧仕様試合の batting_average は不変' do
@@ -68,7 +69,8 @@ RSpec.describe 'v2 経由打席操作の既存データ保全', type: :request d
   describe 'ユーザー通算打率が新旧の batting_average を合算して算出される' do
     let(:old_game) { create(:game_result, user:) }
     let(:new_game) { create(:game_result, user:) }
-    let!(:old_batting_average) do
+
+    before do
       create(:batting_average, game_result: old_game, user:,
                                at_bats: 3, hit: 1, two_base_hit: 0, three_base_hit: 0, home_run: 0,
                                total_bases: 1, runs_batted_in: 0, strike_out: 1, base_on_balls: 0,

--- a/spec/requests/api/v2/data_integrity_spec.rb
+++ b/spec/requests/api/v2/data_integrity_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+# v2 API 経由の打席操作が、既存ユーザーデータを破壊しないことを担保する。
+#
+# 検証ポイント:
+# - 旧仕様試合の batting_average レコードに v2 が触らない
+# - v2 で新仕様試合を作成しても、別試合の batting_average に影響しない
+# - ユーザー通算打率が新旧合算で一貫している（BattingAverage.aggregate_for_user の SUM）
+RSpec.describe 'v2 経由打席操作の既存データ保全', type: :request do
+  let(:user) { create(:user) }
+
+  describe '旧仕様試合（is_new_format=false の打席のみ）の batting_average を v2 が改変しない' do
+    let(:old_format_game) { create(:game_result, user:) }
+    let!(:old_plate_appearance) do
+      create(:plate_appearance, game_result: old_format_game, user:, plate_result_id: 7,
+                                hit_direction_id: 10, is_new_format: false, batting_result: '中安')
+    end
+    let!(:old_batting_average) do
+      # フロントから直接保存された既存値（サーバー計算とは異なる値を意図的に設定）
+      create(:batting_average, game_result: old_format_game, user:,
+                               at_bats: 99, hit: 88, total_bases: 77)
+    end
+
+    it '別試合に v2 で新仕様の打席を作成しても、旧仕様試合の batting_average は不変' do
+      new_format_game = create(:game_result, user:)
+
+      post '/api/v2/plate_appearances',
+           params: {
+             plate_appearance: {
+               game_result_id: new_format_game.id, batter_box_number: 1,
+               plate_result_id: 7, hit_direction_id: 10
+             }
+           },
+           headers: auth_headers_for(user)
+
+      expect(response).to have_http_status(:created)
+
+      old_batting_average.reload
+      expect(old_batting_average.at_bats).to eq(99)
+      expect(old_batting_average.hit).to eq(88)
+      expect(old_batting_average.total_bases).to eq(77)
+    end
+  end
+
+  describe 'v2 で同じ game_result に複数打席を追加しても、別 game_result の batting_average に影響しない' do
+    let(:target_game) { create(:game_result, user:) }
+    let(:other_game) { create(:game_result, user:) }
+    let!(:other_batting_average) do
+      create(:batting_average, game_result: other_game, user:, at_bats: 50, hit: 25)
+    end
+
+    it '他試合の batting_average は不変' do
+      post '/api/v2/plate_appearances',
+           params: {
+             plate_appearance: {
+               game_result_id: target_game.id, batter_box_number: 1,
+               plate_result_id: 8, hit_direction_id: 9
+             }
+           },
+           headers: auth_headers_for(user)
+
+      other_batting_average.reload
+      expect(other_batting_average.at_bats).to eq(50)
+      expect(other_batting_average.hit).to eq(25)
+    end
+  end
+
+  describe 'ユーザー通算打率が新旧の batting_average を合算して算出される' do
+    let(:old_game) { create(:game_result, user:) }
+    let(:new_game) { create(:game_result, user:) }
+    let!(:old_batting_average) do
+      create(:batting_average, game_result: old_game, user:,
+                               at_bats: 3, hit: 1, two_base_hit: 0, three_base_hit: 0, home_run: 0,
+                               total_bases: 1, runs_batted_in: 0, strike_out: 1, base_on_balls: 0,
+                               hit_by_pitch: 0, sacrifice_hit: 0, sacrifice_fly: 0,
+                               stealing_base: 0, caught_stealing: 0, error: 0)
+    end
+
+    it 'v2 で新仕様試合の打席を追加すると、aggregate_for_user は新旧合算した SUM を返す' do
+      post '/api/v2/plate_appearances',
+           params: {
+             plate_appearance: {
+               game_result_id: new_game.id, batter_box_number: 1,
+               plate_result_id: 7, hit_direction_id: 10, rbi: 1
+             }
+           },
+           headers: auth_headers_for(user)
+      post '/api/v2/plate_appearances',
+           params: {
+             plate_appearance: {
+               game_result_id: new_game.id, batter_box_number: 2,
+               plate_result_id: 13
+             }
+           },
+           headers: auth_headers_for(user)
+
+      aggregated = BattingAverage.aggregate_for_user(user.id).reorder(nil).take
+      # 旧 (at_bats=3, hit=1) + 新 (at_bats=2, hit=1) = 合算 (at_bats=5, hit=2)
+      expect(aggregated.at_bats.to_i).to eq(5)
+      expect(aggregated.hit.to_i).to eq(2)
+    end
+  end
+end

--- a/spec/requests/api/v2/hit_depths_spec.rb
+++ b/spec/requests/api/v2/hit_depths_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::HitDepths', type: :request do
+  let(:user) { create(:user) }
+
+  describe 'GET /api/v2/hit_depths' do
+    context 'when authenticated' do
+      it 'returns 200 with all hit depths' do
+        get '/api/v2/hit_depths', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json['hit_depths'].size).to eq(3)
+        expect(json['hit_depths'].first).to include('id' => 1, 'name' => '内野')
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v2/hit_depths'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/hit_directions_spec.rb
+++ b/spec/requests/api/v2/hit_directions_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::HitDirections', type: :request do
+  let(:user) { create(:user) }
+
+  describe 'GET /api/v2/hit_directions' do
+    context 'when authenticated' do
+      it 'returns 200 with all 13 directions including zone_polygon' do
+        get '/api/v2/hit_directions', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json['hit_directions'].size).to eq(13)
+        first = json['hit_directions'].first
+        expect(first).to include('id' => 1, 'name' => '投')
+        expect(first['zone_polygon']).to be_present
+      end
+
+      it '内野方向は depth: nil の単一polygon' do
+        get '/api/v2/hit_directions', headers: auth_headers_for(user)
+        infield = response.parsed_body['hit_directions'].find { |item| item['id'] == 1 }
+        expect(infield['zone_polygon']).to include('depth' => nil)
+        expect(infield['zone_polygon']['polygon']).to be_an(Array)
+      end
+
+      it '外野方向は depth_id 別の複数polygon (配列)' do
+        get '/api/v2/hit_directions', headers: auth_headers_for(user)
+        outfield = response.parsed_body['hit_directions'].find { |item| item['id'] == 10 }
+        expect(outfield['zone_polygon']).to be_an(Array)
+        expect(outfield['zone_polygon'].map { |zone| zone['depth_id'] }).to contain_exactly(1, 2, 3)
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v2/hit_directions'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/hit_directions_spec.rb
+++ b/spec/requests/api/v2/hit_directions_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Api::V2::HitDirections', type: :request do
         get '/api/v2/hit_directions', headers: auth_headers_for(user)
         outfield = response.parsed_body['hit_directions'].find { |item| item['id'] == 10 }
         expect(outfield['zone_polygon']).to be_an(Array)
-        expect(outfield['zone_polygon'].map { |zone| zone['depth_id'] }).to contain_exactly(1, 2, 3)
+        expect(outfield['zone_polygon'].pluck('depth_id')).to contain_exactly(1, 2, 3)
       end
     end
 

--- a/spec/requests/api/v2/pitch_types_spec.rb
+++ b/spec/requests/api/v2/pitch_types_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Api::V2::PitchTypes', type: :request do
         expect(json).to have_key('pitch_types')
         expect(json['pitch_types'].size).to eq(10)
         expect(json['pitch_types'].first).to include('id' => 1, 'name' => 'ストレート系', 'display_order' => 1)
-        expect(json['pitch_types'].map { |item| item['display_order'] }).to eq((1..10).to_a)
+        expect(json['pitch_types'].pluck('display_order')).to eq((1..10).to_a)
       end
     end
 

--- a/spec/requests/api/v2/pitch_types_spec.rb
+++ b/spec/requests/api/v2/pitch_types_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::PitchTypes', type: :request do
+  let(:user) { create(:user) }
+
+  describe 'GET /api/v2/pitch_types' do
+    context 'when authenticated' do
+      it 'returns 200 with all pitch types ordered by display_order' do
+        get '/api/v2/pitch_types', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json).to have_key('pitch_types')
+        expect(json['pitch_types'].size).to eq(10)
+        expect(json['pitch_types'].first).to include('id' => 1, 'name' => 'ストレート系', 'display_order' => 1)
+        expect(json['pitch_types'].map { |item| item['display_order'] }).to eq((1..10).to_a)
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v2/pitch_types'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/plate_appearances_spec.rb
+++ b/spec/requests/api/v2/plate_appearances_spec.rb
@@ -1,0 +1,155 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::PlateAppearances', type: :request do
+  let(:user) { create(:user) }
+  let(:game_result) { create(:game_result, user:) }
+
+  describe 'POST /api/v2/plate_appearances' do
+    let(:base_params) do
+      {
+        plate_appearance: {
+          game_result_id: game_result.id,
+          batter_box_number: 1,
+          plate_result_id: 7,
+          hit_direction_id: 10,
+          hit_location_x: 0.5,
+          hit_location_y: 0.3,
+          rbi: 1,
+          run_scored: 0
+        }
+      }
+    end
+
+    context 'when authenticated' do
+      it '201 で作成され、batting_result がサーバー生成された値で返る' do
+        post '/api/v2/plate_appearances', params: base_params, headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:created)
+        json = response.parsed_body
+        expect(json['batting_result']).to eq('中安')
+        expect(json['is_new_format']).to eq(true)
+      end
+
+      it '作成された打席は is_new_format=true で保存される' do
+        post '/api/v2/plate_appearances', params: base_params, headers: auth_headers_for(user)
+        created = PlateAppearance.find(response.parsed_body['id'])
+        expect(created.is_new_format).to eq(true)
+      end
+
+      it 'batting_average が再集計されて作成される' do
+        expect do
+          post '/api/v2/plate_appearances', params: base_params, headers: auth_headers_for(user)
+        end.to change { BattingAverage.where(game_result_id: game_result.id).count }.from(0).to(1)
+
+        batting_average = BattingAverage.find_by(game_result_id: game_result.id)
+        expect(batting_average.hit).to eq(1)
+        expect(batting_average.at_bats).to eq(1)
+      end
+
+      it 'バリデーションエラーは 422' do
+        bad_params = { plate_appearance: { game_result_id: nil } }
+        post '/api/v2/plate_appearances', params: bad_params, headers: auth_headers_for(user)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        post '/api/v2/plate_appearances', params: base_params
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'PATCH /api/v2/plate_appearances/:id' do
+    let!(:plate_appearance) do
+      create(:plate_appearance, game_result:, user:, plate_result_id: 1,
+                                hit_direction_id: 1, is_new_format: true, batter_box_number: 1)
+    end
+
+    context 'when authenticated' do
+      it '200 で更新され、batting_result が再生成される' do
+        patch "/api/v2/plate_appearances/#{plate_appearance.id}",
+              params: { plate_appearance: { plate_result_id: 7, hit_direction_id: 10 } },
+              headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['batting_result']).to eq('中安')
+      end
+
+      it '他ユーザーの打席は更新できない (404)' do
+        other_user = create(:user)
+        patch "/api/v2/plate_appearances/#{plate_appearance.id}",
+              params: { plate_appearance: { plate_result_id: 7 } },
+              headers: auth_headers_for(other_user)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        patch "/api/v2/plate_appearances/#{plate_appearance.id}",
+              params: { plate_appearance: { plate_result_id: 7 } }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'DELETE /api/v2/plate_appearances/:id' do
+    let!(:plate_appearance) do
+      create(:plate_appearance, game_result:, user:, plate_result_id: 7,
+                                hit_direction_id: 10, is_new_format: true, batter_box_number: 1)
+    end
+
+    context 'when authenticated' do
+      it '削除して batting_average を再計算する' do
+        delete "/api/v2/plate_appearances/#{plate_appearance.id}", headers: auth_headers_for(user)
+        expect(response).to have_http_status(:ok)
+        expect(PlateAppearance.where(id: plate_appearance.id)).not_to exist
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        delete "/api/v2/plate_appearances/#{plate_appearance.id}"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'GET /api/v2/plate_appearances/by_game/:game_result_id' do
+    let!(:plate_appearance_1) do
+      create(:plate_appearance, game_result:, user:, plate_result_id: 7,
+                                hit_direction_id: 10, is_new_format: true, batter_box_number: 1)
+    end
+    let!(:plate_appearance_2) do
+      create(:plate_appearance, game_result:, user:, plate_result_id: 1,
+                                hit_direction_id: 1, is_new_format: true, batter_box_number: 2)
+    end
+
+    context 'when authenticated' do
+      it '試合の全打席を batter_box_number 昇順で返す' do
+        get "/api/v2/plate_appearances/by_game/#{game_result.id}", headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        items = response.parsed_body['plate_appearances']
+        expect(items.size).to eq(2)
+        expect(items.map { |item| item['batter_box_number'] }).to eq([1, 2])
+      end
+
+      it '非公開ユーザーの試合は 403' do
+        private_user = create(:user, is_private: true)
+        private_game = create(:game_result, user: private_user)
+        get "/api/v2/plate_appearances/by_game/#{private_game.id}", headers: auth_headers_for(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get "/api/v2/plate_appearances/by_game/#{game_result.id}"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/plate_appearances_spec.rb
+++ b/spec/requests/api/v2/plate_appearances_spec.rb
@@ -109,6 +109,12 @@ RSpec.describe 'Api::V2::PlateAppearances', type: :request do
         expect(response).to have_http_status(:ok)
         expect(PlateAppearance.where(id: plate_appearance.id)).not_to exist
       end
+
+      it '新仕様試合の最後の打席を削除すると孤立する batting_average も削除される' do
+        create(:batting_average, game_result:, user:, at_bats: 1, hit: 1)
+        delete "/api/v2/plate_appearances/#{plate_appearance.id}", headers: auth_headers_for(user)
+        expect(BattingAverage.where(game_result_id: game_result.id)).not_to exist
+      end
     end
 
     context 'when not authenticated' do

--- a/spec/requests/api/v2/plate_appearances_spec.rb
+++ b/spec/requests/api/v2/plate_appearances_spec.rb
@@ -27,13 +27,13 @@ RSpec.describe 'Api::V2::PlateAppearances', type: :request do
         expect(response).to have_http_status(:created)
         json = response.parsed_body
         expect(json['batting_result']).to eq('中安')
-        expect(json['is_new_format']).to eq(true)
+        expect(json['is_new_format']).to be(true)
       end
 
       it '作成された打席は is_new_format=true で保存される' do
         post '/api/v2/plate_appearances', params: base_params, headers: auth_headers_for(user)
         created = PlateAppearance.find(response.parsed_body['id'])
-        expect(created.is_new_format).to eq(true)
+        expect(created.is_new_format).to be(true)
       end
 
       it 'batting_average が再集計されて作成される' do
@@ -46,10 +46,12 @@ RSpec.describe 'Api::V2::PlateAppearances', type: :request do
         expect(batting_average.at_bats).to eq(1)
       end
 
-      it 'バリデーションエラーは 422' do
-        bad_params = { plate_appearance: { game_result_id: nil } }
+      it '他ユーザーの game_result_id を指定すると 404（IDOR防止）' do
+        other_user = create(:user)
+        other_game = create(:game_result, user: other_user)
+        bad_params = { plate_appearance: { game_result_id: other_game.id, batter_box_number: 1 } }
         post '/api/v2/plate_appearances', params: bad_params, headers: auth_headers_for(user)
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
@@ -118,11 +120,9 @@ RSpec.describe 'Api::V2::PlateAppearances', type: :request do
   end
 
   describe 'GET /api/v2/plate_appearances/by_game/:game_result_id' do
-    let!(:plate_appearance_1) do
+    before do
       create(:plate_appearance, game_result:, user:, plate_result_id: 7,
                                 hit_direction_id: 10, is_new_format: true, batter_box_number: 1)
-    end
-    let!(:plate_appearance_2) do
       create(:plate_appearance, game_result:, user:, plate_result_id: 1,
                                 hit_direction_id: 1, is_new_format: true, batter_box_number: 2)
     end
@@ -134,7 +134,7 @@ RSpec.describe 'Api::V2::PlateAppearances', type: :request do
         expect(response).to have_http_status(:ok)
         items = response.parsed_body['plate_appearances']
         expect(items.size).to eq(2)
-        expect(items.map { |item| item['batter_box_number'] }).to eq([1, 2])
+        expect(items.pluck('batter_box_number')).to eq([1, 2])
       end
 
       it '非公開ユーザーの試合は 403' do

--- a/spec/requests/api/v2/stadiums_spec.rb
+++ b/spec/requests/api/v2/stadiums_spec.rb
@@ -35,6 +35,11 @@ RSpec.describe 'Api::V2::Stadiums', type: :request do
         expect(names).to include('テスト東京ドーム')
         expect(names).not_to include('テスト京セラドーム')
       end
+
+      it 'per_page は MAX_PER_PAGE (100) を超えられない（DoS防止）' do
+        get '/api/v2/stadiums', params: { per_page: 999_999 }, headers: auth_headers_for(user)
+        expect(response.parsed_body['pagination']['per_page']).to eq(100)
+      end
     end
 
     context 'when not authenticated' do

--- a/spec/requests/api/v2/stadiums_spec.rb
+++ b/spec/requests/api/v2/stadiums_spec.rb
@@ -6,8 +6,11 @@ RSpec.describe 'Api::V2::Stadiums', type: :request do
   describe 'GET /api/v2/stadiums' do
     let!(:tokyo) { Prefecture.create!(name: 'スタジアム検証_東京') }
     let!(:osaka) { Prefecture.create!(name: 'スタジアム検証_大阪') }
-    let!(:tokyo_dome) { Stadium.create!(name: 'テスト東京ドーム', prefecture: tokyo, created_by_user: user) }
-    let!(:osaka_dome) { Stadium.create!(name: 'テスト京セラドーム', prefecture: osaka, created_by_user: user) }
+
+    before do
+      Stadium.create!(name: 'テスト東京ドーム', prefecture: tokyo, created_by_user: user)
+      Stadium.create!(name: 'テスト京セラドーム', prefecture: osaka, created_by_user: user)
+    end
 
     context 'when authenticated' do
       it 'returns 200 with paginated stadiums' do
@@ -21,14 +24,14 @@ RSpec.describe 'Api::V2::Stadiums', type: :request do
 
       it 'q パラメータで部分一致検索ができる' do
         get '/api/v2/stadiums', params: { q: '京セラ' }, headers: auth_headers_for(user)
-        names = response.parsed_body['data'].map { |item| item['name'] }
+        names = response.parsed_body['data'].pluck('name')
         expect(names).to include('テスト京セラドーム')
         expect(names).not_to include('テスト東京ドーム')
       end
 
       it 'prefecture_id で都道府県絞り込みができる' do
         get '/api/v2/stadiums', params: { prefecture_id: tokyo.id }, headers: auth_headers_for(user)
-        names = response.parsed_body['data'].map { |item| item['name'] }
+        names = response.parsed_body['data'].pluck('name')
         expect(names).to include('テスト東京ドーム')
         expect(names).not_to include('テスト京セラドーム')
       end

--- a/spec/requests/api/v2/stadiums_spec.rb
+++ b/spec/requests/api/v2/stadiums_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::Stadiums', type: :request do
+  let(:user) { create(:user) }
+
+  describe 'GET /api/v2/stadiums' do
+    let!(:tokyo) { Prefecture.create!(name: 'スタジアム検証_東京') }
+    let!(:osaka) { Prefecture.create!(name: 'スタジアム検証_大阪') }
+    let!(:tokyo_dome) { Stadium.create!(name: 'テスト東京ドーム', prefecture: tokyo, created_by_user: user) }
+    let!(:osaka_dome) { Stadium.create!(name: 'テスト京セラドーム', prefecture: osaka, created_by_user: user) }
+
+    context 'when authenticated' do
+      it 'returns 200 with paginated stadiums' do
+        get '/api/v2/stadiums', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json).to have_key('data')
+        expect(json).to have_key('pagination')
+      end
+
+      it 'q パラメータで部分一致検索ができる' do
+        get '/api/v2/stadiums', params: { q: '京セラ' }, headers: auth_headers_for(user)
+        names = response.parsed_body['data'].map { |item| item['name'] }
+        expect(names).to include('テスト京セラドーム')
+        expect(names).not_to include('テスト東京ドーム')
+      end
+
+      it 'prefecture_id で都道府県絞り込みができる' do
+        get '/api/v2/stadiums', params: { prefecture_id: tokyo.id }, headers: auth_headers_for(user)
+        names = response.parsed_body['data'].map { |item| item['name'] }
+        expect(names).to include('テスト東京ドーム')
+        expect(names).not_to include('テスト京セラドーム')
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v2/stadiums'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'POST /api/v2/stadiums' do
+    let!(:prefecture) { Prefecture.create!(name: 'スタジアム検証_愛知') }
+
+    context 'when authenticated' do
+      it '新規球場を作成して created_by_user_id を自動付与する' do
+        post '/api/v2/stadiums',
+             params: { stadium: { name: 'テストナゴヤドーム', prefecture_id: prefecture.id } },
+             headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:created)
+        created = Stadium.find_by(name: 'テストナゴヤドーム')
+        expect(created).to be_present
+        expect(created.created_by_user_id).to eq(user.id)
+        expect(created.prefecture_id).to eq(prefecture.id)
+      end
+
+      it 'name が空の場合は 422' do
+        post '/api/v2/stadiums',
+             params: { stadium: { name: '', prefecture_id: prefecture.id } },
+             headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['errors']).to be_present
+      end
+
+      it '同一県内で同名の場合は 422（一意性違反）' do
+        Stadium.create!(name: '重複テスト球場', prefecture:, created_by_user: user)
+        post '/api/v2/stadiums',
+             params: { stadium: { name: '重複テスト球場', prefecture_id: prefecture.id } },
+             headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        post '/api/v2/stadiums', params: { stadium: { name: 'X' } }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/timings_spec.rb
+++ b/spec/requests/api/v2/timings_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::Timings', type: :request do
+  let(:user) { create(:user) }
+
+  describe 'GET /api/v2/timings' do
+    context 'when authenticated' do
+      it 'returns 200 with all timings' do
+        get '/api/v2/timings', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json['timings'].size).to eq(3)
+        expect(json['timings'].first).to include('id' => 1, 'name' => 'ドンピシャ')
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v2/timings'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/services/stats/batting_average_recalculator_spec.rb
+++ b/spec/services/stats/batting_average_recalculator_spec.rb
@@ -30,18 +30,20 @@ RSpec.describe Stats::BattingAverageRecalculator, type: :service do
         described_class.new(game_result_id: game_result.id).call
         batting_average = BattingAverage.find_by(game_result_id: game_result.id)
 
-        expect(batting_average.plate_appearances).to eq(4)
-        expect(batting_average.at_bats).to eq(3)              # 7,8,13 が counted_in_at_bats: true（15=四球は false）
-        expect(batting_average.times_at_bat).to eq(3)
-        expect(batting_average.hit).to eq(2)                  # 7 (単打) + 8 (二塁打)
-        expect(batting_average.two_base_hit).to eq(1)
-        expect(batting_average.three_base_hit).to eq(0)
-        expect(batting_average.home_run).to eq(0)
-        expect(batting_average.total_bases).to eq(3)          # 単打 1 + 二塁打 2
-        expect(batting_average.strike_out).to eq(1)
-        expect(batting_average.base_on_balls).to eq(1)
-        expect(batting_average.runs_batted_in).to eq(3)       # rbi の sum
-        expect(batting_average.stealing_base).to eq(1)
+        aggregate_failures do
+          expect(batting_average.plate_appearances).to eq(4)
+          expect(batting_average.at_bats).to eq(3)              # 7,8,13 が counted_in_at_bats: true（15=四球は false）
+          expect(batting_average.times_at_bat).to eq(3)
+          expect(batting_average.hit).to eq(2)                  # 7 (単打) + 8 (二塁打)
+          expect(batting_average.two_base_hit).to eq(1)
+          expect(batting_average.three_base_hit).to eq(0)
+          expect(batting_average.home_run).to eq(0)
+          expect(batting_average.total_bases).to eq(3)          # 単打 1 + 二塁打 2
+          expect(batting_average.strike_out).to eq(1)
+          expect(batting_average.base_on_balls).to eq(1)
+          expect(batting_average.runs_batted_in).to eq(3)       # rbi の sum
+          expect(batting_average.stealing_base).to eq(1)
+        end
       end
 
       it '同 game_result_id に再度呼ばれても結果は安定する（idempotent）' do
@@ -56,13 +58,14 @@ RSpec.describe Stats::BattingAverageRecalculator, type: :service do
     end
 
     context '旧仕様試合（すべての打席が is_new_format=false）' do
-      let!(:existing_plate_appearance) do
-        create(:plate_appearance, game_result:, user:, plate_result_id: 7, hit_direction_id: 10,
-                                  is_new_format: false, batting_result: '中安')
-      end
       let!(:existing_batting_average) do
         create(:batting_average, game_result:, user:,
                                  at_bats: 99, hit: 88, total_bases: 77)
+      end
+
+      before do
+        create(:plate_appearance, game_result:, user:, plate_result_id: 7, hit_direction_id: 10,
+                                  is_new_format: false, batting_result: '中安')
       end
 
       it 'call は nil を返し、既存 batting_average の値を改変しない' do
@@ -77,7 +80,7 @@ RSpec.describe Stats::BattingAverageRecalculator, type: :service do
     end
 
     context '新仕様試合で batting_average レコードがまだ無い場合' do
-      let!(:plate_appearance) do
+      before do
         create(:plate_appearance, game_result:, user:, plate_result_id: 7, hit_direction_id: 10,
                                   is_new_format: true)
       end

--- a/spec/services/stats/batting_average_recalculator_spec.rb
+++ b/spec/services/stats/batting_average_recalculator_spec.rb
@@ -91,5 +91,35 @@ RSpec.describe Stats::BattingAverageRecalculator, type: :service do
         end.to change { BattingAverage.where(game_result_id: game_result.id).count }.from(0).to(1)
       end
     end
+
+    context '新仕様試合の最後の打席が削除されて新仕様打席がゼロになった場合' do
+      let!(:orphan_batting_average) { create(:batting_average, game_result:, user:, at_bats: 1, hit: 1) }
+
+      # 削除後を想定して plate_appearance は作成しない（new_format_game? = false）
+
+      it 'cleanup_orphan: true で対応する batting_average を削除する（孤立レコード防止）' do
+        expect do
+          described_class.new(game_result_id: game_result.id, cleanup_orphan: true).call
+        end.to change { BattingAverage.where(id: orphan_batting_average.id).count }.from(1).to(0)
+      end
+
+      it 'cleanup_orphan: false（デフォルト）の場合は触らない（旧仕様試合の batting_average 保護）' do
+        described_class.new(game_result_id: game_result.id).call
+        expect(BattingAverage.find_by(id: orphan_batting_average.id)).to be_present
+      end
+    end
+
+    context 'user_id を引数で渡した場合' do
+      before do
+        create(:plate_appearance, game_result:, user:, plate_result_id: 7, hit_direction_id: 10,
+                                  is_new_format: true)
+      end
+
+      it 'GameResult への追加クエリなしで batting_average.user_id を設定する' do
+        described_class.new(game_result_id: game_result.id, user_id: user.id).call
+        batting_average = BattingAverage.find_by(game_result_id: game_result.id)
+        expect(batting_average.user_id).to eq(user.id)
+      end
+    end
   end
 end

--- a/spec/services/stats/batting_average_recalculator_spec.rb
+++ b/spec/services/stats/batting_average_recalculator_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe Stats::BattingAverageRecalculator, type: :service do
+  let(:user) { create(:user) }
+  let(:game_result) { create(:game_result, user:) }
+
+  describe '#call' do
+    context '新仕様試合（is_new_format=true の打席が1件以上ある場合）' do
+      before do
+        # is_new_format=true の打席を 4 件作成: ヒット, 単打, 二塁打, 三振
+        create(:plate_appearance, game_result:, user:, plate_result_id: 7, hit_direction_id: 10,
+                                  is_new_format: true, rbi: 1, run_scored: 0, stolen_bases: 0, caught_stealing: 0)
+        create(:plate_appearance, game_result:, user:, plate_result_id: 8, hit_direction_id: 8,
+                                  is_new_format: true, rbi: 2, run_scored: 0, stolen_bases: 0, caught_stealing: 0)
+        create(:plate_appearance, game_result:, user:, plate_result_id: 13, hit_direction_id: nil,
+                                  is_new_format: true, rbi: 0, run_scored: 0, stolen_bases: 0, caught_stealing: 0)
+        create(:plate_appearance, game_result:, user:, plate_result_id: 15, hit_direction_id: nil,
+                                  is_new_format: true, rbi: 0, run_scored: 0, stolen_bases: 1, caught_stealing: 0)
+      end
+
+      it 'batting_average レコードを find_or_create_by + assign する' do
+        described_class.new(game_result_id: game_result.id).call
+
+        batting_average = BattingAverage.find_by(game_result_id: game_result.id)
+        expect(batting_average).to be_present
+        expect(batting_average.user_id).to eq(user.id)
+      end
+
+      it '主要カラムが plate_result_id ベースで集計される' do
+        described_class.new(game_result_id: game_result.id).call
+        batting_average = BattingAverage.find_by(game_result_id: game_result.id)
+
+        expect(batting_average.plate_appearances).to eq(4)
+        expect(batting_average.at_bats).to eq(3)              # 7,8,13 が counted_in_at_bats: true（15=四球は false）
+        expect(batting_average.times_at_bat).to eq(3)
+        expect(batting_average.hit).to eq(2)                  # 7 (単打) + 8 (二塁打)
+        expect(batting_average.two_base_hit).to eq(1)
+        expect(batting_average.three_base_hit).to eq(0)
+        expect(batting_average.home_run).to eq(0)
+        expect(batting_average.total_bases).to eq(3)          # 単打 1 + 二塁打 2
+        expect(batting_average.strike_out).to eq(1)
+        expect(batting_average.base_on_balls).to eq(1)
+        expect(batting_average.runs_batted_in).to eq(3)       # rbi の sum
+        expect(batting_average.stealing_base).to eq(1)
+      end
+
+      it '同 game_result_id に再度呼ばれても結果は安定する（idempotent）' do
+        described_class.new(game_result_id: game_result.id).call
+        batting_average_first = BattingAverage.find_by(game_result_id: game_result.id).attributes.except('updated_at')
+
+        described_class.new(game_result_id: game_result.id).call
+        batting_average_second = BattingAverage.find_by(game_result_id: game_result.id).attributes.except('updated_at')
+
+        expect(batting_average_second).to eq(batting_average_first)
+      end
+    end
+
+    context '旧仕様試合（すべての打席が is_new_format=false）' do
+      let!(:existing_plate_appearance) do
+        create(:plate_appearance, game_result:, user:, plate_result_id: 7, hit_direction_id: 10,
+                                  is_new_format: false, batting_result: '中安')
+      end
+      let!(:existing_batting_average) do
+        create(:batting_average, game_result:, user:,
+                                 at_bats: 99, hit: 88, total_bases: 77)
+      end
+
+      it 'call は nil を返し、既存 batting_average の値を改変しない' do
+        result = described_class.new(game_result_id: game_result.id).call
+
+        expect(result).to be_nil
+        existing_batting_average.reload
+        expect(existing_batting_average.at_bats).to eq(99)
+        expect(existing_batting_average.hit).to eq(88)
+        expect(existing_batting_average.total_bases).to eq(77)
+      end
+    end
+
+    context '新仕様試合で batting_average レコードがまだ無い場合' do
+      let!(:plate_appearance) do
+        create(:plate_appearance, game_result:, user:, plate_result_id: 7, hit_direction_id: 10,
+                                  is_new_format: true)
+      end
+
+      it 'find_or_create_by で新規作成される' do
+        expect do
+          described_class.new(game_result_id: game_result.id).call
+        end.to change { BattingAverage.where(game_result_id: game_result.id).count }.from(0).to(1)
+      end
+    end
+  end
+end

--- a/spec/services/stats/batting_result_text_generator_spec.rb
+++ b/spec/services/stats/batting_result_text_generator_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe Stats::BattingResultTextGenerator, type: :service do
+  describe '.generate' do
+    # mobile/constants/battingData.ts:100-107 の getResultText と同じ出力になることを担保
+    {
+      [10, 7] => '中安', # 中 + ヒット
+      [1, 1] => '投ゴ', # 投 + ゴロ
+      [8, 10] => '左本', # 左 + 本塁打
+      [13, 8] => '右線二', # 右線 + 二塁打
+      [5, 5] => '三失', # 三 + エラー
+      [11, 2] => '右中飛', # 右中 + フライ
+      [2, 3] => '捕邪飛',     # 捕 + ファールフライ
+      [9, 4] => '左中直',     # 左中 + ライナー
+      [7, 6] => '左線野選', # 左線 + フィルダースチョイス
+      [4, 19] => '二併' # 二 + 併殺打
+    }.each do |(direction_id, result_id), expected_text|
+      it "hit_direction_id=#{direction_id} + plate_result_id=#{result_id} で #{expected_text} を返す" do
+        plate_appearance = build_stubbed(
+          :plate_appearance,
+          hit_direction: HitDirection.find(direction_id),
+          plate_result: PlateResult.find(result_id)
+        )
+        expect(described_class.generate(plate_appearance)).to eq(expected_text)
+      end
+    end
+
+    context '打球方向なし結果（hit_direction が nil）' do
+      it '三振は短縮形のみ（hit_direction が nil）' do
+        plate_appearance = build_stubbed(
+          :plate_appearance,
+          hit_direction: nil,
+          plate_result: PlateResult.find(13) # 三振
+        )
+        expect(described_class.generate(plate_appearance)).to eq('三振')
+      end
+
+      it '四球は短縮形のみ' do
+        plate_appearance = build_stubbed(
+          :plate_appearance,
+          hit_direction: nil,
+          plate_result: PlateResult.find(15) # 四球
+        )
+        expect(described_class.generate(plate_appearance)).to eq('四球')
+      end
+
+      it 'plate_result も nil の場合は空文字' do
+        plate_appearance = build_stubbed(:plate_appearance, hit_direction: nil, plate_result: nil)
+        expect(described_class.generate(plate_appearance)).to eq('')
+      end
+    end
+  end
+end

--- a/spec/services/stats/batting_result_text_generator_spec.rb
+++ b/spec/services/stats/batting_result_text_generator_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Stats::BattingResultTextGenerator, type: :service do
   describe '.generate' do
     # mobile/constants/battingData.ts:100-107 の getResultText と同じ出力になることを担保
+    # rubocop:disable Style/HashEachMethods
     {
       [10, 7] => '中安', # 中 + ヒット
       [1, 1] => '投ゴ', # 投 + ゴロ
@@ -24,6 +25,7 @@ RSpec.describe Stats::BattingResultTextGenerator, type: :service do
         expect(described_class.generate(plate_appearance)).to eq(expected_text)
       end
     end
+    # rubocop:enable Style/HashEachMethods
 
     context '打球方向なし結果（hit_direction が nil）' do
       it '三振は短縮形のみ（hit_direction が nil）' do


### PR DESCRIPTION
## 概要

試合・成績記録機能アップデート（ippei-shimizu/buzzbase#331）の API 実装フェーズ。Issue #330 で導入したデータモデルを v2 API として公開する。

詳細仕様: `docs/strategy/product/game-record-update-design-doc.md` / `docs/strategy/product/game-record-update-design/02-api-spec.md`

## スコープ

### 含む

- `plate_appearances.is_new_format` boolean フラグ追加（新仕様試合判定用）
- v2 共通基盤 `Api::V2::ApplicationController`（`paginated_response` 抽出）
- v2 マスタ API 6件: `stadiums` (GET/POST) / `pitch_types` / `contact_qualities` / `timings` / `hit_depths` / `hit_directions` (zone_polygon込み)
- v2 `plate_appearances` CRUD: create / update / destroy / by_game
- `Stats::BattingResultTextGenerator`（`batting_result` 表示テキスト自動生成）
- `Stats::BattingAverageRecalculator`（v2 経由操作時の `batting_average` 自動再集計）
- CI を `release/**` ブランチへの push / PR でも実行するよう trigger 拡張

### 含まない（後続Issueへ）

- 分析API（B-1〜F-2、別Issue #337）
- Pro機能ガード（既存に Pro システム自体が無い）
- v1 API への変更（後方互換維持のため無修正）

## 重要な設計判断

### 既存ユーザーの過去の打率は保持しつつ、新仕様試合は通算に組み込まれる

- `batting_average` は「1試合 = 1レコード」の集計テーブル
- 旧仕様試合のレコードは v1 のフロント計算値を保持（v2 は触らない）
- 新仕様試合のレコードはサーバー (`BattingAverageRecalculator`) で生成
- ユーザー通算打率 (`BattingAverage.aggregate_for_user`) は SUM で集約 → **新旧合算でシームレスに通算**
- サーバー計算ロジックは `plate_result_id` ベースで、mobile/constants/battingData.ts:109-162 `computeBattingStats` と同一結果

### `is_new_format` フラグで判定

- v2 controller で打席 create/update 時に `is_new_format = true` を強制セット
- strong params で permit せず（クライアント偽装防止）
- `BattingAverageRecalculator` は `where(is_new_format: true).exists?` で新仕様試合を判定 → 旧仕様試合の集計値は触らない

### `batting_average` 再計算は v2 controller 内で明示呼び出し

- `after_commit` ではなく v2 controller 末尾でサービス呼び出し
- v1 経由の編集 batting_average に影響しない（v1 フロントは新仕様UI無し、実害なし）
- 暗黙の副作用を避け、デバッグしやすい

## 既存データ保全チェックリスト

ローカル開発DB（plate_appearances 923件、batting_averages 319件）で検証実施済み。

- [x] is_new_format カラム追加マイグレーション前後で snapshot diff ゼロ（既存 plate_appearances / batting_averages の digest 完全一致）
- [x] 旧仕様試合の `batting_average` レコードに v2 が触らない（`data_integrity_spec.rb`）
- [x] v2 で新仕様試合に打席を追加しても別試合の集計値は不変
- [x] ユーザー通算打率が新旧合算で一貫（`aggregate_for_user` の SUM）
- [x] 既存 v1 plate_appearances_spec / batting_averages_spec が変更なしで pass
- [x] 既存 v2 spec（dashboards / game_results / stats）が paginated_response 抽出後も pass
- [x] Stats::BattingResultTextGenerator の代表組み合わせが `getResultText` と一致
- [x] 全RSpec パス: 748 examples / 0 failures
- [x] rubocop: no offenses

## エンドポイント一覧

| メソッド | パス | 説明 |
|---|---|---|
| POST | `/api/v2/plate_appearances` | 1打席作成（リアルタイム保存） |
| PATCH | `/api/v2/plate_appearances/:id` | 打席編集 |
| DELETE | `/api/v2/plate_appearances/:id` | 打席削除 |
| GET | `/api/v2/plate_appearances/by_game/:game_result_id` | 試合の全打席（batter_box_number昇順） |
| GET | `/api/v2/stadiums` | 球場検索（q / prefecture_id絞り込み） |
| POST | `/api/v2/stadiums` | 球場追加（ユーザー追加式） |
| GET | `/api/v2/pitch_types` | 球種マスタ（10種） |
| GET | `/api/v2/contact_qualities` | 打球の質マスタ（5種） |
| GET | `/api/v2/timings` | タイミングマスタ（3種） |
| GET | `/api/v2/hit_depths` | 打球の深さマスタ（3種） |
| GET | `/api/v2/hit_directions` | 打球方向マスタ（13方向、zone_polygon込み） |

## 本番リリース時の注意

- Heroku の release フェーズで `db:migrate` が自動実行され、`is_new_format` カラムが追加される（既存レコードは default: false）
- リリース前に **Heroku PG Backups で手動バックアップ取得**
- リリース後 24-48 時間は Sentry で `plate_appearances` / `batting_average` / v2 API 関連エラーを重点監視
