### PR TITLE
Add: 試合結果に球場 (stadium_id) を保存・露出する

### DIFF
--- a/app/controllers/api/v1/match_results_controller.rb
+++ b/app/controllers/api/v1/match_results_controller.rb
@@ -172,7 +172,7 @@ module Api
       def match_results_params
         params.require(:match_result).permit(:user_id, :game_result_id, :date_and_time, :match_type, :my_team_id, :opponent_team_id, :my_team_score,
                                              :opponent_team_score, :batting_order, :defensive_position, :tournament_id, :memo, :inning_format,
-                                             :appearance_type)
+                                             :appearance_type, :stadium_id)
       end
     end
   end

--- a/app/models/game_result.rb
+++ b/app/models/game_result.rb
@@ -123,14 +123,14 @@ class GameResult < ApplicationRecord
   # opponent_team_name, tournament_name, plate_appearances を1リクエストで返却可能にする。
 
   # 特定ユーザーの試合一覧を関連データ付きで取得する（認証ユーザー向け）
-  # match_result -> opponent_team, tournament と plate_appearances, batting_average, pitching_result を eager-load し、
+  # match_result -> opponent_team, tournament, stadium と plate_appearances, batting_average, pitching_result を eager-load し、
   # N+1クエリを防止する
   # @param user [User, Integer] Userオブジェクトまたはuser_id
   # @return [ActiveRecord::Relation<GameResult>] 日付降順の試合結果リレーション
   def self.v2_game_associated_data_user(user)
     includes(
       :season,
-      match_result: %i[my_team opponent_team tournament],
+      match_result: %i[my_team opponent_team tournament stadium],
       plate_appearances: [],
       batting_average: [],
       pitching_result: []
@@ -158,7 +158,7 @@ class GameResult < ApplicationRecord
   def self.v2_all_game_associated_data
     includes(
       :user,
-      match_result: %i[my_team opponent_team tournament],
+      match_result: %i[my_team opponent_team tournament stadium],
       plate_appearances: [],
       pitching_result: []
     ).where.not(match_result_id: nil)

--- a/app/serializers/v2/match_result_serializer.rb
+++ b/app/serializers/v2/match_result_serializer.rb
@@ -9,8 +9,8 @@ module V2
     attributes :id, :date_and_time, :match_type, :my_team_id, :opponent_team_id,
                :my_team_score, :opponent_team_score, :batting_order,
                :defensive_position, :tournament_id, :memo, :inning_format,
-               :appearance_type,
-               :my_team_name, :opponent_team_name, :tournament_name
+               :appearance_type, :stadium_id,
+               :my_team_name, :opponent_team_name, :tournament_name, :stadium_name
 
     # @return [String, nil] 自チーム名（eager-load済み）
     def my_team_name
@@ -25,6 +25,11 @@ module V2
     # @return [String, nil] 大会名（eager-load済み）
     def tournament_name
       object.tournament&.name
+    end
+
+    # @return [String, nil] 球場名（eager-load済み、未設定時は nil）
+    def stadium_name
+      object.stadium&.name
     end
   end
 end

--- a/spec/requests/api/v1/match_results_spec.rb
+++ b/spec/requests/api/v1/match_results_spec.rb
@@ -120,13 +120,8 @@ RSpec.describe 'Api::V1::MatchResults', type: :request do
     end
   end
 
-  # issue #332: 試合基本情報入力で球場（任意項目）を保存できるようにするため、
-  # v1 match_results_controller の strong params に :stadium_id を追加した。
-  # 既存の MatchResult create フローは GameResult 経由（factory が match_result を自動生成）
-  # で行われるため、ここでは PUT による permit 経路を検証することで stadium_id の保存可否を担保する。
   describe 'stadium_id 保存サポート' do
-    let(:prefecture) { Prefecture.create!(name: 'spec用都道府県') }
-    let(:stadium) { Stadium.create!(name: 'spec用球場', prefecture:, created_by_user: user) }
+    let(:stadium) { create(:stadium) }
     let(:match_result) do
       game_result = create(:game_result, user:)
       game_result.match_result

--- a/spec/requests/api/v1/match_results_spec.rb
+++ b/spec/requests/api/v1/match_results_spec.rb
@@ -120,6 +120,38 @@ RSpec.describe 'Api::V1::MatchResults', type: :request do
     end
   end
 
+  # issue #332: 試合基本情報入力で球場（任意項目）を保存できるようにするため、
+  # v1 match_results_controller の strong params に :stadium_id を追加した。
+  # 既存の MatchResult create フローは GameResult 経由（factory が match_result を自動生成）
+  # で行われるため、ここでは PUT による permit 経路を検証することで stadium_id の保存可否を担保する。
+  describe 'stadium_id 保存サポート' do
+    let(:prefecture) { Prefecture.create!(name: 'spec用都道府県') }
+    let(:stadium) { Stadium.create!(name: 'spec用球場', prefecture:, created_by_user: user) }
+    let(:match_result) do
+      game_result = create(:game_result, user:)
+      game_result.match_result
+    end
+
+    it 'PUT 時に stadium_id を更新できる（permit 経路を担保）' do
+      put "/api/v1/match_results/#{match_result.id}",
+          params: { match_result: { stadium_id: stadium.id } },
+          headers: auth_headers_for(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(match_result.reload.stadium_id).to eq(stadium.id)
+    end
+
+    it 'PUT で stadium_id を nil に戻せる（球場を未指定に変更）' do
+      match_result.update!(stadium_id: stadium.id)
+      put "/api/v1/match_results/#{match_result.id}",
+          params: { match_result: { stadium_id: nil } },
+          headers: auth_headers_for(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(match_result.reload.stadium_id).to be_nil
+    end
+  end
+
   describe 'GET /api/v1/match_results/available_years' do
     # game_result factory が after(:create) で match_result を自動生成するため、
     # game_result を作成 → 自動生成された match_result の date_and_time を更新

--- a/spec/serializers/v2/match_result_serializer_spec.rb
+++ b/spec/serializers/v2/match_result_serializer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe V2::MatchResultSerializer, type: :serializer do
     %i[id date_and_time match_type my_team_id opponent_team_id
        my_team_score opponent_team_score batting_order
        defensive_position tournament_id memo inning_format
-       appearance_type].each do |attr|
+       appearance_type stadium_id].each do |attr|
       expect(serialization).to have_key(attr)
     end
   end
@@ -52,6 +52,32 @@ RSpec.describe V2::MatchResultSerializer, type: :serializer do
 
     it 'returns nil for tournament_name' do
       expect(serialization[:tournament_name]).to be_nil
+    end
+  end
+
+  context 'when stadium is present' do
+    let(:stadium) { create(:stadium, name: '東京ドーム') }
+
+    before do
+      game_result.match_result.update!(stadium:)
+    end
+
+    it 'includes stadium_id' do
+      expect(serialization[:stadium_id]).to eq(stadium.id)
+    end
+
+    it 'includes stadium_name' do
+      expect(serialization[:stadium_name]).to eq('東京ドーム')
+    end
+  end
+
+  context 'when stadium is nil' do
+    it 'returns nil for stadium_id' do
+      expect(serialization[:stadium_id]).to be_nil
+    end
+
+    it 'returns nil for stadium_name' do
+      expect(serialization[:stadium_name]).to be_nil
     end
   end
 end


### PR DESCRIPTION
## 概要

ippei-shimizu/buzzbase#332 の back 側対応。mobile の試合基本情報入力で球場（任意）を保存・取得できるよう、`match_results` 周りで以下を追加する。

詳細仕様: `docs/strategy/product/game-record-update-design/04-mobile-ui.md` §2

## スコープ

### v1 strong params に `:stadium_id` を追加

- `app/controllers/api/v1/match_results_controller.rb`: `match_results_params` の `permit` に `:stadium_id` を追加
- `spec/requests/api/v1/match_results_spec.rb`: PUT で stadium_id を保存・解除できることの spec を追加

### v2 `MatchResultSerializer` に球場情報を露出

- `app/serializers/v2/match_result_serializer.rb`: `stadium_id` / `stadium_name` を追加
  - mobile 編集モードで保存済みの球場を復元するために必要
  - mobile 側 `types/gameResult.ts` の `GameResultMatchResult` 期待値に合わせ flat 形式で返却
- `spec/serializers/v2/match_result_serializer_spec.rb`: 設定済み / nil 時の挙動を spec で担保

## 既存挙動への影響

- 既存 v1 match_results spec 全て pass
- 関連 RSpec（serializer / v1 match_results / v2 stadiums）: 50 examples / 0 failures
- rubocop: no offenses
- Web版（front/）は stadium_id を送信しないため、permit 追加だけでは挙動が変わらない

## なぜ v1 は POST テストではなく PUT テストか

既存の `game_result` factory は `after(:create)` で `match_result` を自動生成するため、テスト内で別個に POST すると `game_result_id` の uniqueness 違反になる。permit が同じ経路を通るため、PUT による更新で stadium_id の保存可否を担保している。

## スコープ外（別 Issue で対応予定）

- stadium マスタの初期 seed 投入
- Design Doc §9.4 既存データ保全 RSpec 検証スイート
- v1 `match_results` レスポンスへの stadium 情報追加（mobile は v2 系で完結する想定）

## 関連 PR / Issue

- 親 Issue: ippei-shimizu/buzzbase#332
- 依存: ippei-shimizu/buzzbase#330 (`match_results.stadium_id` カラム追加)
- mobile 側の対応は別 PR
