### PR TITLE
Fix: BattingAverageRecalculator が混在試合で旧仕様の集計値を破壊するのを防ぐ

### DIFF
--- a/app/services/stats/batting_average_recalculator.rb
+++ b/app/services/stats/batting_average_recalculator.rb
@@ -69,9 +69,12 @@ module Stats
     # 「全 PA が is_new_format=true かつ PA が 1 件以上」のときだけ新仕様試合と判定する。
     # 1 件でも旧 PA (is_new_format=false) が含まれる混在試合では false を返し、
     # 旧フローで batting_averages に直書きされた集計値を保護する。
+    # マイグレーション期間中は旧 PA を含む試合が多数になるため、is_new_format=false の
+    # 存在チェックを先に評価して 1 クエリで早期 return できるようにする。
     def new_format_game?
-      game_pa_relation = PlateAppearance.where(game_result_id: @game_result_id)
-      game_pa_relation.exists? && !game_pa_relation.exists?(is_new_format: false)
+      return false if PlateAppearance.exists?(game_result_id: @game_result_id, is_new_format: false)
+
+      PlateAppearance.exists?(game_result_id: @game_result_id)
     end
 
     # 試合に紐づく PA が 1 件も無い状態かどうか。

--- a/app/services/stats/batting_average_recalculator.rb
+++ b/app/services/stats/batting_average_recalculator.rb
@@ -31,15 +31,17 @@ module Stats
       @cleanup_orphan = cleanup_orphan
     end
 
-    # 対象試合が新仕様試合なら batting_average を再集計して保存する。
-    # 新仕様試合でなく cleanup_orphan が true の場合、対応する batting_average を削除する
+    # 対象試合が新仕様試合（全 PA が is_new_format=true）なら batting_average を再集計して保存する。
+    # 旧 PA が 1 件でも残っている試合では何もしない（既存集計値を保護）。
+    # cleanup_orphan が true かつ PA が完全に 0 件のとき、対応する batting_average を削除する
     # （v2 で新仕様試合の最後の打席を削除した時の孤立レコード対策）。
-    # 旧仕様試合の場合（cleanup_orphan が false）は何もしない（既存集計値を保持）。
+    # PA に旧 PA が含まれる「混在試合」のケースでは旧フローで直書きされた集計値を
+    # 上書きしないよう、cleanup_orphan が true であっても触らない。
     #
     # @return [BattingAverage, nil] 更新後のレコード。再集計しない場合や削除した場合は nil
     def call
       return recalculate_and_save if new_format_game?
-      return cleanup_orphaned_batting_average if @cleanup_orphan
+      return cleanup_orphaned_batting_average if @cleanup_orphan && plate_appearances_empty?
 
       nil
     end
@@ -63,9 +65,18 @@ module Stats
       @user_id || GameResult.find(@game_result_id).user_id
     end
 
-    # is_new_format フラグが立った打席が1件でもあれば新仕様試合
+    # 「全 PA が is_new_format=true かつ PA が 1 件以上」のときだけ新仕様試合と判定する。
+    # 1 件でも旧 PA (is_new_format=false) が含まれる混在試合では false を返し、
+    # 旧フローで batting_averages に直書きされた集計値を保護する。
     def new_format_game?
-      PlateAppearance.exists?(game_result_id: @game_result_id, is_new_format: true)
+      game_pa_relation = PlateAppearance.where(game_result_id: @game_result_id)
+      game_pa_relation.exists? && !game_pa_relation.exists?(is_new_format: false)
+    end
+
+    # 試合に紐づく PA が 1 件も無い状態かどうか。
+    # cleanup_orphan の発動条件として使う（混在試合や旧仕様試合では false になるため誤発動を防ぐ）。
+    def plate_appearances_empty?
+      !PlateAppearance.exists?(game_result_id: @game_result_id)
     end
 
     # 全カラム一気に組み立てる都合上 ABC が高くなるが、各行は独立した集計式で複雑度は低いため許容する。

--- a/app/services/stats/batting_average_recalculator.rb
+++ b/app/services/stats/batting_average_recalculator.rb
@@ -1,8 +1,9 @@
 module Stats
   # game_result 単位で batting_average レコードを再集計するサービス。
   #
-  # 「新仕様試合」（is_new_format = true の plate_appearance が1件以上ある試合）のみを対象とする。
-  # 旧仕様試合（v1 で作成された既存試合）の batting_average は触らない。
+  # 「新仕様試合」（全 plate_appearance が is_new_format=true の試合）のみを対象とする。
+  # 旧 PA が 1 件でも含まれる混在試合や旧仕様試合は、旧フローで直書きされた集計値を
+  # 保護するため再集計対象外。
   #
   # 計算ロジックは plate_result_id ベースで、mobile/constants/battingData.ts:109-162
   # computeBattingStats と整合する結果になるよう設計されている（plate_results.counted_in_at_bats

