### PR TITLE
Add: stats 打撃 - 主要スタッツ + 得点圏打率の API（Sub #366 back）

### DIFF
--- a/app/controllers/api/v2/stats_controller.rb
+++ b/app/controllers/api/v2/stats_controller.rb
@@ -69,6 +69,28 @@ module Api
         render json: result
       end
 
+      def headline_stats
+        result = Stats::HeadlineStatsAggregator.new(
+          user_id: target_user_id,
+          year: params[:year],
+          match_type: convert_match_type(params[:match_type]),
+          season_id: params[:season_id],
+          tournament_id: params[:tournament_id]
+        ).call
+        render json: result
+      end
+
+      def runners_situation
+        result = Stats::RunnersSituationAggregator.new(
+          user_id: target_user_id,
+          year: params[:year],
+          match_type: convert_match_type(params[:match_type]),
+          season_id: params[:season_id],
+          tournament_id: params[:tournament_id]
+        ).call
+        render json: result
+      end
+
       private
 
       # 他ユーザーの成績も参照可能（公開プロフィール設計）

--- a/app/services/stats/headline_stats_aggregator.rb
+++ b/app/services/stats/headline_stats_aggregator.rb
@@ -44,8 +44,10 @@ module Stats
 
     # 8 カラムの SUM を 1 クエリで取得する。scope.sum を都度呼ぶと SELECT が
     # SUM 1 個ずつ 8 本走るため、pick + SUM で 1 本にまとめる。
+    # batting_averages の各カラムには NOT NULL 制約が無いため、SUM(NULL) で対象行が
+    # 除外されないよう COALESCE で NULL を 0 として扱う（SLG 等の過小計上を防ぐ）。
     def aggregate_stats
-      row = filtered_scope.pick(*SUM_COLUMNS.map { |col| Arel.sql("SUM(#{col})") })
+      row = filtered_scope.pick(*SUM_COLUMNS.map { |col| Arel.sql("SUM(COALESCE(#{col}, 0))") })
       values = Array.wrap(row).map(&:to_i)
       SUM_COLUMNS.zip(values).to_h
     end

--- a/app/services/stats/headline_stats_aggregator.rb
+++ b/app/services/stats/headline_stats_aggregator.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Stats
+  # 打撃成績の主要スタッツ（NPB 標準指標）を返す Aggregator。
+  #
+  # batting_averages テーブルを試合単位で SUM して集計し、サーバー側で
+  # OBP / SLG / OPS を計算して返す。クライアント側で同じ計算を別途持つと
+  # 端数処理がズレるリスクがあるため、計算ロジックはサーバーに集約する。
+  #
+  # フィルタは HitDirectionAggregator と同じ 5 項目（year / match_type /
+  # season_id / tournament_id）を踏襲する。
+  class HeadlineStatsAggregator
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+      @user_id = user_id
+      @year = year
+      @match_type = match_type
+      @season_id = season_id
+      @tournament_id = tournament_id
+    end
+
+    # @return [Hash] 7 指標 + at_bats（母数）。値はすべて 0 始まりで、母数 0 でも nil を返さない
+    def call
+      stats = aggregate_stats
+      at_bats = stats[:at_bats]
+      obp_denominator = at_bats + stats[:base_on_balls] + stats[:hit_by_pitch] + stats[:sacrifice_fly]
+      obp = safe_divide(stats[:hit] + stats[:base_on_balls] + stats[:hit_by_pitch], obp_denominator)
+      slg = safe_divide(stats[:total_bases], at_bats)
+
+      {
+        batting_average: safe_divide(stats[:hit], at_bats),
+        hit: stats[:hit],
+        home_run: stats[:home_run],
+        runs_batted_in: stats[:runs_batted_in],
+        on_base_percentage: obp,
+        slugging_percentage: slg,
+        ops: round3(obp + slg),
+        at_bats:
+      }
+    end
+
+    private
+
+    def aggregate_stats
+      scope = filtered_scope
+      {
+        at_bats: scope.sum(:at_bats),
+        hit: scope.sum(:hit),
+        home_run: scope.sum(:home_run),
+        runs_batted_in: scope.sum(:runs_batted_in),
+        base_on_balls: scope.sum(:base_on_balls),
+        hit_by_pitch: scope.sum(:hit_by_pitch),
+        sacrifice_fly: scope.sum(:sacrifice_fly),
+        total_bases: scope.sum(:total_bases)
+      }
+    end
+
+    def filtered_scope
+      scope = BattingAverage.joins(game_result: :match_result).where(user_id: @user_id)
+      scope = apply_year_filter(scope)
+      scope = apply_match_type_filter(scope)
+      scope = apply_season_filter(scope)
+      apply_tournament_filter(scope)
+    end
+
+    def apply_year_filter(scope)
+      return scope if @year.blank? || @year.to_s == '通算'
+
+      yr = @year.to_i
+      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
+                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+    end
+
+    def apply_match_type_filter(scope)
+      return scope if @match_type.blank? || @match_type == '全て'
+
+      scope.where(match_results: { match_type: @match_type })
+    end
+
+    def apply_season_filter(scope)
+      return scope if @season_id.blank?
+
+      scope.where(game_results: { season_id: @season_id })
+    end
+
+    def apply_tournament_filter(scope)
+      return scope if @tournament_id.blank?
+
+      scope.where(match_results: { tournament_id: @tournament_id })
+    end
+
+    # 0 除算を 0.0 に丸めて、率指標は小数 3 桁に揃える。
+    def safe_divide(numerator, denominator)
+      return 0.0 if denominator.to_i.zero?
+
+      round3(numerator.to_f / denominator)
+    end
+
+    def round3(value)
+      value.round(3)
+    end
+  end
+end

