### PR TITLE
Remove: hit_directions/hit_depths テーブルと hit_depth_id カラムを物理削除 (PR3/4)

### DIFF
--- a/db/migrate/20260612130000_remove_hit_depth_from_plate_appearances.rb
+++ b/db/migrate/20260612130000_remove_hit_depth_from_plate_appearances.rb
@@ -1,5 +1,9 @@
 class RemoveHitDepthFromPlateAppearances < ActiveRecord::Migration[7.1]
-  def change
+  def up
     remove_reference :plate_appearances, :hit_depth, foreign_key: true, index: true
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20260612130000_remove_hit_depth_from_plate_appearances.rb
+++ b/db/migrate/20260612130000_remove_hit_depth_from_plate_appearances.rb
@@ -1,0 +1,5 @@
+class RemoveHitDepthFromPlateAppearances < ActiveRecord::Migration[7.1]
+  def change
+    remove_reference :plate_appearances, :hit_depth, foreign_key: true, index: true
+  end
+end

--- a/db/migrate/20260612130001_drop_hit_depths.rb
+++ b/db/migrate/20260612130001_drop_hit_depths.rb
@@ -1,0 +1,9 @@
+class DropHitDepths < ActiveRecord::Migration[7.1]
+  def up
+    drop_table :hit_depths
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20260612130002_drop_hit_directions.rb
+++ b/db/migrate/20260612130002_drop_hit_directions.rb
@@ -1,0 +1,12 @@
+class DropHitDirections < ActiveRecord::Migration[7.1]
+  def up
+    # plate_appearances.hit_direction_id は素の integer 列で FK 制約は張られていないが、
+    # 過去のスキーマ状態によっては存在する可能性があるため防御的に確認する。
+    remove_foreign_key :plate_appearances, :hit_directions if foreign_key_exists?(:plate_appearances, :hit_directions)
+    drop_table :hit_directions
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_12_120000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_12_130002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -252,25 +252,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_12_120000) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "hit_depths", force: :cascade do |t|
-    t.string "name", null: false
-    t.integer "display_order", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["display_order"], name: "index_hit_depths_on_display_order"
-    t.index ["name"], name: "index_hit_depths_on_name", unique: true
-  end
-
-  create_table "hit_directions", force: :cascade do |t|
-    t.string "name", null: false
-    t.integer "display_order", null: false
-    t.jsonb "zone_polygon"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["display_order"], name: "index_hit_directions_on_display_order"
-    t.index ["name"], name: "index_hit_directions_on_name", unique: true
-  end
-
   create_table "management_notices", force: :cascade do |t|
     t.string "title", null: false
     t.text "body", null: false
@@ -404,7 +385,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_12_120000) do
     t.bigint "contact_quality_id"
     t.bigint "timing_id"
     t.bigint "pitch_type_id"
-    t.bigint "hit_depth_id"
     t.text "self_analysis_memo"
     t.text "opponent_memo"
     t.decimal "hit_location_x", precision: 4, scale: 3
@@ -415,7 +395,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_12_120000) do
     t.index ["appearance_situation_id"], name: "index_plate_appearances_on_appearance_situation_id"
     t.index ["contact_quality_id"], name: "index_plate_appearances_on_contact_quality_id"
     t.index ["game_result_id"], name: "index_plate_appearances_on_game_result_id"
-    t.index ["hit_depth_id"], name: "index_plate_appearances_on_hit_depth_id"
     t.index ["is_new_format"], name: "index_plate_appearances_on_is_new_format"
     t.index ["pitch_type_id"], name: "index_plate_appearances_on_pitch_type_id"
     t.index ["pitcher_id"], name: "index_plate_appearances_on_pitcher_id"
@@ -612,7 +591,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_12_120000) do
   add_foreign_key "plate_appearances", "appearance_situations"
   add_foreign_key "plate_appearances", "contact_qualities"
   add_foreign_key "plate_appearances", "game_results", on_delete: :cascade
-  add_foreign_key "plate_appearances", "hit_depths"
   add_foreign_key "plate_appearances", "pitch_types"
   add_foreign_key "plate_appearances", "pitchers"
   add_foreign_key "plate_appearances", "timings"

