### PR TITLE
Add: 相手投手データのマスタ・API 追加 (Issue #334 一部)

### DIFF
--- a/app/controllers/api/v2/appearance_situations_controller.rb
+++ b/app/controllers/api/v2/appearance_situations_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  module V2
+    # 投手の登板状況マスタ (3種: 先発 / 中継ぎ / 抑え) を display_order 昇順で返却する。
+    class AppearanceSituationsController < Api::V2::ApplicationController
+      before_action :authenticate_api_v1_user!
+
+      def index
+        appearance_situations = AppearanceSituation.order(:display_order)
+        render json: {
+          appearance_situations: ActiveModelSerializers::SerializableResource.new(
+            appearance_situations, each_serializer: ::V2::AppearanceSituationSerializer
+          )
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/arm_angles_controller.rb
+++ b/app/controllers/api/v2/arm_angles_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  module V2
+    # 腕の角度マスタ (4種) を display_order 昇順で返却する。
+    class ArmAnglesController < Api::V2::ApplicationController
+      before_action :authenticate_api_v1_user!
+
+      def index
+        arm_angles = ArmAngle.order(:display_order)
+        render json: {
+          arm_angles: ActiveModelSerializers::SerializableResource.new(
+            arm_angles, each_serializer: ::V2::ArmAngleSerializer
+          )
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/pitcher_styles_controller.rb
+++ b/app/controllers/api/v2/pitcher_styles_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  module V2
+    # 投手タイプマスタ (4種) を display_order 昇順で返却する。
+    class PitcherStylesController < Api::V2::ApplicationController
+      before_action :authenticate_api_v1_user!
+
+      def index
+        pitcher_styles = PitcherStyle.order(:display_order)
+        render json: {
+          pitcher_styles: ActiveModelSerializers::SerializableResource.new(
+            pitcher_styles, each_serializer: ::V2::PitcherStyleSerializer
+          )
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/pitchers_controller.rb
+++ b/app/controllers/api/v2/pitchers_controller.rb
@@ -30,6 +30,17 @@ module Api
         end
       end
 
+      # 他ユーザーが作成した投手は `created_pitchers` スコープに含まれないため、
+      # find で 404 が返り編集を防げる（IDOR 防止）。
+      def update
+        pitcher = current_api_v1_user.created_pitchers.find(params[:id])
+        if pitcher.update(pitcher_params)
+          render json: pitcher, serializer: ::V2::PitcherSerializer
+        else
+          render json: { errors: pitcher.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
       private
 
       def pitcher_params

--- a/app/controllers/api/v2/pitchers_controller.rb
+++ b/app/controllers/api/v2/pitchers_controller.rb
@@ -1,0 +1,50 @@
+module Api
+  module V2
+    # 相手投手マスタの取得と追加。
+    #
+    # 投手は **ユーザー固有マスタ** として扱う（球場マスタとは異なる）:
+    # - `GET /api/v2/pitchers` は current_api_v1_user が作成した投手のみ返す
+    # - `POST /api/v2/pitchers` は created_by_user を current_api_v1_user に固定
+    class PitchersController < Api::V2::ApplicationController
+      before_action :authenticate_api_v1_user!
+
+      MAX_PER_PAGE = 100
+      DEFAULT_PER_PAGE = 20
+
+      def index
+        pitchers = current_api_v1_user.created_pitchers
+                                      .includes(:arm_angle, :velocity_zone, :pitcher_style)
+        pitchers = pitchers.where('name ILIKE ?', "%#{params[:q]}%") if params[:q].present?
+        pitchers = pitchers.where(team_id: params[:team_id]) if params[:team_id].present?
+        pitchers = pitchers.order(:name).page(params[:page]).per(per_page_size)
+
+        render json: paginated_response(pitchers, ::V2::PitcherSerializer)
+      end
+
+      def create
+        pitcher = Pitcher.new(pitcher_params.merge(created_by_user: current_api_v1_user))
+        if pitcher.save
+          render json: pitcher, serializer: ::V2::PitcherSerializer, status: :created
+        else
+          render json: { errors: pitcher.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def pitcher_params
+        params.require(:pitcher).permit(
+          :name, :team_id, :throw_hand,
+          :arm_angle_id, :velocity_zone_id, :pitcher_style_id
+        )
+      end
+
+      def per_page_size
+        requested = params[:per_page].to_i
+        return DEFAULT_PER_PAGE if requested <= 0
+
+        [requested, MAX_PER_PAGE].min
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/pitchers_controller.rb
+++ b/app/controllers/api/v2/pitchers_controller.rb
@@ -35,7 +35,8 @@ module Api
       def pitcher_params
         params.require(:pitcher).permit(
           :name, :team_id, :throw_hand,
-          :arm_angle_id, :velocity_zone_id, :pitcher_style_id
+          :arm_angle_id, :velocity_zone_id, :pitcher_style_id,
+          :memo
         )
       end
 

--- a/app/controllers/api/v2/plate_appearances_controller.rb
+++ b/app/controllers/api/v2/plate_appearances_controller.rb
@@ -13,6 +13,8 @@ module Api
       def create
         # game_result_id を current_api_v1_user 所有のものに限定し、IDOR を防ぐ。
         game_result = current_api_v1_user.game_results.find(plate_appearance_params[:game_result_id])
+        return if pitcher_id_invalid?(plate_appearance_params[:pitcher_id])
+
         plate_appearance = game_result.plate_appearances.build(plate_appearance_params.except(:game_result_id))
         plate_appearance.user = current_api_v1_user
         plate_appearance.is_new_format = true
@@ -28,6 +30,8 @@ module Api
 
       def update
         # 更新時は所属 game_result の付け替えを許さない（IDOR 防止）。
+        return if pitcher_id_invalid?(plate_appearance_params[:pitcher_id])
+
         @plate_appearance.assign_attributes(plate_appearance_params.except(:game_result_id))
         @plate_appearance.is_new_format = true
         @plate_appearance.batting_result = ::Stats::BattingResultTextGenerator.generate(@plate_appearance)
@@ -57,7 +61,9 @@ module Api
         return if render_forbidden_if_private!(game_result.user)
 
         plate_appearances = PlateAppearance.where(game_result_id: game_result.id)
-                                           .includes(:contact_quality, :timing, :pitch_type, :hit_depth)
+                                           .includes(:contact_quality, :timing, :pitch_type, :hit_depth,
+                                                     :appearance_situation,
+                                                     pitcher: %i[arm_angle velocity_zone pitcher_style])
                                            .order(:batter_box_number)
         render json: {
           plate_appearances: ActiveModelSerializers::SerializableResource.new(
@@ -84,8 +90,20 @@ module Api
           :final_balls, :final_strikes, :final_outs,
           :first_pitch_swing, :runners_state, :inning,
           :contact_quality_id, :timing_id, :pitch_type_id, :hit_depth_id,
-          :self_analysis_memo, :opponent_memo
+          :self_analysis_memo, :opponent_memo,
+          :pitcher_id, :appearance_situation_id
         )
+      end
+
+      # 投手はユーザー固有マスタのため、他ユーザーが作成した pitcher_id を
+      # 紐付ける攻撃を防ぐ。指定された pitcher_id が存在するが current user の作成物でない場合、
+      # 422 を返して呼び出し側の早期 return を促す。
+      def pitcher_id_invalid?(pitcher_id)
+        return false if pitcher_id.blank?
+        return false if current_api_v1_user.created_pitchers.exists?(id: pitcher_id)
+
+        render json: { errors: ['指定された投手は存在しません'] }, status: :unprocessable_entity
+        true
       end
 
       def recalculate_batting_average(game_result_id, user_id:, cleanup_orphan: false)

--- a/app/controllers/api/v2/velocity_zones_controller.rb
+++ b/app/controllers/api/v2/velocity_zones_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  module V2
+    # 投手の球速帯マスタ (5種) を display_order 昇順で返却する。
+    class VelocityZonesController < Api::V2::ApplicationController
+      before_action :authenticate_api_v1_user!
+
+      def index
+        velocity_zones = VelocityZone.order(:display_order)
+        render json: {
+          velocity_zones: ActiveModelSerializers::SerializableResource.new(
+            velocity_zones, each_serializer: ::V2::VelocityZoneSerializer
+          )
+        }
+      end
+    end
+  end
+end

--- a/app/models/appearance_situation.rb
+++ b/app/models/appearance_situation.rb
@@ -1,0 +1,8 @@
+# 投手の登板状況マスタ（3種: 先発 / 中継ぎ / 抑え）。
+# 試合終盤の対投手成績分析に使う。
+class AppearanceSituation < ApplicationRecord
+  has_many :plate_appearances, dependent: :restrict_with_error
+
+  validates :name, presence: true, uniqueness: true
+  validates :display_order, presence: true
+end

--- a/app/models/arm_angle.rb
+++ b/app/models/arm_angle.rb
@@ -1,0 +1,7 @@
+# 投手の腕の角度マスタ（4種）。display_order で UI 表示順を保持する。
+class ArmAngle < ApplicationRecord
+  has_many :pitchers, dependent: :restrict_with_error
+
+  validates :name, presence: true, uniqueness: true
+  validates :display_order, presence: true
+end

--- a/app/models/pitcher.rb
+++ b/app/models/pitcher.rb
@@ -1,0 +1,22 @@
+# 相手投手マスタ。ユーザー追加可能（球場マスタと同パターン）だが、
+# `created_by_user_id` 経由で **記録したユーザーのみが閲覧・紐付け可能** な
+# ユーザー固有マスタとして扱う（球場のように全体共有はしない）。
+#
+# 同じ投手と複数回対戦する想定のため、属性を毎回入力させず再利用する。
+class Pitcher < ApplicationRecord
+  belongs_to :team, optional: true
+  belongs_to :arm_angle, optional: true
+  belongs_to :velocity_zone, optional: true
+  belongs_to :pitcher_style, optional: true
+  belongs_to :created_by_user, class_name: 'User'
+
+  has_many :plate_appearances, dependent: :nullify
+
+  enum throw_hand: { right: 0, left: 1 }, _prefix: true
+
+  validates :name, presence: true, length: { maximum: 100 }
+  # 同一ユーザー内 + 同一チームでの同名投手を防ぐ。team_id が異なれば別投手扱い。
+  # `index_pitchers_on_user_team_name` (unique, created_by_user_id + team_id + name) が
+  # スコープを丸ごとカバーするが、RuboCop は単独カラムの index しか検出できないため抑制する。
+  validates :name, uniqueness: { scope: %i[created_by_user_id team_id], case_sensitive: false }
+end

--- a/app/models/pitcher.rb
+++ b/app/models/pitcher.rb
@@ -15,6 +15,7 @@ class Pitcher < ApplicationRecord
   enum throw_hand: { right: 0, left: 1 }, _prefix: true
 
   validates :name, presence: true, length: { maximum: 100 }
+  validates :memo, length: { maximum: 1000 }, allow_nil: true
   # 同一ユーザー内 + 同一チームでの同名投手を防ぐ。team_id が異なれば別投手扱い。
   # `index_pitchers_on_user_team_name` (unique, created_by_user_id + team_id + name) が
   # スコープを丸ごとカバーするが、RuboCop は単独カラムの index しか検出できないため抑制する。

--- a/app/models/pitcher_style.rb
+++ b/app/models/pitcher_style.rb
@@ -1,0 +1,7 @@
+# 投手タイプマスタ（4種: 本格派 / 技巧派 / 変則派 / パワー型）。
+class PitcherStyle < ApplicationRecord
+  has_many :pitchers, dependent: :restrict_with_error
+
+  validates :name, presence: true, uniqueness: true
+  validates :display_order, presence: true
+end

--- a/app/models/plate_appearance.rb
+++ b/app/models/plate_appearance.rb
@@ -7,6 +7,8 @@ class PlateAppearance < ApplicationRecord
   belongs_to :timing, optional: true
   belongs_to :pitch_type, optional: true
   belongs_to :hit_depth, optional: true
+  belongs_to :pitcher, optional: true
+  belongs_to :appearance_situation, optional: true
 
   # Rails 7.1 では enum がカラム未存在状態だと "Undeclared attribute type" エラーになるため、
   # 明示的に attribute type を declare してマイグレーション前後どちらでもロードできるようにする。

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,7 @@ class User < ActiveRecord::Base
   has_many :batting_averages, dependent: :destroy
   has_many :pitching_results, dependent: :destroy
   has_many :plate_appearances, dependent: :destroy
+  has_many :created_pitchers, class_name: 'Pitcher', foreign_key: 'created_by_user_id', dependent: :destroy, inverse_of: :created_by_user
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable

--- a/app/models/velocity_zone.rb
+++ b/app/models/velocity_zone.rb
@@ -1,0 +1,7 @@
+# 投手の球速帯マスタ（5種）。display_order で UI 表示順を保持する。
+class VelocityZone < ApplicationRecord
+  has_many :pitchers, dependent: :restrict_with_error
+
+  validates :name, presence: true, uniqueness: true
+  validates :display_order, presence: true
+end

--- a/app/serializers/v2/appearance_situation_serializer.rb
+++ b/app/serializers/v2/appearance_situation_serializer.rb
@@ -1,0 +1,5 @@
+module V2
+  class AppearanceSituationSerializer < ActiveModel::Serializer
+    attributes :id, :name, :display_order
+  end
+end

--- a/app/serializers/v2/arm_angle_serializer.rb
+++ b/app/serializers/v2/arm_angle_serializer.rb
@@ -1,0 +1,5 @@
+module V2
+  class ArmAngleSerializer < ActiveModel::Serializer
+    attributes :id, :name, :display_order
+  end
+end

--- a/app/serializers/v2/pitcher_serializer.rb
+++ b/app/serializers/v2/pitcher_serializer.rb
@@ -1,0 +1,12 @@
+module V2
+  # 投手マスタのレスポンス。所属チーム + 3 つの属性マスタを nested で返す。
+  # `created_by_user_id` はクライアントに露出しない（ユーザー固有マスタの整合性は
+  # サーバ側のクエリで担保するため、フロントには持たせない）。
+  class PitcherSerializer < ActiveModel::Serializer
+    attributes :id, :name, :throw_hand, :team_id
+
+    has_one :arm_angle, serializer: V2::ArmAngleSerializer
+    has_one :velocity_zone, serializer: V2::VelocityZoneSerializer
+    has_one :pitcher_style, serializer: V2::PitcherStyleSerializer
+  end
+end

--- a/app/serializers/v2/pitcher_serializer.rb
+++ b/app/serializers/v2/pitcher_serializer.rb
@@ -3,7 +3,7 @@ module V2
   # `created_by_user_id` はクライアントに露出しない（ユーザー固有マスタの整合性は
   # サーバ側のクエリで担保するため、フロントには持たせない）。
   class PitcherSerializer < ActiveModel::Serializer
-    attributes :id, :name, :throw_hand, :team_id
+    attributes :id, :name, :throw_hand, :team_id, :memo
 
     has_one :arm_angle, serializer: V2::ArmAngleSerializer
     has_one :velocity_zone, serializer: V2::VelocityZoneSerializer

--- a/app/serializers/v2/pitcher_style_serializer.rb
+++ b/app/serializers/v2/pitcher_style_serializer.rb
@@ -1,0 +1,5 @@
+module V2
+  class PitcherStyleSerializer < ActiveModel::Serializer
+    attributes :id, :name, :display_order
+  end
+end

--- a/app/serializers/v2/plate_appearance_serializer.rb
+++ b/app/serializers/v2/plate_appearance_serializer.rb
@@ -21,6 +21,8 @@ module V2
     has_one :timing, serializer: V2::TimingSerializer
     has_one :pitch_type, serializer: V2::PitchTypeSerializer
     has_one :hit_depth, serializer: V2::HitDepthSerializer
+    has_one :pitcher, serializer: V2::PitcherSerializer
+    has_one :appearance_situation, serializer: V2::AppearanceSituationSerializer
 
     # mobile 側で「詳細未入力」バッジを出すための boolean。
     # 任意の詳細データ系カラム（マスタID・カウント・状況・メモ）のいずれかに値があれば true。
@@ -34,7 +36,8 @@ module V2
     def detail_attributes
       %i[contact_quality_id timing_id pitch_type_id hit_depth_id
          final_balls final_strikes final_outs first_pitch_swing
-         runners_state inning self_analysis_memo opponent_memo]
+         runners_state inning self_analysis_memo opponent_memo
+         pitcher_id appearance_situation_id]
     end
   end
 end

--- a/app/serializers/v2/velocity_zone_serializer.rb
+++ b/app/serializers/v2/velocity_zone_serializer.rb
@@ -1,0 +1,5 @@
+module V2
+  class VelocityZoneSerializer < ActiveModel::Serializer
+    attributes :id, :name, :display_order
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -228,7 +228,7 @@ Rails.application.routes.draw do
         end
       end
       resources :stadiums, only: %i[index create]
-      resources :pitchers, only: %i[index create]
+      resources :pitchers, only: %i[index create update]
       resources :pitch_types, only: :index
       resources :contact_qualities, only: :index
       resources :timings, only: :index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -228,11 +228,16 @@ Rails.application.routes.draw do
         end
       end
       resources :stadiums, only: %i[index create]
+      resources :pitchers, only: %i[index create]
       resources :pitch_types, only: :index
       resources :contact_qualities, only: :index
       resources :timings, only: :index
       resources :hit_depths, only: :index
       resources :hit_directions, only: :index
+      resources :arm_angles, only: :index
+      resources :velocity_zones, only: :index
+      resources :pitcher_styles, only: :index
+      resources :appearance_situations, only: :index
     end
   end
 

--- a/db/data/master_seeds/appearance_situations.yml
+++ b/db/data/master_seeds/appearance_situations.yml
@@ -1,0 +1,9 @@
+- id: 1
+  name: 先発
+  display_order: 1
+- id: 2
+  name: 中継ぎ
+  display_order: 2
+- id: 3
+  name: 抑え
+  display_order: 3

--- a/db/data/master_seeds/arm_angles.yml
+++ b/db/data/master_seeds/arm_angles.yml
@@ -1,0 +1,12 @@
+- id: 1
+  name: オーバースロー
+  display_order: 1
+- id: 2
+  name: スリークォーター
+  display_order: 2
+- id: 3
+  name: サイドスロー
+  display_order: 3
+- id: 4
+  name: アンダースロー
+  display_order: 4

--- a/db/data/master_seeds/pitcher_styles.yml
+++ b/db/data/master_seeds/pitcher_styles.yml
@@ -1,0 +1,12 @@
+- id: 1
+  name: 本格派
+  display_order: 1
+- id: 2
+  name: 技巧派
+  display_order: 2
+- id: 3
+  name: 変則派
+  display_order: 3
+- id: 4
+  name: パワー型
+  display_order: 4

--- a/db/data/master_seeds/velocity_zones.yml
+++ b/db/data/master_seeds/velocity_zones.yml
@@ -1,0 +1,15 @@
+- id: 1
+  name: 120km/h未満
+  display_order: 1
+- id: 2
+  name: 120-130km/h
+  display_order: 2
+- id: 3
+  name: 130-140km/h
+  display_order: 3
+- id: 4
+  name: 140-150km/h
+  display_order: 4
+- id: 5
+  name: 150km/h以上
+  display_order: 5

--- a/db/migrate/20260611120000_create_arm_angles.rb
+++ b/db/migrate/20260611120000_create_arm_angles.rb
@@ -1,0 +1,17 @@
+class CreateArmAngles < ActiveRecord::Migration[7.0]
+  def up
+    create_table :arm_angles do |t|
+      t.string :name, null: false
+      t.integer :display_order, null: false
+      t.timestamps
+    end
+    add_index :arm_angles, :name, unique: true, name: 'index_arm_angles_on_name'
+    add_index :arm_angles, :display_order, name: 'index_arm_angles_on_display_order'
+
+    MasterData::Seeder.from_yaml(connection, table: 'arm_angles', file: 'arm_angles.yml')
+  end
+
+  def down
+    drop_table :arm_angles
+  end
+end

--- a/db/migrate/20260611120001_create_velocity_zones.rb
+++ b/db/migrate/20260611120001_create_velocity_zones.rb
@@ -1,0 +1,17 @@
+class CreateVelocityZones < ActiveRecord::Migration[7.0]
+  def up
+    create_table :velocity_zones do |t|
+      t.string :name, null: false
+      t.integer :display_order, null: false
+      t.timestamps
+    end
+    add_index :velocity_zones, :name, unique: true, name: 'index_velocity_zones_on_name'
+    add_index :velocity_zones, :display_order, name: 'index_velocity_zones_on_display_order'
+
+    MasterData::Seeder.from_yaml(connection, table: 'velocity_zones', file: 'velocity_zones.yml')
+  end
+
+  def down
+    drop_table :velocity_zones
+  end
+end

--- a/db/migrate/20260611120002_create_pitcher_styles.rb
+++ b/db/migrate/20260611120002_create_pitcher_styles.rb
@@ -1,0 +1,17 @@
+class CreatePitcherStyles < ActiveRecord::Migration[7.0]
+  def up
+    create_table :pitcher_styles do |t|
+      t.string :name, null: false
+      t.integer :display_order, null: false
+      t.timestamps
+    end
+    add_index :pitcher_styles, :name, unique: true, name: 'index_pitcher_styles_on_name'
+    add_index :pitcher_styles, :display_order, name: 'index_pitcher_styles_on_display_order'
+
+    MasterData::Seeder.from_yaml(connection, table: 'pitcher_styles', file: 'pitcher_styles.yml')
+  end
+
+  def down
+    drop_table :pitcher_styles
+  end
+end

--- a/db/migrate/20260611120003_create_appearance_situations.rb
+++ b/db/migrate/20260611120003_create_appearance_situations.rb
@@ -1,0 +1,17 @@
+class CreateAppearanceSituations < ActiveRecord::Migration[7.0]
+  def up
+    create_table :appearance_situations do |t|
+      t.string :name, null: false
+      t.integer :display_order, null: false
+      t.timestamps
+    end
+    add_index :appearance_situations, :name, unique: true, name: 'index_appearance_situations_on_name'
+    add_index :appearance_situations, :display_order, name: 'index_appearance_situations_on_display_order'
+
+    MasterData::Seeder.from_yaml(connection, table: 'appearance_situations', file: 'appearance_situations.yml')
+  end
+
+  def down
+    drop_table :appearance_situations
+  end
+end

--- a/db/migrate/20260611120004_create_pitchers.rb
+++ b/db/migrate/20260611120004_create_pitchers.rb
@@ -1,0 +1,15 @@
+class CreatePitchers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :pitchers do |t|
+      t.string :name, null: false
+      t.references :team, null: true, foreign_key: true
+      t.integer :throw_hand
+      t.references :arm_angle, null: true, foreign_key: true
+      t.references :velocity_zone, null: true, foreign_key: true
+      t.references :pitcher_style, null: true, foreign_key: true
+      t.references :created_by_user, null: false, foreign_key: { to_table: :users }
+      t.timestamps
+    end
+    add_index :pitchers, %i[created_by_user_id team_id name], unique: true, name: 'index_pitchers_on_user_team_name'
+  end
+end

--- a/db/migrate/20260611120005_add_pitcher_columns_to_plate_appearances.rb
+++ b/db/migrate/20260611120005_add_pitcher_columns_to_plate_appearances.rb
@@ -1,0 +1,8 @@
+class AddPitcherColumnsToPlateAppearances < ActiveRecord::Migration[7.0]
+  def change
+    change_table :plate_appearances, bulk: true do |t|
+      t.references :pitcher, foreign_key: true, null: true
+      t.references :appearance_situation, foreign_key: true, null: true
+    end
+  end
+end

--- a/db/migrate/20260611160000_add_memo_to_pitchers.rb
+++ b/db/migrate/20260611160000_add_memo_to_pitchers.rb
@@ -1,0 +1,5 @@
+class AddMemoToPitchers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :pitchers, :memo, :text
+  end
+end

--- a/db/migrate/20260612120000_add_partial_unique_index_to_pitchers_for_null_team.rb
+++ b/db/migrate/20260612120000_add_partial_unique_index_to_pitchers_for_null_team.rb
@@ -1,0 +1,11 @@
+class AddPartialUniqueIndexToPitchersForNullTeam < ActiveRecord::Migration[7.0]
+  # PostgreSQL では NULL != NULL のため、(created_by_user_id, team_id, name) の複合 unique index は
+  # team_id が NULL のとき同名投手の重複作成を防げない。team_id が NULL のケースに対する
+  # 部分インデックスを別途追加し、レースコンディションでも一意性を担保する。
+  def change
+    add_index :pitchers, %i[created_by_user_id name],
+              unique: true,
+              where: 'team_id IS NULL',
+              name: 'index_pitchers_on_user_name_without_team'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_260_531_120_000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_11_120005) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -90,6 +90,24 @@ ActiveRecord::Schema[7.1].define(version: 20_260_531_120_000) do
     t.datetime "updated_at", null: false
     t.index ["week_end_date"], name: "index_admin_weekly_statistics_on_week_end_date"
     t.index ["week_start_date"], name: "index_admin_weekly_statistics_on_week_start_date", unique: true
+  end
+
+  create_table "appearance_situations", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "display_order", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["display_order"], name: "index_appearance_situations_on_display_order"
+    t.index ["name"], name: "index_appearance_situations_on_name", unique: true
+  end
+
+  create_table "arm_angles", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "display_order", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["display_order"], name: "index_arm_angles_on_display_order"
+    t.index ["name"], name: "index_arm_angles_on_name", unique: true
   end
 
   create_table "awards", force: :cascade do |t|
@@ -309,6 +327,33 @@ ActiveRecord::Schema[7.1].define(version: 20_260_531_120_000) do
     t.index ["name"], name: "index_pitch_types_on_name", unique: true
   end
 
+  create_table "pitcher_styles", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "display_order", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["display_order"], name: "index_pitcher_styles_on_display_order"
+    t.index ["name"], name: "index_pitcher_styles_on_name", unique: true
+  end
+
+  create_table "pitchers", force: :cascade do |t|
+    t.string "name", null: false
+    t.bigint "team_id"
+    t.integer "throw_hand"
+    t.bigint "arm_angle_id"
+    t.bigint "velocity_zone_id"
+    t.bigint "pitcher_style_id"
+    t.bigint "created_by_user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["arm_angle_id"], name: "index_pitchers_on_arm_angle_id"
+    t.index ["created_by_user_id", "team_id", "name"], name: "index_pitchers_on_user_team_name", unique: true
+    t.index ["created_by_user_id"], name: "index_pitchers_on_created_by_user_id"
+    t.index ["pitcher_style_id"], name: "index_pitchers_on_pitcher_style_id"
+    t.index ["team_id"], name: "index_pitchers_on_team_id"
+    t.index ["velocity_zone_id"], name: "index_pitchers_on_velocity_zone_id"
+  end
+
   create_table "pitching_results", force: :cascade do |t|
     t.bigint "game_result_id", null: false
     t.bigint "user_id", null: false
@@ -363,11 +408,15 @@ ActiveRecord::Schema[7.1].define(version: 20_260_531_120_000) do
     t.decimal "hit_location_x", precision: 4, scale: 3
     t.decimal "hit_location_y", precision: 4, scale: 3
     t.boolean "is_new_format", default: false, null: false
+    t.bigint "pitcher_id"
+    t.bigint "appearance_situation_id"
+    t.index ["appearance_situation_id"], name: "index_plate_appearances_on_appearance_situation_id"
     t.index ["contact_quality_id"], name: "index_plate_appearances_on_contact_quality_id"
     t.index ["game_result_id"], name: "index_plate_appearances_on_game_result_id"
     t.index ["hit_depth_id"], name: "index_plate_appearances_on_hit_depth_id"
     t.index ["is_new_format"], name: "index_plate_appearances_on_is_new_format"
     t.index ["pitch_type_id"], name: "index_plate_appearances_on_pitch_type_id"
+    t.index ["pitcher_id"], name: "index_plate_appearances_on_pitcher_id"
     t.index ["timing_id"], name: "index_plate_appearances_on_timing_id"
     t.index ["user_id"], name: "index_plate_appearances_on_user_id"
   end
@@ -520,6 +569,15 @@ ActiveRecord::Schema[7.1].define(version: 20_260_531_120_000) do
     t.index ["user_id"], name: "index_users_on_user_id", unique: true
   end
 
+  create_table "velocity_zones", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "display_order", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["display_order"], name: "index_velocity_zones_on_display_order"
+    t.index ["name"], name: "index_velocity_zones_on_name", unique: true
+  end
+
   add_foreign_key "admin_refresh_tokens", "admin_users"
   add_foreign_key "baseball_notes", "users"
   add_foreign_key "batting_averages", "users"
@@ -543,11 +601,18 @@ ActiveRecord::Schema[7.1].define(version: 20_260_531_120_000) do
   add_foreign_key "match_results", "teams", column: "opponent_team_id"
   add_foreign_key "match_results", "users"
   add_foreign_key "notifications", "users", column: "actor_id"
+  add_foreign_key "pitchers", "arm_angles"
+  add_foreign_key "pitchers", "pitcher_styles"
+  add_foreign_key "pitchers", "teams"
+  add_foreign_key "pitchers", "users", column: "created_by_user_id"
+  add_foreign_key "pitchers", "velocity_zones"
   add_foreign_key "pitching_results", "users"
+  add_foreign_key "plate_appearances", "appearance_situations"
   add_foreign_key "plate_appearances", "contact_qualities"
   add_foreign_key "plate_appearances", "game_results", on_delete: :cascade
   add_foreign_key "plate_appearances", "hit_depths"
   add_foreign_key "plate_appearances", "pitch_types"
+  add_foreign_key "plate_appearances", "pitchers"
   add_foreign_key "plate_appearances", "timings"
   add_foreign_key "plate_appearances", "users"
   add_foreign_key "seasons", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_11_120005) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_11_160000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -346,6 +346,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_11_120005) do
     t.bigint "created_by_user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "memo"
     t.index ["arm_angle_id"], name: "index_pitchers_on_arm_angle_id"
     t.index ["created_by_user_id", "team_id", "name"], name: "index_pitchers_on_user_team_name", unique: true
     t.index ["created_by_user_id"], name: "index_pitchers_on_created_by_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_11_160000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_12_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -348,6 +348,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_11_160000) do
     t.datetime "updated_at", null: false
     t.text "memo"
     t.index ["arm_angle_id"], name: "index_pitchers_on_arm_angle_id"
+    t.index ["created_by_user_id", "name"], name: "index_pitchers_on_user_name_without_team", unique: true, where: "(team_id IS NULL)"
     t.index ["created_by_user_id", "team_id", "name"], name: "index_pitchers_on_user_team_name", unique: true
     t.index ["created_by_user_id"], name: "index_pitchers_on_created_by_user_id"
     t.index ["pitcher_style_id"], name: "index_pitchers_on_pitcher_style_id"

--- a/lib/tasks/dev_data.rake
+++ b/lib/tasks/dev_data.rake
@@ -5,14 +5,14 @@
 # rake dev_data:reset   -- DB再作成 + setup
 
 require_relative 'dev_data_creator'
-namespace :dev_data do
+namespace :dev_data do # rubocop:disable Metrics/BlockLength
   desc '開発環境データを一括作成（マスターデータ + サンプルデータ）'
   task setup: :environment do
     Rake::Task['dev_data:master'].invoke
     Rake::Task['dev_data:sample'].invoke
   end
 
-  desc 'マスターデータを作成（Position, Prefecture, BaseballCategory, Admin::User）'
+  desc 'マスターデータを作成（Position, Prefecture, BaseballCategory, Admin::User, Award, Tournament）'
   task master: :environment do
     Rails.logger.debug 'Creating master data...'
 
@@ -20,13 +20,15 @@ namespace :dev_data do
     DevDataCreator.create_prefectures
     DevDataCreator.create_baseball_categories
     DevDataCreator.create_admin_user
+    DevDataCreator.create_awards
+    DevDataCreator.create_tournaments
 
     Rake::Task['masters:reseed'].invoke
 
     Rails.logger.debug 'Master data creation completed!'
   end
 
-  desc 'サンプルデータを作成（Users, Teams, GameResults等）— マスターデータが必要'
+  desc 'サンプルデータを作成（Users, Teams, GameResults, PlateAppearances等）— マスターデータが必要'
   task sample: :environment do
     if Position.count.zero?
       Rails.logger.debug 'Position data not found. Please run `rake dev_data:master` first.'
@@ -37,7 +39,10 @@ namespace :dev_data do
 
     users = DevDataCreator.create_users
     teams = DevDataCreator.create_teams
+    DevDataCreator.create_seasons(users)
     DevDataCreator.create_game_results(users, teams)
+    DevDataCreator.create_user_awards(users)
+    DevDataCreator.create_device_tokens(users)
     DevDataCreator.create_relationships(users)
     private_users = DevDataCreator.setup_private_accounts(users)
     DevDataCreator.create_pending_follow_requests(users, private_users)

--- a/lib/tasks/dev_data.rake
+++ b/lib/tasks/dev_data.rake
@@ -49,6 +49,7 @@ namespace :dev_data do # rubocop:disable Metrics/BlockLength
     DevDataCreator.create_follow_notifications
     DevDataCreator.create_groups(users)
     DevDataCreator.create_baseball_notes(users)
+    DevDataCreator.apply_user_lifecycle_states(users)
     DevDataCreator.print_summary
 
     Rails.logger.debug 'Sample data creation completed!'

--- a/lib/tasks/dev_data_creator.rb
+++ b/lib/tasks/dev_data_creator.rb
@@ -1,5 +1,10 @@
 # 開発環境データ作成ヘルパー
 # dev_data.rake から呼び出される
+#
+# release/game-stats-202605 で追加予定の機能（pitchers / arm_angles /
+# velocity_zones / pitcher_styles / appearance_situations / stadiums /
+# plate_appearances v2 詳細データ）は意図的に含めず、現在運用中の
+# 既存機能のデータを実ユーザーに近い形で大量に再現する。
 class DevDataCreator # rubocop:disable Metrics/ClassLength
   PREFECTURES = [
     { name: '北海道', hiragana: 'ほっかいどう', katakana: 'ホッカイドウ', alphabet: 'Hokkaido' },
@@ -74,6 +79,84 @@ class DevDataCreator # rubocop:disable Metrics/ClassLength
     { name: 'その他', hiragana: 'そのた', katakana: 'ソノタ', alphabet: 'Sonota' }
   ].freeze
 
+  TEAM_NAMES = %w[
+    ブルースターズ レッドファルコンズ グリーンイーグルス
+    ホワイトベアーズ ブラックパンサーズ
+    東京ストリーム 横浜ウェーブス 大阪サンライズ
+    名古屋アローズ 札幌ノーザンライツ
+    福岡ハリケーンズ 広島フェニックス 京都グランディアズ
+    神戸シーホークス 仙台サンダーボルツ
+  ].freeze
+
+  AWARD_TITLES = [
+    '首位打者', '本塁打王', '打点王', '盗塁王',
+    'ベストナイン', '新人賞', '最優秀防御率',
+    '最多勝', 'セーブ王', '最優秀選手 (MVP)',
+    'ゴールデングラブ', '最多奪三振', '殊勲賞'
+  ].freeze
+
+  TOURNAMENT_NAMES = %w[
+    春季大会 夏季大会 秋季大会 冬季リーグ
+    地区予選 県大会 都市対抗 社会人野球選手権
+    高校選手権 ボーイズリーグ全国大会
+    リトルシニア地区大会 中学軟式選手権
+    オープン戦シリーズ 練習試合シリーズ
+  ].freeze
+
+  SEASON_NAMES = %w[2024シーズン 2025シーズン 2026シーズン].freeze
+
+  NOTE_CATEGORIES = %w[打撃練習 守備練習 投球練習 試合反省 目標設定 トレーニング ミーティング 自主練].freeze
+
+  NOTE_TEMPLATES = [
+    '今日の練習で気づいたことを記録します。コーチからのフィードバックを踏まえて次回への改善点を整理しました。',
+    '試合での反省と次回の改善点をまとめました。特にチャンスの場面での集中力が課題だと感じました。',
+    'コーチからのアドバイスを忘れないように記録します。バッティングフォームの修正ポイントを意識します。',
+    '明日の目標と重点的に取り組むべきことを整理しました。守備練習にも時間を割きたいです。',
+    '練習メニューと取り組み内容を残します。スイングスピードの改善が次の課題です。',
+    '対戦相手の傾向と次回の対策を考えました。投手の球種と配球パターンをイメージしておきます。',
+    '今日の反省を踏まえて、明日からの取り組みを変えていきたいと思います。',
+    '体調管理とコンディション維持の重要性を再認識しました。'
+  ].freeze
+
+  USER_NAMES = %w[
+    田中太郎 佐藤花子 鈴木一郎 高橋健太 渡辺真理
+    伊藤蓮 山本翔太 中村優斗 小林大輔 加藤さくら
+    吉田陸 山田悠斗 佐々木遼 山口奈々 松本拓海
+    井上颯太 木村光輝 林大樹 清水裕真 山崎涼介
+    森智也 阿部琉生 池田結菜 橋本悠 石川駿
+    山下春樹 中島陽向 前田蒼真 藤田結翔 後藤泰我
+    岡田一馬 長谷川夏輝 村上湊斗 近藤朔耶 石井朝陽
+    斎藤悠仁 坂本煌 遠藤湊 青木琉之介 福田隼大
+    三浦悠太 西村一斗 太田悠真 藤井湊太 岡本柊
+    松田岳 中川樹 中野航 原田陸斗 小川聖
+  ].freeze
+
+  # 打撃レベル: 各ユーザーに 1 段階割り当て、打席ごとの安打確率を制御する。
+  BATTING_LEVELS = {
+    strong: { hit: 0.34, extra: 0.32, hr: 0.06, bb: 0.10, k: 0.16 },
+    regular: { hit: 0.27, extra: 0.22, hr: 0.03, bb: 0.08, k: 0.22 },
+    slumped: { hit: 0.18, extra: 0.14, hr: 0.01, bb: 0.05, k: 0.30 }
+  }.freeze
+
+  # MatchResult APPEARANCE_TYPES と inning_format 候補は model のバリデーションに合わせる。
+  APPEARANCE_TYPE_WEIGHTS = {
+    'starter' => 80,
+    'substitute' => 6,
+    'pinch_hitter' => 6,
+    'pinch_runner' => 4,
+    'no_play' => 4
+  }.freeze
+
+  INNING_FORMATS = [9, 7].freeze
+
+  DEVICE_TOKEN_PLATFORMS = %w[ios android].freeze
+
+  # PlateResult のうち打席で使われる選択肢。v1 形式（is_new_format = false）の
+  # plate_appearances を作るために `name` 文字列で扱う。
+  PLATE_RESULT_OUTCOMES = %w[ゴロ フライ ライナー エラー フィルダースチョイス
+                             ヒット 二塁打 三塁打 本塁打 犠打 犠飛
+                             三振 振り逃げ 四球 死球 打撃妨害 併殺打].freeze
+
   class << self
     def create_positions
       %w[投手 捕手 一塁手 二塁手 三塁手 遊撃手 左翼手 中堅手 右翼手 指名打者].each do |name|
@@ -112,59 +195,102 @@ class DevDataCreator # rubocop:disable Metrics/ClassLength
       Rails.logger.debug { "Admin Users: #{Admin::User.count}" }
     end
 
+    def create_awards
+      AWARD_TITLES.each { |title| Award.find_or_create_by!(title:) }
+      Rails.logger.debug { "Awards: #{Award.count}" }
+    end
+
+    def create_tournaments
+      TOURNAMENT_NAMES.each { |name| Tournament.find_or_create_by!(name:) }
+      Rails.logger.debug { "Tournaments: #{Tournament.count}" }
+    end
+
     def create_users
       positions = Position.all
+      level_keys = BATTING_LEVELS.keys
       users = []
-      20.times do |i|
-        n = i + 1
+      USER_NAMES.each_with_index do |display_name, index|
+        n = index + 1
         user = User.find_or_create_by!(email: "dev#{n}@example.com") do |u|
           u.password = 'password123'
-          u.name = "開発ユーザー#{n}"
+          u.name = display_name
           u.user_id = "devuser#{n}"
           u.confirmed_at = Time.current
         end
         users << user
         UserPosition.find_or_create_by!(user:, position: positions.sample)
+        # 後の打撃成績生成で使う打撃レベルを user 単位でメモする。
+        user.instance_variable_set(:@dev_data_batting_level, level_keys.sample)
       end
       Rails.logger.debug { "Users: #{User.count}" }
       users
     end
 
     def create_teams
-      team_names = %w[ブルースターズ レッドファルコンズ グリーンイーグルス ホワイトベアーズ ブラックパンサーズ]
-      teams = team_names.map { |name| Team.find_or_create_by!(name:) }
+      teams = TEAM_NAMES.map { |name| Team.find_or_create_by!(name:) }
       Rails.logger.debug { "Teams: #{Team.count}" }
       teams
     end
 
-    def create_game_results(users, teams)
-      # match_results.match_type は本番フォームでは "regular" / "open" の英語キーで
-      # 保存されるため、開発用シードでも同じ値域に揃える。
-      # 過去には日本語値（"練習試合" 等）を使っていたが、表示時の変換が一致せず
-      # バッジが日本語のまま表示される問題があったため英語キーに統一。
-      match_types = %w[regular open]
+    def create_seasons(users)
       users.each do |user|
-        rand(3..5).times do
+        SEASON_NAMES.each do |name|
+          Season.find_or_create_by!(user:, name:)
+        end
+      end
+      Rails.logger.debug { "Seasons: #{Season.count}" }
+    end
+
+    def create_user_awards(users)
+      awards = Award.all.to_a
+      users.each do |user|
+        rand(0..3).times do
+          award = awards.sample
+          UserAward.find_or_create_by!(user:, award:)
+        end
+      end
+      Rails.logger.debug { "UserAwards: #{UserAward.count}" }
+    end
+
+    def create_device_tokens(users)
+      users.sample(users.size / 3).each do |user|
+        platform = DEVICE_TOKEN_PLATFORMS.sample
+        # トークン文字列は実機の Expo Push トークンに似せたランダム文字列。
+        token = "ExpoPushToken[#{SecureRandom.alphanumeric(40)}]"
+        DeviceToken.find_or_create_by!(user:, token:) { |t| t.platform = platform }
+      end
+      Rails.logger.debug { "DeviceTokens: #{DeviceToken.count}" }
+    end
+
+    def create_game_results(users, teams)
+      tournaments = Tournament.all.to_a
+      users.each do |user|
+        seasons_by_year = user.seasons.index_by { |s| s.name[/\d{4}/].to_i }
+        rand(50..100).times do
           my_team = teams.sample
           opponent_team = teams.reject { |t| t.id == my_team.id }.sample
-          game_time = rand(1..60).days.ago + rand(8..18).hours
+          game_time = rand(1..180).days.ago + rand(8..18).hours
 
+          context = { user:, my_team:, opponent_team:, game_time:, tournaments:, seasons_by_year: }
           ActiveRecord::Base.transaction do
-            game_result = create_single_game(user, my_team, opponent_team, game_time, match_types)
+            game_result = create_single_game(context)
             create_batting_average(user, game_result, game_time)
             create_pitching_result_if_pitcher(user, game_result, game_time)
+            create_plate_appearances(user, game_result, game_time)
           end
         end
       end
       Rails.logger.debug { "GameResults: #{GameResult.count}" }
+      Rails.logger.debug { "MatchResults: #{MatchResult.count}" }
       Rails.logger.debug { "BattingAverages: #{BattingAverage.count}" }
       Rails.logger.debug { "PitchingResults: #{PitchingResult.count}" }
+      Rails.logger.debug { "PlateAppearances: #{PlateAppearance.count}" }
     end
 
     def create_relationships(users)
       Rails.logger.debug 'Creating relationships...'
-      users.first(10).each do |follower|
-        followed_users = users.reject { |u| u.id == follower.id }.sample(rand(2..5))
+      users.each do |follower|
+        followed_users = users.reject { |u| u.id == follower.id }.sample(rand(5..20))
         followed_users.each do |followed|
           Relationship.find_or_create_by!(follower_id: follower.id, followed_id: followed.id) do |r|
             r.status = :accepted
@@ -176,7 +302,7 @@ class DevDataCreator # rubocop:disable Metrics/ClassLength
 
     def setup_private_accounts(users)
       Rails.logger.debug 'Setting private accounts...'
-      private_users = users[17..18]
+      private_users = users.sample(7)
       private_users.each { |u| u.update!(is_private: true) }
       Rails.logger.debug { "Private users: #{User.where(is_private: true).count}" }
       private_users
@@ -185,7 +311,7 @@ class DevDataCreator # rubocop:disable Metrics/ClassLength
     def create_pending_follow_requests(users, private_users)
       Rails.logger.debug 'Creating pending follow requests...'
       private_users.each do |private_user|
-        requesters = users.reject { |u| u.id == private_user.id }.sample(3)
+        requesters = users.reject { |u| u.id == private_user.id }.sample(rand(3..6))
         requesters.each do |requester|
           rel = Relationship.find_or_create_by!(follower_id: requester.id, followed_id: private_user.id) do |r|
             r.status = :pending
@@ -199,7 +325,7 @@ class DevDataCreator # rubocop:disable Metrics/ClassLength
 
     def create_follow_notifications
       Rails.logger.debug 'Creating follow notifications...'
-      Relationship.accepted.limit(5).each do |rel|
+      Relationship.accepted.limit(30).each do |rel|
         notification = Notification.create!(actor_id: rel.follower_id, event_type: 'followed', event_id: rel.follower_id)
         UserNotification.create!(user_id: rel.followed_id, notification_id: notification.id)
       end
@@ -208,31 +334,26 @@ class DevDataCreator # rubocop:disable Metrics/ClassLength
 
     def create_groups(users)
       Rails.logger.debug 'Creating groups...'
-      2.times do |i|
-        group = Group.find_or_create_by!(name: "開発テストグループ#{i + 1}")
-        owner = users[i]
-        members = ensure_enough_following(owner, users)
+      group_names = %w[東日本チーム交流会 高校野球記録共有グループ 中学野球データ共有
+                       社会人野球分析チーム 少年野球コーチ陣 大学野球研究会]
+      group_names.first(rand(4..6)).each_with_index do |name, i|
+        group = Group.find_or_create_by!(name:)
+        owner = users[i % users.size]
+        members = ensure_enough_following(owner, users, target: rand(5..15))
         register_group_members([owner] + members, group)
       end
       Rails.logger.debug { "Groups: #{Group.count}" }
+      Rails.logger.debug { "GroupUsers: #{GroupUser.count}" }
     end
 
     def create_baseball_notes(users)
       Rails.logger.debug 'Creating baseball notes...'
-      note_categories = %w[打撃練習 守備練習 投球練習 試合反省 目標設定 トレーニング]
-      note_templates = [
-        '今日の練習で気づいたことを記録します。',
-        '試合での反省と次回の改善点をまとめました。',
-        'コーチからのアドバイスを忘れないように記録します。',
-        '明日の目標と重点的に取り組むべきことを整理しました。'
-      ]
-
-      users.first(10).each do |user|
-        rand(1..3).times do
-          note_date = rand(1..30).days.ago.to_date
-          memo_content = [{ 'type' => 'paragraph', 'children' => [{ 'text' => note_templates.sample }] }]
+      users.each do |user|
+        rand(5..15).times do
+          note_date = rand(1..180).days.ago.to_date
+          memo_content = [{ 'type' => 'paragraph', 'children' => [{ 'text' => NOTE_TEMPLATES.sample }] }]
           BaseballNote.create!(
-            user:, title: "#{note_categories.sample} - #{note_date.strftime('%m/%d')}",
+            user:, title: "#{NOTE_CATEGORIES.sample} - #{note_date.strftime('%m/%d')}",
             date: note_date, memo: memo_content.to_json,
             created_at: note_date.beginning_of_day + rand(18).hours,
             updated_at: note_date.beginning_of_day + rand(18).hours
@@ -244,7 +365,9 @@ class DevDataCreator # rubocop:disable Metrics/ClassLength
 
     def print_summary
       Rails.logger.debug "\n=== Sample Data Creation Summary ==="
-      %w[User Team GameResult BattingAverage PitchingResult Relationship Notification Group BaseballNote].each do |model|
+      %w[User Team GameResult MatchResult BattingAverage PitchingResult PlateAppearance
+         Season Tournament Award UserAward DeviceToken
+         Relationship Notification Group GroupUser BaseballNote].each do |model|
         Rails.logger.debug { "#{model}: #{model.constantize.count}" }
       end
       Rails.logger.debug { "Private Users: #{User.where(is_private: true).count}" }
@@ -253,23 +376,39 @@ class DevDataCreator # rubocop:disable Metrics/ClassLength
 
     private
 
-    def create_single_game(user, my_team, opponent_team, game_time, match_types)
-      game_result = GameResult.create!(user:, created_at: game_time, updated_at: game_time)
+    def create_single_game(context)
+      user = context.fetch(:user)
+      my_team = context.fetch(:my_team)
+      opponent_team = context.fetch(:opponent_team)
+      game_time = context.fetch(:game_time)
+      tournaments = context.fetch(:tournaments)
+      seasons_by_year = context.fetch(:seasons_by_year)
+      game_result = GameResult.create!(user:, season: seasons_by_year[game_time.year],
+                                       created_at: game_time, updated_at: game_time)
+      appearance_type = sample_weighted(APPEARANCE_TYPE_WEIGHTS)
+      # `defensive_position` は DB レベルで null: false。starter 以外は守備不在を表す "0" を入れる。
+      defensive_position = appearance_type == 'starter' ? rand(1..9).to_s : '0'
+      tournament = tournaments.sample if rand < 0.3
       match_result = MatchResult.create!(
-        game_result:, user:, date_and_time: game_time, match_type: match_types.sample,
+        game_result:, user:, date_and_time: game_time, match_type: %w[regular open].sample,
         my_team:, opponent_team:, my_team_score: rand(0..12), opponent_team_score: rand(0..12),
-        batting_order: rand(1..9), defensive_position: rand(1..9),
-        memo: '開発用テストデータ', created_at: game_time, updated_at: game_time
+        batting_order: rand(1..9).to_s, defensive_position:,
+        appearance_type:, inning_format: INNING_FORMATS.sample,
+        tournament:, memo: '開発用テストデータ',
+        created_at: game_time, updated_at: game_time
       )
       game_result.update!(match_result_id: match_result.id)
       game_result
     end
 
     def create_batting_average(user, game_result, game_time)
-      return unless rand < 0.85
+      return if game_result.match_result.appearance_type == 'no_play'
+      return unless rand < 0.9
 
-      stats = generate_plate_stats
-      extra_hits = generate_extra_base_hits(stats[:hits])
+      level = user.instance_variable_get(:@dev_data_batting_level) || :regular
+      probs = BATTING_LEVELS[level]
+      stats = generate_plate_stats(probs)
+      extra_hits = generate_extra_base_hits(stats[:hits], probs)
 
       batting_average = BattingAverage.create!(
         user:, game_result:, **batting_average_attrs(stats, extra_hits, game_time)
@@ -278,32 +417,48 @@ class DevDataCreator # rubocop:disable Metrics/ClassLength
     end
 
     def create_pitching_result_if_pitcher(user, game_result, game_time)
-      return unless game_result.match_result.defensive_position == 1
+      match_result = game_result.match_result
+      starter_pitcher = match_result.defensive_position == '1'
+      relief_pitcher = !starter_pitcher && rand < 0.05
+      return unless starter_pitcher || relief_pitcher
 
-      ip = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0].sample
-      ha = rand(2..(ip.to_i + 6))
-      ra = rand(0..[ha / 2, 8].min)
-      er = rand(0..ra)
-      my_score = game_result.match_result.my_team_score
-      opp_score = game_result.match_result.opponent_team_score
-      win = my_score > opp_score ? rand(0..1) : 0
-      loss = my_score < opp_score ? rand(0..1) : 0
-
+      ip = starter_pitcher ? [3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0].sample : [1.0, 2.0, 3.0].sample
       pitching_result = PitchingResult.create!(
-        user:, game_result:, win:, loss:, hold: win.zero? && loss.zero? ? rand(0..1) : 0,
-        saves: 0, innings_pitched: ip, number_of_pitches: (ip * rand(12..18)).to_i,
-        got_to_the_distance: ip >= 9.0, hits_allowed: ha, run_allowed: ra, earned_run: er,
-        base_on_balls: rand(0..5), strikeouts: rand((ip * 0.5).to_i..(ip * 1.5).to_i),
-        home_runs_hit: rand(0..[er / 2, 2].min), hit_by_pitch: rand(0..2),
-        created_at: game_time, updated_at: game_time
+        user:, game_result:, **pitching_result_attrs(ip:, match_result:, game_time:, starter: starter_pitcher)
       )
       game_result.update!(pitching_result_id: pitching_result.id)
     end
 
-    def ensure_enough_following(owner, users)
+    # v1 形式の打席記録を生成する（is_new_format = false）。
+    # 集計値（batting_average）との整合は厳密には取らないが、
+    # 打席数の概観として 3〜5 打席ずつ残しておくと検索 / 表示 UI のテストに足る。
+    def create_plate_appearances(user, game_result, game_time)
+      return if game_result.match_result.appearance_type == 'no_play'
+
+      plate_result_records = PlateResult.where(name: PLATE_RESULT_OUTCOMES).to_a
+      hit_direction_records = HitDirection.all.to_a
+      batter_box_count = rand(3..5)
+      batter_box_count.times do |index|
+        plate_result = plate_result_records.sample
+        hit_direction = plate_result.hit_direction_required ? hit_direction_records.sample : nil
+        PlateAppearance.create!(
+          game_result:, user:,
+          batter_box_number: index + 1,
+          batting_result: plate_result.name,
+          plate_result_id: plate_result.id,
+          hit_direction_id: hit_direction&.id,
+          batting_position_id: nil,
+          is_new_format: false,
+          created_at: game_time + index.minutes,
+          updated_at: game_time + index.minutes
+        )
+      end
+    end
+
+    def ensure_enough_following(owner, users, target:)
       candidates = owner.following.to_a
-      if candidates.size < 9
-        additional = users.reject { |u| u.id == owner.id || candidates.include?(u) }.sample(9 - candidates.size)
+      if candidates.size < target
+        additional = users.reject { |u| u.id == owner.id || candidates.include?(u) }.sample(target - candidates.size)
         additional.each do |u|
           Relationship.find_or_create_by!(follower_id: owner.id, followed_id: u.id) do |r|
             r.status = :accepted
@@ -311,7 +466,7 @@ class DevDataCreator # rubocop:disable Metrics/ClassLength
         end
         candidates = owner.following.reload.to_a
       end
-      candidates.sample([9, candidates.size].min)
+      candidates.sample([target, candidates.size].min)
     end
 
     def register_group_members(members, group)
@@ -324,28 +479,41 @@ class DevDataCreator # rubocop:disable Metrics/ClassLength
       end
     end
 
+    # 重み付きランダムサンプリング。{ key => weight } のハッシュから 1 つの key を返す。
+    def sample_weighted(weights)
+      total = weights.values.sum
+      threshold = rand * total
+      cumulative = 0.0
+      weights.each do |key, weight|
+        cumulative += weight
+        return key if threshold < cumulative
+      end
+      weights.keys.last
+    end
+
     def random_flag(probability)
       rand < probability ? 1 : 0
     end
 
-    def generate_plate_stats
+    def generate_plate_stats(probs)
       pa = rand(3..5)
-      bb = random_flag(0.08)
+      bb = random_flag(probs[:bb])
       hbp = random_flag(0.03)
       sh = random_flag(0.05)
       sf = random_flag(0.04)
       ab = [pa - bb - hbp - sh - sf, 1].max
-      hits = (0...ab).count { rand < 0.27 }
-      { pa:, ab:, hits:, bb:, hbp:, sh:, sf: }
+      hits = (0...ab).count { rand < probs[:hit] }
+      strike_outs = (0...(ab - hits)).count { rand < probs[:k] }
+      { pa:, ab:, hits:, bb:, hbp:, sh:, sf:, strike_outs: }
     end
 
-    def generate_extra_base_hits(hits)
+    def generate_extra_base_hits(hits, probs)
       remaining = hits
-      hr = remaining.positive? ? random_flag(0.05) : 0
+      hr = remaining.positive? ? random_flag(probs[:hr]) : 0
       remaining -= hr
-      tbh = remaining.positive? ? random_flag(0.03) : 0
+      tbh = remaining.positive? ? random_flag(0.04) : 0
       remaining -= tbh
-      dbh = remaining.positive? ? random_flag(0.20) : 0
+      dbh = remaining.positive? ? random_flag(probs[:extra]) : 0
       { hr:, tbh:, dbh: }
     end
 
@@ -358,12 +526,45 @@ class DevDataCreator # rubocop:disable Metrics/ClassLength
         total_bases: hits + extra[:dbh] + (extra[:tbh] * 2) + (extra[:hr] * 3),
         runs_batted_in: hits.positive? ? rand(0..[hits, 3].min) : 0,
         run: hits.positive? ? rand(0..[hits, 2].min) : 0,
-        strike_out: rand(0..[ab - hits, 2].min),
+        strike_out: stats[:strike_outs],
         base_on_balls: stats[:bb], hit_by_pitch: stats[:hbp],
         sacrifice_hit: stats[:sh], sacrifice_fly: stats[:sf],
         stealing_base: random_flag(0.10), caught_stealing: random_flag(0.03), error: random_flag(0.05),
         created_at: game_time, updated_at: game_time
       }
+    end
+
+    def pitching_result_attrs(ip:, match_result:, game_time:, starter:)
+      ha = rand(2..(ip.to_i + 6))
+      ra = rand(0..[ha / 2, 8].min)
+      er = rand(0..ra)
+      win_flag, loss_flag, save_flag = decide_pitching_result_flags(match_result:, starter:)
+      {
+        win: win_flag, loss: loss_flag, hold: win_flag.zero? && loss_flag.zero? && save_flag.zero? ? rand(0..1) : 0,
+        saves: save_flag,
+        innings_pitched: ip,
+        number_of_pitches: (ip * rand(12..18)).to_i,
+        got_to_the_distance: starter && ip >= match_result.inning_format,
+        hits_allowed: ha, run_allowed: ra, earned_run: er,
+        base_on_balls: rand(0..5), strikeouts: rand((ip * 0.5).to_i..(ip * 1.5).to_i),
+        home_runs_hit: rand(0..[er / 2, 2].min), hit_by_pitch: rand(0..2),
+        created_at: game_time, updated_at: game_time
+      }
+    end
+
+    def decide_pitching_result_flags(match_result:, starter:)
+      my_score = match_result.my_team_score
+      opp_score = match_result.opponent_team_score
+      score_diff = my_score - opp_score
+      if starter
+        win = score_diff.positive? ? rand(0..1) : 0
+        loss = score_diff.negative? ? rand(0..1) : 0
+        [win, loss, 0]
+      else
+        # リリーフ登板: スコア差が小さいときに save の可能性。
+        save = score_diff.positive? && score_diff <= 3 ? rand(0..1) : 0
+        [0, 0, save]
+      end
     end
   end
 end

--- a/lib/tasks/dev_data_creator.rb
+++ b/lib/tasks/dev_data_creator.rb
@@ -151,6 +151,21 @@ class DevDataCreator # rubocop:disable Metrics/ClassLength
 
   DEVICE_TOKEN_PLATFORMS = %w[ios android].freeze
 
+  # エッジケース: 集計値・UI 表示のエッジケースを必ずカバーするため、各ユーザーに 1 試合ずつ生成する。
+  BATTING_EDGE_CASES = %i[perfect_game cycle_hit no_hit strike_out_show
+                          walks_only homer_show rbi_show sacrifice_only].freeze
+  PITCHING_EDGE_CASES = %i[complete_shutout blowout_loss many_strikeouts wild_pitch
+                           save_close hold_clean long_relief_clean relief_loss].freeze
+  GAME_SCORE_EDGE_CASES = %i[blowout_win blowout_loss close_win sayonara high_score].freeze
+
+  MATCH_SCORE_EDGE_ATTRS = {
+    blowout_win: { my_team_score: 15, opponent_team_score: 0 },
+    blowout_loss: { my_team_score: 0, opponent_team_score: 15 },
+    close_win: { my_team_score: 3, opponent_team_score: 2 },
+    sayonara: { my_team_score: 5, opponent_team_score: 4 },
+    high_score: { my_team_score: 18, opponent_team_score: 15 }
+  }.freeze
+
   # PlateResult のうち打席で使われる選択肢。v1 形式（is_new_format = false）の
   # plate_appearances を作るために `name` 文字列で扱う。
   PLATE_RESULT_OUTCOMES = %w[ゴロ フライ ライナー エラー フィルダースチョイス
@@ -266,7 +281,9 @@ class DevDataCreator # rubocop:disable Metrics/ClassLength
       tournaments = Tournament.all.to_a
       users.each do |user|
         seasons_by_year = user.seasons.index_by { |s| s.name[/\d{4}/].to_i }
-        rand(50..100).times do
+        create_edge_case_games(user:, teams:, tournaments:, seasons_by_year:)
+        # エッジケースを差し引いた残り（最低 30 試合）をランダム生成する。
+        rand(30..80).times do
           my_team = teams.sample
           opponent_team = teams.reject { |t| t.id == my_team.id }.sample
           game_time = rand(1..180).days.ago + rand(8..18).hours
@@ -285,6 +302,81 @@ class DevDataCreator # rubocop:disable Metrics/ClassLength
       Rails.logger.debug { "BattingAverages: #{BattingAverage.count}" }
       Rails.logger.debug { "PitchingResults: #{PitchingResult.count}" }
       Rails.logger.debug { "PlateAppearances: #{PlateAppearance.count}" }
+    end
+
+    # 各ユーザーに対して、打撃・投手・スコアそれぞれの極端ケースを 1 試合ずつ生成する。
+    # UI / 集計の境界値テストを開発環境で行いやすくする目的。
+    def create_edge_case_games(user:, teams:, tournaments:, seasons_by_year:)
+      context = { user:, teams:, tournaments:, seasons_by_year: }
+      is_pitcher = user.positions.exists?(name: '投手')
+
+      GAME_SCORE_EDGE_CASES.each { |edge| create_edge_case_game(context, score_edge: edge) }
+      BATTING_EDGE_CASES.each { |edge| create_edge_case_game(context, batting_edge: edge) }
+      return unless is_pitcher
+
+      PITCHING_EDGE_CASES.each { |edge| create_edge_case_game(context, pitching_edge: edge) }
+    end
+
+    def create_edge_case_game(context, score_edge: nil, batting_edge: nil, pitching_edge: nil)
+      user = context.fetch(:user)
+      teams = context.fetch(:teams)
+      my_team = teams.sample
+      opponent_team = teams.reject { |t| t.id == my_team.id }.sample
+      game_time = rand(1..180).days.ago + rand(8..18).hours
+      score = score_edge ? MATCH_SCORE_EDGE_ATTRS.fetch(score_edge) : random_match_score
+      ActiveRecord::Base.transaction do
+        game_record_context = context.merge(game_time:, my_team:, opponent_team:,
+                                            score:, force_starter_pitcher: pitching_edge.present?)
+        game_result = build_edge_case_game_record(game_record_context)
+        apply_batting_average(user, game_result, game_time, batting_edge)
+        apply_pitching_result(user, game_result, game_time, pitching_edge)
+        create_plate_appearances(user, game_result, game_time)
+      end
+    end
+
+    def build_edge_case_game_record(context)
+      user = context.fetch(:user)
+      game_time = context.fetch(:game_time)
+      score = context.fetch(:score)
+      seasons_by_year = context.fetch(:seasons_by_year)
+      tournaments = context.fetch(:tournaments)
+      game_result = GameResult.create!(user:, season: seasons_by_year[game_time.year],
+                                       created_at: game_time, updated_at: game_time)
+      defensive_position = context.fetch(:force_starter_pitcher) ? '1' : rand(1..9).to_s
+      tournament = tournaments.sample if rand < 0.3
+      match_result = MatchResult.create!(
+        game_result:, user:, date_and_time: game_time, match_type: %w[regular open].sample,
+        my_team: context.fetch(:my_team), opponent_team: context.fetch(:opponent_team),
+        my_team_score: score[:my_team_score], opponent_team_score: score[:opponent_team_score],
+        batting_order: rand(1..9).to_s, defensive_position:,
+        appearance_type: 'starter', inning_format: INNING_FORMATS.sample,
+        tournament:, memo: '開発用テストデータ（エッジケース）',
+        created_at: game_time, updated_at: game_time
+      )
+      game_result.update!(match_result_id: match_result.id)
+      game_result
+    end
+
+    def apply_batting_average(user, game_result, game_time, batting_edge)
+      attrs = batting_edge ? edge_case_batting_average_attrs(batting_edge, game_time) : nil
+      return create_batting_average(user, game_result, game_time) if attrs.nil?
+
+      batting_average = BattingAverage.create!(user:, game_result:, **attrs)
+      game_result.update!(batting_average_id: batting_average.id)
+    end
+
+    def apply_pitching_result(user, game_result, game_time, pitching_edge)
+      if pitching_edge
+        attrs = edge_case_pitching_attrs(pitching_edge, game_time, match_result: game_result.match_result)
+        pitching_result = PitchingResult.create!(user:, game_result:, **attrs)
+        game_result.update!(pitching_result_id: pitching_result.id)
+      else
+        create_pitching_result_if_pitcher(user, game_result, game_time)
+      end
+    end
+
+    def random_match_score
+      { my_team_score: rand(0..12), opponent_team_score: rand(0..12) }
     end
 
     def create_relationships(users)
@@ -551,6 +643,91 @@ class DevDataCreator # rubocop:disable Metrics/ClassLength
         created_at: game_time, updated_at: game_time
       }
     end
+
+    # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
+    def edge_case_batting_average_attrs(edge, game_time)
+      base = { created_at: game_time, updated_at: game_time,
+               stealing_base: 0, caught_stealing: 0, error: 0,
+               hit_by_pitch: 0, base_on_balls: 0, sacrifice_hit: 0, sacrifice_fly: 0,
+               strike_out: 0 }
+      case edge
+      when :perfect_game
+        base.merge(plate_appearances: 5, at_bats: 5, times_at_bat: 5,
+                   hit: 5, two_base_hit: 1, three_base_hit: 0, home_run: 1,
+                   total_bases: 5 + 1 + 3, runs_batted_in: 4, run: 3, stealing_base: 1)
+      when :cycle_hit
+        base.merge(plate_appearances: 4, at_bats: 4, times_at_bat: 4,
+                   hit: 4, two_base_hit: 1, three_base_hit: 1, home_run: 1,
+                   total_bases: 1 + 2 + 3 + 4, runs_batted_in: 5, run: 3)
+      when :no_hit
+        base.merge(plate_appearances: 4, at_bats: 4, times_at_bat: 4,
+                   hit: 0, two_base_hit: 0, three_base_hit: 0, home_run: 0,
+                   total_bases: 0, runs_batted_in: 0, run: 0, strike_out: 1)
+      when :strike_out_show
+        base.merge(plate_appearances: 4, at_bats: 4, times_at_bat: 4,
+                   hit: 0, two_base_hit: 0, three_base_hit: 0, home_run: 0,
+                   total_bases: 0, runs_batted_in: 0, run: 0, strike_out: 4)
+      when :walks_only
+        base.merge(plate_appearances: 4, at_bats: 0, times_at_bat: 0,
+                   hit: 0, two_base_hit: 0, three_base_hit: 0, home_run: 0,
+                   total_bases: 0, runs_batted_in: 1, run: 2, base_on_balls: 4)
+      when :homer_show
+        base.merge(plate_appearances: 4, at_bats: 4, times_at_bat: 4,
+                   hit: 3, two_base_hit: 0, three_base_hit: 0, home_run: 2,
+                   total_bases: 3 + 6, runs_batted_in: 6, run: 3)
+      when :rbi_show
+        base.merge(plate_appearances: 5, at_bats: 5, times_at_bat: 5,
+                   hit: 4, two_base_hit: 1, three_base_hit: 0, home_run: 1,
+                   total_bases: 4 + 1 + 3, runs_batted_in: 8, run: 2)
+      when :sacrifice_only
+        base.merge(plate_appearances: 3, at_bats: 0, times_at_bat: 0,
+                   hit: 0, two_base_hit: 0, three_base_hit: 0, home_run: 0,
+                   total_bases: 0, runs_batted_in: 1, run: 0,
+                   sacrifice_hit: 2, sacrifice_fly: 1)
+      end
+    end
+
+    def edge_case_pitching_attrs(edge, game_time, match_result:)
+      base = { created_at: game_time, updated_at: game_time,
+               win: 0, loss: 0, hold: 0, saves: 0,
+               got_to_the_distance: false, home_runs_hit: 0, hit_by_pitch: 0 }
+      case edge
+      when :complete_shutout
+        base.merge(win: 1, innings_pitched: match_result.inning_format.to_f,
+                   number_of_pitches: 110, got_to_the_distance: true,
+                   hits_allowed: 3, run_allowed: 0, earned_run: 0,
+                   base_on_balls: 1, strikeouts: 9)
+      when :blowout_loss
+        base.merge(loss: 1, innings_pitched: 4.0, number_of_pitches: 95,
+                   hits_allowed: 12, run_allowed: 10, earned_run: 9,
+                   base_on_balls: 3, strikeouts: 2, home_runs_hit: 2, hit_by_pitch: 1)
+      when :many_strikeouts
+        base.merge(win: 1, innings_pitched: 8.0, number_of_pitches: 130,
+                   hits_allowed: 5, run_allowed: 1, earned_run: 1,
+                   base_on_balls: 1, strikeouts: 15)
+      when :wild_pitch
+        base.merge(innings_pitched: 5.0, number_of_pitches: 105,
+                   hits_allowed: 6, run_allowed: 4, earned_run: 3,
+                   base_on_balls: 7, strikeouts: 3, hit_by_pitch: 2)
+      when :save_close
+        base.merge(saves: 1, innings_pitched: 1.0, number_of_pitches: 18,
+                   hits_allowed: 1, run_allowed: 0, earned_run: 0,
+                   base_on_balls: 0, strikeouts: 2)
+      when :hold_clean
+        base.merge(hold: 1, innings_pitched: 1.0, number_of_pitches: 14,
+                   hits_allowed: 0, run_allowed: 0, earned_run: 0,
+                   base_on_balls: 0, strikeouts: 2)
+      when :long_relief_clean
+        base.merge(win: 1, innings_pitched: 4.0, number_of_pitches: 55,
+                   hits_allowed: 2, run_allowed: 0, earned_run: 0,
+                   base_on_balls: 1, strikeouts: 5)
+      when :relief_loss
+        base.merge(loss: 1, innings_pitched: 1.0, number_of_pitches: 25,
+                   hits_allowed: 3, run_allowed: 3, earned_run: 3,
+                   base_on_balls: 1, strikeouts: 0)
+      end
+    end
+    # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity
 
     def decide_pitching_result_flags(match_result:, starter:)
       my_score = match_result.my_team_score

--- a/lib/tasks/dev_data_creator.rb
+++ b/lib/tasks/dev_data_creator.rb
@@ -151,6 +151,23 @@ class DevDataCreator # rubocop:disable Metrics/ClassLength
 
   DEVICE_TOKEN_PLATFORMS = %w[ios android].freeze
 
+  USER_INTRODUCTIONS = [
+    '中学から野球を始めて、今は外野手として頑張っています。',
+    '投手として日々練習中。変化球の精度を上げたいです。',
+    'チームメイトと記録を共有したくて使い始めました。',
+    '打撃フォーム改善中。長打を増やしたいです。',
+    'データで自分の成績を振り返るのが好きです。',
+    '守備が得意。捕球の安定感を意識しています。',
+    '夏の大会に向けて練習中。応援よろしくお願いします。',
+    '打率 3 割を目指して頑張ります！',
+    '子どもの頃から野球が大好き。社会人野球で続けています。',
+    'ピッチング動画を見て勉強しています。アドバイスください！',
+    '父子で野球をやってます。記録を残すために登録しました。',
+    'カーブとスライダーが得意です。'
+  ].freeze
+
+  SUSPENDED_REASONS = %w[規約違反のため スパム投稿のため 迷惑行為の疑いがあったため].freeze
+
   # エッジケース: 集計値・UI 表示のエッジケースを必ずカバーするため、各ユーザーに 1 試合ずつ生成する。
   BATTING_EDGE_CASES = %i[perfect_game cycle_hit no_hit strike_out_show
                           walks_only homer_show rbi_show sacrifice_only].freeze
@@ -231,6 +248,7 @@ class DevDataCreator # rubocop:disable Metrics/ClassLength
           u.name = display_name
           u.user_id = "devuser#{n}"
           u.confirmed_at = Time.current
+          assign_profile_attributes(u, n)
         end
         users << user
         UserPosition.find_or_create_by!(user:, position: positions.sample)
@@ -240,6 +258,42 @@ class DevDataCreator # rubocop:disable Metrics/ClassLength
       Rails.logger.debug { "Users: #{User.count}" }
       users
     end
+
+    # 退会・凍結ユーザーを混ぜる。本番には soft_delete / suspended 状態のレコードが
+    # 存在するため、管理画面・取得 API の絞り込み（active scope）を開発環境でも検証できる。
+    def apply_user_lifecycle_states(users)
+      # 既存の private / 退会候補と重ならないよう、先頭から固定でピック。
+      suspended_targets = users.last(5).first(3)
+      deleted_targets = users.last(2)
+
+      suspended_targets.each do |user|
+        user.update!(suspended_at: rand(1..60).days.ago, suspended_reason: SUSPENDED_REASONS.sample)
+      end
+      deleted_targets.each do |user|
+        user.update!(deleted_at: rand(1..90).days.ago)
+      end
+      Rails.logger.debug { "Suspended Users: #{User.suspended.count}" }
+      Rails.logger.debug { "Soft Deleted Users: #{User.soft_deleted.count}" }
+    end
+
+    private
+
+    # プロフィール属性（自己紹介・画像・ログイン日時など）を実ユーザー像に近づける。
+    def assign_profile_attributes(user_builder, sequence)
+      user_builder.introduction = USER_INTRODUCTIONS.sample if rand < 0.8
+      # 実画像アップロードは重いので URL 文字列だけ流し込む。
+      # pravatar はシード付きで毎回同じ顔を返してくれる安定アバター。
+      user_builder.image = "https://i.pravatar.cc/300?u=devuser#{sequence}"
+      user_builder.last_login_at = sample_last_login_at
+      user_builder.last_management_notice_read_at = rand(1..60).days.ago if rand < 0.6
+    end
+
+    # 80% は直近 1 週間のアクティブユーザー / 20% は半年以上前の非アクティブを模す。
+    def sample_last_login_at
+      rand < 0.8 ? rand(0..7).days.ago : rand(180..365).days.ago
+    end
+
+    public
 
     def create_teams
       teams = TEAM_NAMES.map { |name| Team.find_or_create_by!(name:) }

--- a/spec/requests/api/v2/appearance_situations_spec.rb
+++ b/spec/requests/api/v2/appearance_situations_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::AppearanceSituations', type: :request do
+  let(:user) { create(:user) }
+
+  describe 'GET /api/v2/appearance_situations' do
+    context 'when authenticated' do
+      it 'returns 200 with seeded masters in display_order' do
+        get '/api/v2/appearance_situations', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        names = response.parsed_body['appearance_situations'].pluck('name')
+        expect(names).to eq(%w[先発 中継ぎ 抑え])
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v2/appearance_situations'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/arm_angles_spec.rb
+++ b/spec/requests/api/v2/arm_angles_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::ArmAngles', type: :request do
+  let(:user) { create(:user) }
+
+  describe 'GET /api/v2/arm_angles' do
+    context 'when authenticated' do
+      it 'returns 200 with seeded masters in display_order' do
+        get '/api/v2/arm_angles', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        names = response.parsed_body['arm_angles'].pluck('name')
+        expect(names).to eq(%w[オーバースロー スリークォーター サイドスロー アンダースロー])
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v2/arm_angles'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/pitcher_styles_spec.rb
+++ b/spec/requests/api/v2/pitcher_styles_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::PitcherStyles', type: :request do
+  let(:user) { create(:user) }
+
+  describe 'GET /api/v2/pitcher_styles' do
+    context 'when authenticated' do
+      it 'returns 200 with seeded masters in display_order' do
+        get '/api/v2/pitcher_styles', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        names = response.parsed_body['pitcher_styles'].pluck('name')
+        expect(names).to eq(%w[本格派 技巧派 変則派 パワー型])
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v2/pitcher_styles'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/pitchers_spec.rb
+++ b/spec/requests/api/v2/pitchers_spec.rb
@@ -75,4 +75,30 @@ RSpec.describe 'Api::V2::Pitchers', type: :request do
       expect(response.parsed_body['errors']).not_to be_empty
     end
   end
+
+  describe 'PATCH /api/v2/pitchers/:id' do
+    let!(:own_pitcher) { Pitcher.create!(name: '自分の投手', throw_hand: :right, created_by_user: user) }
+    let!(:other_pitcher) { Pitcher.create!(name: '他人の投手', throw_hand: :right, created_by_user: other_user) }
+
+    it '自分の投手の属性を更新できる' do
+      patch "/api/v2/pitchers/#{own_pitcher.id}",
+            params: { pitcher: { name: '更新後', throw_hand: 'left', memo: '配球メモ' } },
+            headers: auth_headers_for(user), as: :json
+
+      expect(response).to have_http_status(:ok)
+      own_pitcher.reload
+      expect(own_pitcher.name).to eq('更新後')
+      expect(own_pitcher.throw_hand).to eq('left')
+      expect(own_pitcher.memo).to eq('配球メモ')
+    end
+
+    it '他ユーザーが作成した投手は更新できず 404' do
+      patch "/api/v2/pitchers/#{other_pitcher.id}",
+            params: { pitcher: { name: '改ざん' } },
+            headers: auth_headers_for(user), as: :json
+
+      expect(response).to have_http_status(:not_found)
+      expect(other_pitcher.reload.name).to eq('他人の投手')
+    end
+  end
 end

--- a/spec/requests/api/v2/pitchers_spec.rb
+++ b/spec/requests/api/v2/pitchers_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Api::V2::Pitchers', type: :request do
   let(:user) { create(:user) }
   let(:other_user) { create(:user) }
-  let!(:arm_angle) { ArmAngle.first }
+  let!(:arm_angle) { ArmAngle.find_by!(name: 'オーバースロー') }
 
   describe 'GET /api/v2/pitchers' do
     before do

--- a/spec/requests/api/v2/pitchers_spec.rb
+++ b/spec/requests/api/v2/pitchers_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::Pitchers', type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let!(:arm_angle) { ArmAngle.first }
+
+  describe 'GET /api/v2/pitchers' do
+    before do
+      Pitcher.create!(name: '田中投手', throw_hand: :right, created_by_user: user)
+      Pitcher.create!(name: '佐藤投手', throw_hand: :left, created_by_user: user)
+      Pitcher.create!(name: '別ユーザー投手', throw_hand: :right, created_by_user: other_user)
+    end
+
+    context 'when authenticated' do
+      it 'current user が作成した投手のみ返す（他ユーザー分は除外）' do
+        get '/api/v2/pitchers', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        names = response.parsed_body['data'].pluck('name')
+        expect(names).to include('田中投手', '佐藤投手')
+        expect(names).not_to include('別ユーザー投手')
+      end
+
+      it 'q パラメータで部分一致検索ができる' do
+        get '/api/v2/pitchers', params: { q: '田中' }, headers: auth_headers_for(user)
+        names = response.parsed_body['data'].pluck('name')
+        expect(names).to eq(['田中投手'])
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v2/pitchers'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'POST /api/v2/pitchers' do
+    let(:payload) do
+      {
+        pitcher: {
+          name: '新規投手',
+          throw_hand: 'right',
+          arm_angle_id: arm_angle.id
+        }
+      }
+    end
+
+    it '投手を作成し、created_by_user は current_api_v1_user に固定される' do
+      expect do
+        post '/api/v2/pitchers', params: payload, headers: auth_headers_for(user), as: :json
+      end.to change(Pitcher, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      created = Pitcher.find(response.parsed_body['id'])
+      expect(created.created_by_user).to eq(user)
+      expect(created.throw_hand).to eq('right')
+    end
+
+    it 'クライアントが created_by_user_id を渡しても無視される' do
+      malicious = payload.deep_merge(pitcher: { created_by_user_id: other_user.id })
+      post '/api/v2/pitchers', params: malicious, headers: auth_headers_for(user), as: :json
+
+      expect(response).to have_http_status(:created)
+      created = Pitcher.find(response.parsed_body['id'])
+      expect(created.created_by_user).to eq(user)
+    end
+
+    it 'name が空ならバリデーションエラー' do
+      post '/api/v2/pitchers', params: { pitcher: { name: '' } }, headers: auth_headers_for(user), as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body['errors']).not_to be_empty
+    end
+  end
+end

--- a/spec/requests/api/v2/plate_appearances_spec.rb
+++ b/spec/requests/api/v2/plate_appearances_spec.rb
@@ -53,6 +53,27 @@ RSpec.describe 'Api::V2::PlateAppearances', type: :request do
         post '/api/v2/plate_appearances', params: bad_params, headers: auth_headers_for(user)
         expect(response).to have_http_status(:not_found)
       end
+
+      it '他ユーザーが作成した pitcher_id を指定すると 422（IDOR防止）' do
+        other_user = create(:user)
+        other_pitcher = Pitcher.create!(name: '他人の投手', throw_hand: :right, created_by_user: other_user)
+        bad_params = base_params.deep_merge(plate_appearance: { pitcher_id: other_pitcher.id })
+
+        post '/api/v2/plate_appearances', params: bad_params, headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['errors']).to include('指定された投手は存在しません')
+      end
+
+      it '自分が作成した pitcher_id を指定すると作成できる' do
+        own_pitcher = Pitcher.create!(name: '自分の投手', throw_hand: :left, created_by_user: user)
+        good_params = base_params.deep_merge(plate_appearance: { pitcher_id: own_pitcher.id })
+
+        post '/api/v2/plate_appearances', params: good_params, headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:created)
+        expect(PlateAppearance.find(response.parsed_body['id']).pitcher_id).to eq(own_pitcher.id)
+      end
     end
 
     context 'when not authenticated' do
@@ -85,6 +106,19 @@ RSpec.describe 'Api::V2::PlateAppearances', type: :request do
               params: { plate_appearance: { plate_result_id: 7 } },
               headers: auth_headers_for(other_user)
         expect(response).to have_http_status(:not_found)
+      end
+
+      it '他ユーザーが作成した pitcher_id を指定すると 422（IDOR防止）' do
+        other_user = create(:user)
+        other_pitcher = Pitcher.create!(name: '他人の投手', throw_hand: :right, created_by_user: other_user)
+
+        patch "/api/v2/plate_appearances/#{plate_appearance.id}",
+              params: { plate_appearance: { pitcher_id: other_pitcher.id } },
+              headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['errors']).to include('指定された投手は存在しません')
+        expect(plate_appearance.reload.pitcher_id).to be_nil
       end
     end
 