--- a/app/services/stats/headline_stats_aggregator.rb
+++ b/app/services/stats/headline_stats_aggregator.rb
@@ -40,18 +40,14 @@ module Stats
 
     private
 
+    SUM_COLUMNS = %i[at_bats hit home_run runs_batted_in base_on_balls hit_by_pitch sacrifice_fly total_bases].freeze
+
+    # 8 カラムの SUM を 1 クエリで取得する。scope.sum を都度呼ぶと SELECT が
+    # SUM 1 個ずつ 8 本走るため、pick + SUM で 1 本にまとめる。
     def aggregate_stats
-      scope = filtered_scope
-      {
-        at_bats: scope.sum(:at_bats),
-        hit: scope.sum(:hit),
-        home_run: scope.sum(:home_run),
-        runs_batted_in: scope.sum(:runs_batted_in),
-        base_on_balls: scope.sum(:base_on_balls),
-        hit_by_pitch: scope.sum(:hit_by_pitch),
-        sacrifice_fly: scope.sum(:sacrifice_fly),
-        total_bases: scope.sum(:total_bases)
-      }
+      row = filtered_scope.pick(*SUM_COLUMNS.map { |col| Arel.sql("SUM(#{col})") })
+      values = Array.wrap(row).map(&:to_i)
+      SUM_COLUMNS.zip(values).to_h
     end
 
     def filtered_scope

--- a/app/services/stats/runners_situation_aggregator.rb
+++ b/app/services/stats/runners_situation_aggregator.rb
@@ -27,21 +27,34 @@ module Stats
 
     # @return [Hash] at_bats / hits / two_base_hit / three_base_hit / home_run / batting_average
     def call
-      scope = filtered_scope
-      at_bats = scope.joins(:plate_result).where(plate_results: { counted_in_at_bats: true }).count
-      hits = scope.where(plate_result_id: HIT_RESULT_IDS).count
-
+      counts = aggregate_counts
       {
-        batting_average: safe_divide(hits, at_bats),
-        at_bats:,
-        hits:,
-        two_base_hit: scope.where(plate_result_id: DOUBLE_HIT_ID).count,
-        three_base_hit: scope.where(plate_result_id: TRIPLE_HIT_ID).count,
-        home_run: scope.where(plate_result_id: HOME_RUN_ID).count
+        batting_average: safe_divide(counts[:hits], counts[:at_bats]),
+        at_bats: counts[:at_bats],
+        hits: counts[:hits],
+        two_base_hit: counts[:two_base_hit],
+        three_base_hit: counts[:three_base_hit],
+        home_run: counts[:home_run]
       }
     end
 
     private