--- a/spec/db/migration_invariants_spec.rb
+++ b/spec/db/migration_invariants_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'マイグレーション後の既存データ保全', type: :mod
       plate_appearance.reload
       new_columns = %i[out_type hit_type rbi run_scored stolen_bases caught_stealing
                        final_balls final_strikes final_outs first_pitch_swing runners_state inning
-                       contact_quality_id timing_id pitch_type_id hit_depth_id
+                       contact_quality_id timing_id pitch_type_id
                        self_analysis_memo opponent_memo hit_location_x hit_location_y]
       aggregate_failures do
         new_columns.each do |column|


### PR DESCRIPTION
## Summary

- PR1 でコードからの依存を全廃済み、PR2 で mobile からの依存も撤廃済み
- DB スキーマから死蔵テーブル（`hit_directions` / `hit_depths`）と `plate_appearances.hit_depth_id` カラムを物理削除する
- `plate_appearances.hit_direction_id`（int カラム）は残し、`Stats::HitDirectionAggregator::DIRECTION_LABELS` 定数を SSoT として継続利用

## マイグレーション 3 本

| # | クラス | 内容 |
|---|---|---|
| 1 | `RemoveHitDepthFromPlateAppearances` | `remove_reference :plate_appearances, :hit_depth, foreign_key: true, index: true` で FK・index・カラムを一括削除 |
| 2 | `DropHitDepths` | `drop_table :hit_depths` |
| 3 | `DropHitDirections` | `foreign_key_exists?` ガード付きで FK を念のため削除してから `drop_table :hit_directions` |

`drop_table` 系は `down` を `raise ActiveRecord::IrreversibleMigration` とし、誤ったロールバックを防止する。

## schema.rb 差分

- `create_table "hit_depths"` 削除
- `create_table "hit_directions"` 削除（`zone_polygon` jsonb 列ごと）
- `plate_appearances.hit_depth_id` bigint 列 + `index_plate_appearances_on_hit_depth_id` 削除
- `add_foreign_key "plate_appearances", "hit_depths"` 削除
- スキーマバージョン: `2026_06_12_120000` → `2026_06_12_130002`

## **マージ前に本番 DB で実行する事前確認 SQL**

ステージング適用前に確認推奨、本番適用前は必須。

```sql
-- 1. hit_direction_id に 1〜13 以外が混入していないか
SELECT COUNT(*) FROM plate_appearances
 WHERE hit_direction_id IS NOT NULL AND hit_direction_id NOT BETWEEN 1 AND 13;
-- 期待: 0

-- 2. hit_depth_id が本当に全件 NULL か
SELECT COUNT(*) FROM plate_appearances WHERE hit_depth_id IS NOT NULL;
-- 期待: 0

-- 3. 他テーブルから hit_directions / hit_depths への FK が残っていないか
SELECT tc.table_name, kcu.column_name
  FROM information_schema.table_constraints tc
  JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
 WHERE tc.constraint_type = 'FOREIGN KEY'
   AND kcu.column_name IN ('hit_direction_id', 'hit_depth_id');
-- 期待: plate_appearances.hit_depth_id → hit_depths の 1 行のみ
```

加えて、**本番デプロイ前に DB バックアップを取得**する。

## 関連 Issue / PR

- ippei-shimizu/buzzbase#362
- 先行 PR (back PR1): ippei-shimizu/buzzbase_back#254（マージ済）
- 先行 PR (mobile PR2): ippei-shimizu/buzzbase_mobile#112（マージ済）

## Test plan

- [x] `bundle exec rails db:migrate` 3 本全成功（ローカル）
- [x] `bundle exec rspec` 757 example 全成功
- [x] `bundle exec rubocop` 違反なし
- [x] `git diff db/schema.rb` で期待差分を確認（テーブル / 列 / index / FK 削除）
- [ ] **本番 DB で上記事前確認 SQL を実行**
- [ ] **本番 DB バックアップ取得**
- [ ] stg 環境でマイグレーション適用、`POST /api/v2/plate_appearances` の動作確認

## ロールバック計画

- `drop_table` は IrreversibleMigration として宣言
- 万一の場合: git history から `db/data/master_seeds/hit_directions.yml` / `hit_depths.yml` を復元 + 手動マイグレーションでテーブル再構築 + DB バックアップから plate_appearances 復元

## 後続 PR

- PR4: 設計ドキュメント整理（`03-ground-zones.md` 削除など）