--- a/spec/requests/api/v2/velocity_zones_spec.rb
+++ b/spec/requests/api/v2/velocity_zones_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::VelocityZones', type: :request do
+  let(:user) { create(:user) }
+
+  describe 'GET /api/v2/velocity_zones' do
+    context 'when authenticated' do
+      it 'returns 200 with seeded masters in display_order' do
+        get '/api/v2/velocity_zones', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        names = response.parsed_body['velocity_zones'].pluck('name')
+        expect(names).to eq(['120km/h未満', '120-130km/h', '130-140km/h', '140-150km/h', '150km/h以上'])
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v2/velocity_zones'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/support/master_data_seed.rb
+++ b/spec/support/master_data_seed.rb
@@ -4,7 +4,8 @@
 
 RSpec.configure do |config|
   config.before(:suite) do
-    %w[hit_directions plate_results pitch_types contact_qualities timings hit_depths].each do |table|
+    %w[hit_directions plate_results pitch_types contact_qualities timings hit_depths
+       arm_angles velocity_zones pitcher_styles appearance_situations].each do |table|
       MasterData::Seeder.from_yaml(ActiveRecord::Base.connection, table:, file: "#{table}.yml")
     end
   end


### PR DESCRIPTION
## Summary

ippei-shimizu/buzzbase#334 の Step3 詳細データ入力に **相手投手データ** を追加するためのバックエンド対応。