+
+    # COUNT(*) FILTER (WHERE ...) で 5 つのカウントを 1 クエリにまとめる。
+    # join した plate_results.counted_in_at_bats と plate_appearances.plate_result_id の
+    # 両方を FILTER 条件で使う。
+    def aggregate_counts
+      sql = <<~SQL.squish
+        COUNT(*) FILTER (WHERE plate_results.counted_in_at_bats = TRUE) AS at_bats,
+        COUNT(*) FILTER (WHERE plate_appearances.plate_result_id IN (#{HIT_RESULT_IDS.join(',')})) AS hits,
+        COUNT(*) FILTER (WHERE plate_appearances.plate_result_id = #{DOUBLE_HIT_ID}) AS two_base_hit,
+        COUNT(*) FILTER (WHERE plate_appearances.plate_result_id = #{TRIPLE_HIT_ID}) AS three_base_hit,
+        COUNT(*) FILTER (WHERE plate_appearances.plate_result_id = #{HOME_RUN_ID}) AS home_run
+      SQL
+      row = filtered_scope.joins(:plate_result).pick(Arel.sql(sql))
+      values = Array.wrap(row).map(&:to_i)
+      %i[at_bats hits two_base_hit three_base_hit home_run].zip(values).to_h
+    end
 
     def filtered_scope
       scope = PlateAppearance.joins(game_result: :match_result)

--- a/app/services/stats/runners_situation_aggregator.rb
+++ b/app/services/stats/runners_situation_aggregator.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Stats
+  # 得点圏（二塁・三塁・一二塁・一三塁・二三塁・満塁）打席の集計サービス。
+  #
+  # plate_appearances.runners_state の enum が 2..7（second / third / first_second /
+  # first_third / second_third / bases_loaded）の打席に絞って at_bats / hits /
+  # 長打 / 打率 を返す。
+  #
+  # 新仕様カラム (runners_state) が必須のため、旧 PA は集計対象外。
+  # 母数 0 のときも nil ではなく 0 / 0.0 を返す（クライアント側で「対象データなし」UI に分岐）。
+  class RunnersSituationAggregator
+    HIT_RESULT_IDS = ::Stats::BattingAverageRecalculator::HIT_RESULT_IDS
+    DOUBLE_HIT_ID = ::Stats::BattingAverageRecalculator::DOUBLE_HIT_ID
+    TRIPLE_HIT_ID = ::Stats::BattingAverageRecalculator::TRIPLE_HIT_ID
+    HOME_RUN_ID = ::Stats::BattingAverageRecalculator::HOME_RUN_ID
+
+    SCORING_POSITION_STATES = %w[second third first_second first_third second_third bases_loaded].freeze
+
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+      @user_id = user_id
+      @year = year
+      @match_type = match_type
+      @season_id = season_id
+      @tournament_id = tournament_id
+    end
+
+    # @return [Hash] at_bats / hits / two_base_hit / three_base_hit / home_run / batting_average
+    def call
+      scope = filtered_scope
+      at_bats = scope.joins(:plate_result).where(plate_results: { counted_in_at_bats: true }).count
+      hits = scope.where(plate_result_id: HIT_RESULT_IDS).count
+
+      {
+        batting_average: safe_divide(hits, at_bats),
+        at_bats:,
+        hits:,
+        two_base_hit: scope.where(plate_result_id: DOUBLE_HIT_ID).count,
+        three_base_hit: scope.where(plate_result_id: TRIPLE_HIT_ID).count,
+        home_run: scope.where(plate_result_id: HOME_RUN_ID).count
+      }
+    end
+
+    private
+
+    def filtered_scope
+      scope = PlateAppearance.joins(game_result: :match_result)
+                             .where(user_id: @user_id, runners_state: SCORING_POSITION_STATES)
+      scope = apply_year_filter(scope)
+      scope = apply_match_type_filter(scope)
+      scope = apply_season_filter(scope)
+      apply_tournament_filter(scope)
+    end
+
+    def apply_year_filter(scope)
+      return scope if @year.blank? || @year.to_s == '通算'
+
+      yr = @year.to_i
+      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
+                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+    end
+
+    def apply_match_type_filter(scope)
+      return scope if @match_type.blank? || @match_type == '全て'
+
+      scope.where(match_results: { match_type: @match_type })
+    end
+
+    def apply_season_filter(scope)
+      return scope if @season_id.blank?
+
+      scope.where(game_results: { season_id: @season_id })
+    end
+
+    def apply_tournament_filter(scope)
+      return scope if @tournament_id.blank?
+
+      scope.where(match_results: { tournament_id: @tournament_id })
+    end
+
+    def safe_divide(numerator, denominator)
+      return 0.0 if denominator.to_i.zero?
+
+      (numerator.to_f / denominator).round(3)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -220,6 +220,8 @@ Rails.application.routes.draw do
         get :pitching, on: :member
         get :era_trend, on: :member
         get :game_summary, on: :member
+        get :headline_stats, on: :member
+        get :runners_situation, on: :member
       end
 
       resources :plate_appearances, only: %i[create update destroy] do

--- a/spec/requests/api/v2/stats_spec.rb
+++ b/spec/requests/api/v2/stats_spec.rb
@@ -132,4 +132,40 @@ RSpec.describe 'Api::V2::Stats', type: :request do
       expect(json['recent_form'].first['match_type']).to eq('regular')
     end
   end
+
+  describe 'GET /api/v2/stats/headline_stats' do
+    it 'returns 401 when not authenticated' do
+      get '/api/v2/stats/headline_stats'
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns 200 with the 7 headline indicators and at_bats' do
+      get('/api/v2/stats/headline_stats', headers:)
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json).to include(
+        'batting_average', 'hit', 'home_run', 'runs_batted_in',
+        'on_base_percentage', 'slugging_percentage', 'ops', 'at_bats'
+      )
+    end
+  end
+
+  describe 'GET /api/v2/stats/runners_situation' do
+    it 'returns 401 when not authenticated' do
+      get '/api/v2/stats/runners_situation'
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns 200 with scoring position aggregation' do
+      get('/api/v2/stats/runners_situation', headers:)
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json).to include(
+        'batting_average', 'at_bats', 'hits',
+        'two_base_hit', 'three_base_hit', 'home_run'
+      )
+    end
+  end
 end

--- a/spec/services/stats/headline_stats_aggregator_spec.rb
+++ b/spec/services/stats/headline_stats_aggregator_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Stats::HeadlineStatsAggregator, type: :service do
+  let(:user) { create(:user) }
+
+  def build_game(date: '2026-04-01', match_type: 'regular', batting_attrs: {})
+    game_result = create(:game_result, user:)
+    game_result.match_result.update!(date_and_time: Time.zone.parse(date), match_type:)
+    default_attrs = {
+      plate_appearances: 4, times_at_bat: 4, at_bats: 4,
+      hit: 1, two_base_hit: 0, three_base_hit: 0, home_run: 0,
+      total_bases: 1, runs_batted_in: 0, base_on_balls: 0,
+      hit_by_pitch: 0, sacrifice_fly: 0, sacrifice_hit: 0
+    }
+    create(:batting_average, game_result:, user:, **default_attrs.merge(batting_attrs))
+    game_result
+  end
+
+  describe '#call' do
+    context 'when no games' do
+      it 'returns zero for all stats without raising ZeroDivisionError' do
+        result = described_class.new(user_id: user.id).call
+
+        aggregate_failures do
+          expect(result[:batting_average]).to eq(0.0)
+          expect(result[:on_base_percentage]).to eq(0.0)
+          expect(result[:slugging_percentage]).to eq(0.0)
+          expect(result[:ops]).to eq(0.0)
+          expect(result[:at_bats]).to eq(0)
+          expect(result[:hit]).to eq(0)
+          expect(result[:home_run]).to eq(0)
+          expect(result[:runs_batted_in]).to eq(0)
+        end
+      end
+    end
+
+    context 'when summing multiple games' do
+      before do
+        # 1試合目: 4打数 2安打 (うち1本塁打) 2打点 1四球
+        build_game(
+          batting_attrs: {
+            at_bats: 4, hit: 2, two_base_hit: 0, three_base_hit: 0, home_run: 1,
+            total_bases: 5, runs_batted_in: 2, base_on_balls: 1
+          }
+        )
+        # 2試合目: 3打数 1安打 (二塁打) 1打点 0四球 1犠飛
+        build_game(
+          batting_attrs: {
+            at_bats: 3, hit: 1, two_base_hit: 1, three_base_hit: 0, home_run: 0,
+            total_bases: 2, runs_batted_in: 1, base_on_balls: 0, sacrifice_fly: 1
+          }
+        )
+      end
+
+      it 'returns aggregated counts (sum across games)' do
+        result = described_class.new(user_id: user.id).call
+
+        aggregate_failures do
+          expect(result[:at_bats]).to eq(7)
+          expect(result[:hit]).to eq(3)
+          expect(result[:home_run]).to eq(1)
+          expect(result[:runs_batted_in]).to eq(3)
+        end
+      end
+
+      it 'computes batting_average, OBP, SLG, OPS in NPB formula' do
+        result = described_class.new(user_id: user.id).call
+
+        # 打率 = 3/7 = 0.4285...
+        expect(result[:batting_average]).to eq((3.0 / 7).round(3))
+        # OBP = (3 + 1 + 0) / (7 + 1 + 0 + 1) = 4/9
+        expect(result[:on_base_percentage]).to eq((4.0 / 9).round(3))
+        # SLG = (5+2) / 7 = 1.0
+        expect(result[:slugging_percentage]).to eq((7.0 / 7).round(3))
+        # OPS = OBP + SLG
+        expect(result[:ops]).to eq((result[:on_base_percentage] + result[:slugging_percentage]).round(3))
+      end
+    end
+
+    context 'with match_type filter' do
+      before do
+        build_game(date: '2026-04-01', match_type: 'regular',
+                   batting_attrs: { at_bats: 4, hit: 2, total_bases: 2 })
+        build_game(date: '2026-04-02', match_type: 'open',
+                   batting_attrs: { at_bats: 3, hit: 0, total_bases: 0 })
+      end
+
+      it 'only counts batting_averages whose match_results.match_type matches' do
+        result = described_class.new(user_id: user.id, match_type: 'regular').call
+
+        aggregate_failures do
+          expect(result[:at_bats]).to eq(4)
+          expect(result[:hit]).to eq(2)
+        end
+      end
+    end
+
+    context 'with year filter' do
+      before do
+        build_game(date: '2025-09-30', batting_attrs: { at_bats: 4, hit: 1, total_bases: 1 })
+        build_game(date: '2026-04-01', batting_attrs: { at_bats: 5, hit: 2, total_bases: 2 })
+      end
+
+      it 'only counts batting_averages within the year' do
+        result = described_class.new(user_id: user.id, year: 2026).call
+
+        expect(result[:at_bats]).to eq(5)
+        expect(result[:hit]).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/services/stats/runners_situation_aggregator_spec.rb
+++ b/spec/services/stats/runners_situation_aggregator_spec.rb
@@ -71,5 +71,75 @@ RSpec.describe Stats::RunnersSituationAggregator, type: :service do
         end
       end
     end
+
+    context 'with year filter' do
+      before do
+        old_game = create(:game_result, user:)
+        old_game.match_result.update!(date_and_time: Time.zone.parse('2025-09-30'))
+        create(:plate_appearance, game_result: old_game, user:, batter_box_number: 1,
+                                  plate_result_id: 7, runners_state: :second, is_new_format: true)
+
+        new_game = create(:game_result, user:)
+        new_game.match_result.update!(date_and_time: Time.zone.parse('2026-04-01'))
+        create(:plate_appearance, game_result: new_game, user:, batter_box_number: 1,
+                                  plate_result_id: 8, runners_state: :third, is_new_format: true)
+      end
+
+      it 'only counts plate_appearances within the year' do
+        result = described_class.new(user_id: user.id, year: 2026).call
+
+        aggregate_failures do
+          expect(result[:at_bats]).to eq(1)
+          expect(result[:hits]).to eq(1)
+          expect(result[:two_base_hit]).to eq(1)
+        end
+      end
+    end
+
+    context 'with match_type filter' do
+      before do
+        regular_game = create(:game_result, user:)
+        regular_game.match_result.update!(match_type: 'regular')
+        create(:plate_appearance, game_result: regular_game, user:, batter_box_number: 1,
+                                  plate_result_id: 7, runners_state: :second, is_new_format: true)
+
+        open_game = create(:game_result, user:)
+        open_game.match_result.update!(match_type: 'open')
+        create(:plate_appearance, game_result: open_game, user:, batter_box_number: 1,
+                                  plate_result_id: 13, runners_state: :third, is_new_format: true)
+      end
+
+      it 'only counts plate_appearances whose match_results.match_type matches' do
+        result = described_class.new(user_id: user.id, match_type: 'regular').call
+
+        aggregate_failures do
+          expect(result[:at_bats]).to eq(1)
+          expect(result[:hits]).to eq(1)
+        end
+      end
+    end
+
+    context 'with season filter' do
+      let(:season) { create(:season, user:) }
+
+      before do
+        in_season_game = create(:game_result, user:, season:)
+        create(:plate_appearance, game_result: in_season_game, user:, batter_box_number: 1,
+                                  plate_result_id: 7, runners_state: :second, is_new_format: true)
+
+        no_season_game = create(:game_result, user:)
+        create(:plate_appearance, game_result: no_season_game, user:, batter_box_number: 1,
+                                  plate_result_id: 7, runners_state: :second, is_new_format: true)
+      end
+
+      it 'only counts plate_appearances within the season' do
+        result = described_class.new(user_id: user.id, season_id: season.id).call
+
+        aggregate_failures do
+          expect(result[:at_bats]).to eq(1)
+          expect(result[:hits]).to eq(1)
+        end
+      end
+    end
   end
 end

--- a/spec/services/stats/runners_situation_aggregator_spec.rb
+++ b/spec/services/stats/runners_situation_aggregator_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Stats::RunnersSituationAggregator, type: :service do
+  let(:user) { create(:user) }
+  let(:game_result) { create(:game_result, user:) }
+
+  def create_pa(plate_result_id:, runners_state:, batter_box_number: nil)
+    attrs = {
+      game_result:, user:, plate_result_id:, runners_state:, is_new_format: true
+    }
+    attrs[:batter_box_number] = batter_box_number if batter_box_number
+    create(:plate_appearance, **attrs)
+  end
+
+  describe '#call' do
+    context 'when no plate appearances' do
+      it 'returns zero母数 without raising' do
+        result = described_class.new(user_id: user.id).call
+
+        aggregate_failures do
+          expect(result[:at_bats]).to eq(0)
+          expect(result[:hits]).to eq(0)
+          expect(result[:batting_average]).to eq(0.0)
+          expect(result[:home_run]).to eq(0)
+        end
+      end
+    end
+
+    context 'with scoring position plate appearances' do
+      before do
+        # 得点圏（second, third, first_second, first_third, second_third, bases_loaded）
+        create_pa(plate_result_id: 7, runners_state: :second)       # ヒット
+        create_pa(plate_result_id: 8, runners_state: :third)        # 二塁打
+        create_pa(plate_result_id: 10, runners_state: :bases_loaded) # 本塁打
+        create_pa(plate_result_id: 13, runners_state: :first_second) # 三振（凡退）
+        # 得点圏外
+        create_pa(plate_result_id: 7, runners_state: :no_runner)    # ヒット（除外）
+        create_pa(plate_result_id: 7, runners_state: :first)        # ヒット（除外）
+      end
+
+      it 'only counts plate_appearances whose runners_state is 2..7' do
+        result = described_class.new(user_id: user.id).call
+
+        aggregate_failures do
+          expect(result[:at_bats]).to eq(4)
+          expect(result[:hits]).to eq(3)
+          expect(result[:two_base_hit]).to eq(1)
+          expect(result[:three_base_hit]).to eq(0)
+          expect(result[:home_run]).to eq(1)
+          expect(result[:batting_average]).to eq((3.0 / 4).round(3))
+        end
+      end
+    end
+
+    context 'when only old-format PA exist (runners_state nil)' do
+      before do
+        # 旧仕様：runners_state が NULL → 対象外
+        create(:plate_appearance, game_result:, user:, plate_result_id: 7,
+                                  is_new_format: false, runners_state: nil)
+      end
+
+      it 'returns母数 0 because the filter excludes NULL runners_state' do
+        result = described_class.new(user_id: user.id).call
+
+        aggregate_failures do
+          expect(result[:at_bats]).to eq(0)
+          expect(result[:hits]).to eq(0)
+          expect(result[:batting_average]).to eq(0.0)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Sub Issue #366 (Issue #336 の 1/5) の back 側実装。stats タブ打撃セクションの「主要スタッツ」と「得点圏打率カード」用の API を追加する。

関連: ippei-shimizu/buzzbase#366 / 親 ippei-shimizu/buzzbase#336

## 変更内容

### 新規サービス

| サービス | 内容 |
|---|---|
| `Stats::HeadlineStatsAggregator` | batting_averages を SUM して打率 / 安打 / 本塁打 / 打点 / 出塁率 / 長打率 / OPS をサーバー計算 |
| `Stats::RunnersSituationAggregator` | plate_appearances を runners_state IN (2..7) でフィルタし、at_bats / hits / 長打 / 打率 を返す |

OPS = OBP + SLG はクライアントで持つと端数処理がズレるのでサーバーに集約。

### Controller / Routes

- `Api::V2::StatsController` に `headline_stats` / `runners_situation` の 2 アクション追加
- `config/routes.rb` の `resource :stats` member にエンドポイント追加
- フィルタは既存の `convert_match_type` 等を流用（hit_directions と同パターン）

### Spec

- 各 Aggregator の service spec を追加（OPS=OBP+SLG 検証、母数0、フィルタ動作、旧PA除外）
- `spec/requests/api/v2/stats_spec.rb` に 2 endpoint の 401 / 200 / レスポンスキーチェック追加

## 既存データ保全

- HeadlineStats: 既存 batting_averages 集計のため旧データも完全反映
- RunnersSituation: runners_state は新仕様カラムなので旧 PA は対象外。母数 0 のときも 0/0.0 を返し mobile 側で「対象データなし」UI に分岐できるようにする

batting_average テーブルの再集計は走らない読み取り専用 API。既存集計値への影響なし。

## 自動テスト

```
docker compose exec back bundle exec rspec spec/services/stats/headline_stats_aggregator_spec.rb spec/services/stats/runners_situation_aggregator_spec.rb spec/requests/api/v2/stats_spec.rb
=> 25 examples, 0 failures

docker compose exec back bundle exec rubocop app/services/stats/headline_stats_aggregator.rb app/services/stats/runners_situation_aggregator.rb app/controllers/api/v2/stats_controller.rb spec/services/stats/headline_stats_aggregator_spec.rb spec/services/stats/runners_situation_aggregator_spec.rb
=> 5 files inspected, no offenses detected
```

## 後続作業

本 PR マージ後、Sub Issue #366 の mobile 側実装（HeadlineStatsCard / RunnersSituationCard）に進む。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