--- a/spec/services/stats/batting_average_recalculator_spec.rb
+++ b/spec/services/stats/batting_average_recalculator_spec.rb
@@ -79,6 +79,29 @@ RSpec.describe Stats::BattingAverageRecalculator, type: :service do
       end
     end
 
+    context '旧仕様試合に cleanup_orphan: true が渡されたケース' do
+      let!(:existing_batting_average) do
+        create(:batting_average, game_result:, user:,
+                                 at_bats: 99, hit: 88, total_bases: 77)
+      end
+
+      before do
+        create(:plate_appearance, game_result:, user:, plate_result_id: 7, hit_direction_id: 10,
+                                  is_new_format: false, batting_result: '中安')
+      end
+
+      it 'plate_appearances_empty? が false なので batting_average は destroy されず値も改変されない' do
+        described_class.new(game_result_id: game_result.id, cleanup_orphan: true).call
+
+        existing_batting_average.reload
+        aggregate_failures do
+          expect(existing_batting_average.at_bats).to eq(99)
+          expect(existing_batting_average.hit).to eq(88)
+          expect(existing_batting_average.total_bases).to eq(77)
+        end
+      end
+    end
+
     context '新仕様試合で batting_average レコードがまだ無い場合' do
       before do
         create(:plate_appearance, game_result:, user:, plate_result_id: 7, hit_direction_id: 10,

--- a/spec/services/stats/batting_average_recalculator_spec.rb
+++ b/spec/services/stats/batting_average_recalculator_spec.rb
@@ -109,6 +109,52 @@ RSpec.describe Stats::BattingAverageRecalculator, type: :service do
       end
     end
 
+    context '混在試合（旧 PA と新 PA が同じ game_result に存在）' do
+      let!(:existing_batting_average) do
+        create(:batting_average, game_result:, user:,
+                                 runs_batted_in: 3, run: 2, stealing_base: 1, caught_stealing: 0,
+                                 hit: 2, two_base_hit: 1, home_run: 0, at_bats: 4)
+      end
+
+      before do
+        # 旧 PA 3 件（is_new_format=false, per-PA カラムは NULL）
+        3.times do |i|
+          create(:plate_appearance, game_result:, user:,
+                                    batter_box_number: i + 1, plate_result_id: 7,
+                                    is_new_format: false, batting_result: '中安')
+        end
+        # 新 PA 1 件（is_new_format=true, per-PA カラムに値あり）
+        create(:plate_appearance, game_result:, user:,
+                                  batter_box_number: 4, plate_result_id: 7,
+                                  is_new_format: true, batting_result: '左安',
+                                  rbi: 1, run_scored: 0, stolen_bases: 0, caught_stealing: 0)
+      end
+
+      it 'call は nil を返し、既存 batting_average の値を改変しない' do
+        result = described_class.new(game_result_id: game_result.id).call
+
+        expect(result).to be_nil
+        existing_batting_average.reload
+        aggregate_failures do
+          expect(existing_batting_average.runs_batted_in).to eq(3)
+          expect(existing_batting_average.run).to eq(2)
+          expect(existing_batting_average.stealing_base).to eq(1)
+          expect(existing_batting_average.hit).to eq(2)
+          expect(existing_batting_average.at_bats).to eq(4)
+        end
+      end
+
+      context '新 PA を全削除して旧 PA だけが残った後、cleanup_orphan: true で呼ばれた場合' do
+        it '旧仕様試合に戻ったとみなして既存 batting_average を destroy しない' do
+          PlateAppearance.where(game_result_id: game_result.id, is_new_format: true).destroy_all
+
+          expect do
+            described_class.new(game_result_id: game_result.id, cleanup_orphan: true).call
+          end.not_to(change { BattingAverage.where(game_result_id: game_result.id).count })
+        end
+      end
+    end
+
     context 'user_id を引数で渡した場合' do
       before do
         create(:plate_appearance, game_result:, user:, plate_result_id: 7, hit_direction_id: 10,


### PR DESCRIPTION
## 概要

`Stats::BattingAverageRecalculator` の `new_format_game?` 判定を「**全 PA が `is_new_format=true` のときだけ true**」に厳格化し、混在試合（旧 PA + 新 PA）では既存の `batting_averages` を破壊しないようにする。

関連: `docs/strategy/product/game-record-update-release-risk-analysis.md`

## 課題（リリースブロッカー）

現状の `new_format_game?` は「PA が 1 件でも `is_new_format=true` なら true」を返す:

```ruby
def new_format_game?
  PlateAppearance.exists?(game_result_id: @game_result_id, is_new_format: true)
end
```

このため、`release/game-stats-202605` をリリースして既存ユーザーが旧仕様試合の打席を新仕様 UI（試合詳細の打席カードタップ → `PlateAppearanceWizard`）で **1 件編集すると**:

1. 編集された PA が `is_new_format=true` 化（v2 controller の強制セット）
2. Recalculator が「新仕様試合」と誤判定 → 試合全体を再集計
3. 集計式は per-PA カラム (`rbi` / `run_scored` / `stolen_bases` / `caught_stealing`) を SUM
4. 旧 PA はこれらが全件 NULL → SUM 結果 = 編集 1 件分のみ
5. 旧フローで `batting_averages` 直書きされていた合計値が **編集 1 件分の値（または 0）に上書き**

### 本番影響規模（2026-06-13 SQL 実測）

- 破壊リスク試合: **2,552 試合**
- 消失リスク打点: 2,832 件
- 消失リスク得点: 2,679 件
- 消失リスク盗塁: 2,347 件
- 消失リスク盗塁死: 162 件

## 設計

### 修正後の挙動マトリクス

| PA の状態 | `cleanup_orphan` | 修正前 | 修正後 |
|---|---|---|---|
| 全件 `is_new_format=true` | - | 再集計 | 再集計（変わらず） |
| 全件 `is_new_format=false` | - | 何もしない | 何もしない（変わらず） |
| **混在（旧 + 新）** | - | **再集計（破壊）** | **何もしない（保護）** |
| 0 件 | true | destroy_all（孤立対策） | destroy_all（変わらず） |
| 0 件 | false | 何もしない | 何もしない（変わらず） |
| 新 PA を最後に削除して旧 PA が残った | true | destroy_all（旧仕様 BA が消える） | **何もしない（保護）** |

### コード変更

`back/app/services/stats/batting_average_recalculator.rb`

```ruby
def new_format_game?
  game_pa_relation = PlateAppearance.where(game_result_id: @game_result_id)
  game_pa_relation.exists? && !game_pa_relation.exists?(is_new_format: false)
end

def plate_appearances_empty?
  !PlateAppearance.exists?(game_result_id: @game_result_id)
end

def call
  return recalculate_and_save if new_format_game?
  return cleanup_orphaned_batting_average if @cleanup_orphan && plate_appearances_empty?

  nil
end
```

## テスト

`back/spec/services/stats/batting_average_recalculator_spec.rb` に「混在試合」context を追加:

- 旧 PA 3 件 + 新 PA 1 件 → `call` は nil 返却、既存 `batting_average` の値を改変しない
- 新 PA を全削除して旧 PA だけ残った状態で `cleanup_orphan: true` で呼ばれても `BattingAverage` を destroy しない

既存の「新仕様試合」「旧仕様試合」「孤立レコード削除」「user_id 引数」 context はそのまま動作確認済み。

## 自動テスト

```
docker compose exec back bundle exec rspec spec/services/stats/batting_average_recalculator_spec.rb
=> 10 examples, 0 failures

docker compose exec back bundle exec rspec spec/requests/api/v2/plate_appearances_spec.rb
=> 17 examples, 0 failures

docker compose exec back bundle exec rubocop app/services/stats/batting_average_recalculator.rb spec/services/stats/batting_average_recalculator_spec.rb
=> 2 files inspected, no offenses detected
```

## 手動シナリオ（開発機）

`feature/dev-data-production-equivalent`（既マージ済み）で再投入した本番相当 dev データを使用:

1. 旧仕様試合（`is_new_format=false` の PA のみ + `batting_averages.runs_batted_in > 0`）を SQL で 1 試合選ぶ
2. その試合の `runs_batted_in` / `run` / `stealing_base` / `caught_stealing` を控える
3. mobile (release ブランチ) の試合詳細から打席カードをタップ → 編集 → 保存
4. `batting_averages` の値が **変わっていない** ことを確認

```sql
SELECT runs_batted_in, run, stealing_base, caught_stealing
FROM batting_averages WHERE game_result_id = <試合ID>;
```

完全新仕様試合（新規記録した試合）の編集・削除では従来通り再集計が走ることも確認。

## 後続作業（本 PR スコープ外）

- mobile PR #113（試合詳細・打席編集・削除UI）は本 PR デプロイ後に本番リリース可能になる
- A-1 分布図の旧データ欠落注記（別 Issue）
- 編集 UI で `hit_direction_id` → グラウンドキャンバス座標逆引きでマーカー初期化（別 Issue）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