### 追加データモデル

#### 新規マスタ（4 つ）
- `arm_angles`（4種: オーバースロー / スリークォーター / サイドスロー / アンダースロー）
- `velocity_zones`（5種: 120未満 / 120-130 / 130-140 / 140-150 / 150+ km/h）
- `pitcher_styles`（4種: 本格派 / 技巧派 / 変則派 / パワー型）
- `appearance_situations`（3種: 先発 / 中継ぎ / 抑え）

#### 新規エンティティ
- `pitchers` テーブル（ユーザー追加可能、`(created_by_user_id, team_id, name)` で unique）

#### 既存テーブル拡張
- `plate_appearances` に `pitcher_id` / `appearance_situation_id` を nullable で追加（既存集計に影響なし）

### v2 API
- `GET /api/v2/arm_angles` 他マスタ 3 本
- `GET /api/v2/pitchers`（current user 作成分のみ返却）
- `POST /api/v2/pitchers`（`created_by_user` を current user に固定。クライアントからの上書き不可）
- `POST/PATCH /api/v2/plate_appearances` Strong Params に `pitcher_id` / `appearance_situation_id` を追加し、**他ユーザーの pitcher_id を渡された場合は 422** で弾く

### 投手マスタのユーザー固有マスタ化
- 球場マスタとは異なり、投手は記録したユーザーのみ閲覧・紐付け可能
- 他ユーザー投手への紐付けを controller 側で防御

## Test plan

- [x] `rspec spec/requests/api/v2/pitchers_spec.rb` パス（index ユーザー絞り込み / create で `created_by_user_id` 上書き / バリデーション）
- [x] `rspec spec/requests/api/v2/arm_angles_spec.rb` パス
- [x] 既存 `plate_appearances_spec.rb` リグレッションなし
- [x] `rubocop` パス
- [x] マイグレーション ロールバック可能（`db:rollback`）
- [ ] ステージング適用後、mobile PR の動作確認
