### PR TITLE
Feature: stats 打撃 - 打球分析 API（A-1 / A-2 / D-1）

### DIFF
--- a/app/controllers/api/v2/stats_controller.rb
+++ b/app/controllers/api/v2/stats_controller.rb
@@ -91,6 +91,28 @@ module Api
         render json: result
       end
 
+      def hit_locations
+        result = Stats::HitLocationAggregator.new(
+          user_id: target_user_id,
+          year: params[:year],
+          match_type: convert_match_type(params[:match_type]),
+          season_id: params[:season_id],
+          tournament_id: params[:tournament_id]
+        ).call
+        render json: result
+      end
+
+      def out_type_breakdown
+        result = Stats::OutTypeBreakdownService.new(
+          user_id: target_user_id,
+          year: params[:year],
+          match_type: convert_match_type(params[:match_type]),
+          season_id: params[:season_id],
+          tournament_id: params[:tournament_id]
+        ).call
+        render json: result
+      end
+
       private
 
       # 他ユーザーの成績も参照可能（公開プロフィール設計）

--- a/app/services/stats/hit_direction_aggregator.rb
+++ b/app/services/stats/hit_direction_aggregator.rb
@@ -39,6 +39,17 @@ module Stats
       @tournament_id = tournament_id
     end
 
+    # 方向別の打球集計を返す。
+    #
+    # @return [Hash{Symbol=>Array<Hash>}] :directions と :home_runs を持つハッシュ。
+    #   `directions` の各要素はキー `:count` と `:hits` の意味が異なる点に注意：
+    #   - `count`: 本塁打を **除いた** 打球数。スキャッターチャート（バブル）の
+    #     方向別件数として表示するために、本塁打を別グループ (`home_runs`) に
+    #     寄せて二重表示しない設計になっている。
+    #   - `hits`: 本塁打を **含む** 安打数（単打・二塁打・三塁打・本塁打の合計）。
+    #     方向別の打率計算 (hits / at_bats) で使うため。
+    #   そのため、ある方向が本塁打のみのときは `count: 0, hits: 1, home_run: 1`
+    #   になり得る。フロントで `count < hits` を検知しても異常ではない。
     def call
       dir_categories = aggregate_direction_categories
       dir_stats = aggregate_direction_stats

--- a/app/services/stats/hit_direction_aggregator.rb
+++ b/app/services/stats/hit_direction_aggregator.rb
@@ -150,13 +150,17 @@ module Stats
       end
     end
 
+    # call 内で aggregate_direction_categories / aggregate_direction_stats から
+    # 2 回参照されるため、同一インスタンス内では scope 構築を再利用する。
     def filtered_scope
-      scope = PlateAppearance.joins(game_result: :match_result)
-                             .where(user_id: @user_id)
-      scope = apply_year_filter(scope)
-      scope = apply_match_type_filter(scope)
-      scope = apply_season_filter(scope)
-      apply_tournament_filter(scope)
+      @filtered_scope ||= begin
+        scope = PlateAppearance.joins(game_result: :match_result)
+                               .where(user_id: @user_id)
+        scope = apply_year_filter(scope)
+        scope = apply_match_type_filter(scope)
+        scope = apply_season_filter(scope)
+        apply_tournament_filter(scope)
+      end
     end
 
     def apply_year_filter(scope)

--- a/app/services/stats/hit_direction_aggregator.rb
+++ b/app/services/stats/hit_direction_aggregator.rb
@@ -25,7 +25,8 @@ module Stats
     }.freeze
 
     HR_RESULT_ID = 10
-    HIT_RESULT_IDS = [7, 8, 9, 10].freeze
+    # 値の食い違いを避けるため BattingAverageRecalculator の HIT_RESULT_IDS を SSoT として参照する。
+    HIT_RESULT_IDS = ::Stats::BattingAverageRecalculator::HIT_RESULT_IDS
     TWO_BASE_RESULT_ID = 8
     THREE_BASE_RESULT_ID = 9
     TOTAL_BASES_PER_RESULT = { 7 => 1, 8 => 2, 9 => 3, 10 => 4 }.freeze

--- a/app/services/stats/hit_direction_aggregator.rb
+++ b/app/services/stats/hit_direction_aggregator.rb
@@ -25,6 +25,10 @@ module Stats
     }.freeze
 
     HR_RESULT_ID = 10
+    HIT_RESULT_IDS = [7, 8, 9, 10].freeze
+    TWO_BASE_RESULT_ID = 8
+    THREE_BASE_RESULT_ID = 9
+    TOTAL_BASES_PER_RESULT = { 7 => 1, 8 => 2, 9 => 3, 10 => 4 }.freeze
 
     def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
       @user_id = user_id
@@ -36,8 +40,12 @@ module Stats
 
     def call
       dir_categories = aggregate_direction_categories
+      dir_stats = aggregate_direction_stats
 
-      { directions: build_directions(dir_categories), home_runs: build_home_runs(dir_categories) }
+      {
+        directions: build_directions(dir_categories, dir_stats),
+        home_runs: build_home_runs(dir_categories)
+      }
     end
 
     private
@@ -59,6 +67,34 @@ module Stats
       dir_categories
     end
 
+    # 方向別の打数 / 安打 / 長打打数を集計する。
+    # plate_results.counted_in_at_bats を SSoT として打数を導出するため joins(:plate_result) で結合する。
+    def aggregate_direction_stats
+      base = filtered_scope
+      direction_sql = build_direction_sql
+      cross = base
+              .joins(:plate_result)
+              .where("#{direction_sql} IS NOT NULL AND #{direction_sql} > 0")
+              .group(Arel.sql(direction_sql), :plate_result_id, 'plate_results.counted_in_at_bats')
+              .count
+
+      dir_stats = Hash.new do |h, k|
+        h[k] = { at_bats: 0, hits: 0, two_base_hit: 0, three_base_hit: 0, home_run: 0, total_bases: 0 }
+      end
+      cross.each do |(dir_id, result_id, counted), cnt| # rubocop:disable Style/HashEachMethods
+        bucket = dir_stats[dir_id]
+        bucket[:at_bats] += cnt if counted
+        next unless HIT_RESULT_IDS.include?(result_id)
+
+        bucket[:hits] += cnt
+        bucket[:total_bases] += cnt * TOTAL_BASES_PER_RESULT.fetch(result_id, 0)
+        bucket[:two_base_hit] += cnt if result_id == TWO_BASE_RESULT_ID
+        bucket[:three_base_hit] += cnt if result_id == THREE_BASE_RESULT_ID
+        bucket[:home_run] += cnt if result_id == HR_RESULT_ID
+      end
+      dir_stats
+    end
+
     def build_direction_sql
       <<~SQL.squish
         COALESCE(
@@ -71,13 +107,25 @@ module Stats
       SQL
     end
 
-    def build_directions(dir_categories)
+    def build_directions(dir_categories, dir_stats)
       DIRECTION_LABELS.map do |id, label|
         cats = dir_categories[id]
         non_hr = cats.except('本塁打')
         total = non_hr.values.sum
         top_category = non_hr.max_by { |_, v| v }&.first || 'その他'
-        { id:, label:, count: total, top_category: }
+        stats = dir_stats[id]
+        {
+          id:,
+          label:,
+          count: total,
+          top_category:,
+          at_bats: stats[:at_bats],
+          hits: stats[:hits],
+          two_base_hit: stats[:two_base_hit],
+          three_base_hit: stats[:three_base_hit],
+          home_run: stats[:home_run],
+          total_bases: stats[:total_bases]
+        }
       end
     end
 

--- a/app/services/stats/hit_location_aggregator.rb
+++ b/app/services/stats/hit_location_aggregator.rb
@@ -4,7 +4,9 @@ module Stats
   class HitLocationAggregator
     # 値の食い違いを避けるため BattingAverageRecalculator の HIT_RESULT_IDS を SSoT として参照する。
     HIT_RESULT_IDS = ::Stats::BattingAverageRecalculator::HIT_RESULT_IDS
-    OUT_RESULT_IDS = [1, 2, 3, 4, 19].freeze
+    # PlateAppearanceBreakdownService::CATEGORIES と分類を揃える。
+    # id:19 (併殺打) はそちらでも 'その他' 扱いなので、ここでも 'out' ではなく 'other' に落とす。
+    OUT_RESULT_IDS = [1, 2, 3, 4].freeze
 
     # @param user_id [Integer] 対象ユーザー ID
     # @param year [Integer, String, nil] 集計対象の年（nil または '通算' で全期間）

--- a/app/services/stats/hit_location_aggregator.rb
+++ b/app/services/stats/hit_location_aggregator.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Stats
+  class HitLocationAggregator
+    HIT_RESULT_IDS = [7, 8, 9, 10].freeze
+    OUT_RESULT_IDS = [1, 2, 3, 4, 19].freeze
+
+    # @param user_id [Integer] 対象ユーザー ID
+    # @param year [Integer, String, nil] 集計対象の年（nil または '通算' で全期間）
+    # @param match_type [String, nil] 試合種別フィルタ
+    # @param season_id [Integer, String, nil] シーズン ID フィルタ
+    # @param tournament_id [Integer, String, nil] 大会 ID フィルタ
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+      @user_id = user_id
+      @year = year
+      @match_type = match_type
+      @season_id = season_id
+      @tournament_id = tournament_id
+    end
+
+    # @return [Hash] points: 各打席の (x, y, category, plate_result_id) 配列
+    def call
+      rows = filtered_scope
+             .where('hit_location_x IS NOT NULL AND hit_location_y IS NOT NULL')
+             .pluck(:hit_location_x, :hit_location_y, :plate_result_id)
+
+      points = rows.map do |x, y, result_id|
+        {
+          x: x.to_f,
+          y: y.to_f,
+          category: categorize(result_id),
+          plate_result_id: result_id
+        }
+      end
+
+      { points: }
+    end
+
+    private
+
+    def categorize(result_id)
+      return 'hit' if HIT_RESULT_IDS.include?(result_id)
+      return 'out' if OUT_RESULT_IDS.include?(result_id)
+
+      'other'
+    end
+
+    def filtered_scope
+      scope = PlateAppearance.joins(game_result: :match_result)
+                             .where(user_id: @user_id)
+      scope = apply_year_filter(scope)
+      scope = apply_match_type_filter(scope)
+      scope = apply_season_filter(scope)
+      apply_tournament_filter(scope)
+    end
+
+    def apply_year_filter(scope)
+      return scope if @year.blank? || @year.to_s == '通算'
+
+      yr = @year.to_i
+      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
+                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+    end
+
+    def apply_match_type_filter(scope)
+      return scope if @match_type.blank? || @match_type == '全て'
+
+      scope.where(match_results: { match_type: @match_type })
+    end
+
+    def apply_season_filter(scope)
+      return scope if @season_id.blank?
+
+      scope.where(game_results: { season_id: @season_id })
+    end
+
+    def apply_tournament_filter(scope)
+      return scope if @tournament_id.blank?
+
+      scope.where(match_results: { tournament_id: @tournament_id })
+    end
+  end
+end

--- a/app/services/stats/hit_location_aggregator.rb
+++ b/app/services/stats/hit_location_aggregator.rb
@@ -2,7 +2,8 @@
 
 module Stats
   class HitLocationAggregator
-    HIT_RESULT_IDS = [7, 8, 9, 10].freeze
+    # 値の食い違いを避けるため BattingAverageRecalculator の HIT_RESULT_IDS を SSoT として参照する。
+    HIT_RESULT_IDS = ::Stats::BattingAverageRecalculator::HIT_RESULT_IDS
     OUT_RESULT_IDS = [1, 2, 3, 4, 19].freeze
 
     # @param user_id [Integer] 対象ユーザー ID

--- a/app/services/stats/out_type_breakdown_service.rb
+++ b/app/services/stats/out_type_breakdown_service.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Stats
+  class OutTypeBreakdownService
+    # PlateAppearance.out_types の enum 値順を SSoT として保つために、enum 定義を参照する。
+    CATEGORY_LABELS = {
+      'ground_ball' => 'ゴロ',
+      'fly_ball' => 'フライ',
+      'line_drive' => 'ライナー',
+      'double_play' => '併殺打',
+      'foul_fly' => 'ファールフライ'
+    }.freeze
+
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+      @user_id = user_id
+      @year = year
+      @match_type = match_type
+      @season_id = season_id
+      @tournament_id = tournament_id
+    end
+
+    # @return [Hash] breakdown: [{ category, count, percentage }], total: 集計対象の総数
+    def call
+      counts_by_enum = filtered_scope.where.not(out_type: nil).group(:out_type).count
+      total = counts_by_enum.values.sum
+
+      breakdown = CATEGORY_LABELS.map do |enum_key, label|
+        count = counts_by_enum.fetch(enum_key, 0)
+        percentage = total.zero? ? 0.0 : (count.to_f / total * 100).round(1)
+        { category: label, count:, percentage: }
+      end
+
+      { breakdown:, total: }
+    end
+
+    private
+
+    def filtered_scope
+      scope = PlateAppearance.joins(game_result: :match_result)
+                             .where(user_id: @user_id)
+      scope = apply_year_filter(scope)
+      scope = apply_match_type_filter(scope)
+      scope = apply_season_filter(scope)
+      apply_tournament_filter(scope)
+    end
+
+    def apply_year_filter(scope)
+      return scope if @year.blank? || @year.to_s == '通算'
+
+      yr = @year.to_i
+      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
+                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+    end
+
+    def apply_match_type_filter(scope)
+      return scope if @match_type.blank? || @match_type == '全て'
+
+      scope.where(match_results: { match_type: @match_type })
+    end
+
+    def apply_season_filter(scope)
+      return scope if @season_id.blank?
+
+      scope.where(game_results: { season_id: @season_id })
+    end
+
+    def apply_tournament_filter(scope)
+      return scope if @tournament_id.blank?
+
+      scope.where(match_results: { tournament_id: @tournament_id })
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -222,6 +222,8 @@ Rails.application.routes.draw do
         get :game_summary, on: :member
         get :headline_stats, on: :member
         get :runners_situation, on: :member
+        get :hit_locations, on: :member
+        get :out_type_breakdown, on: :member
       end
 
       resources :plate_appearances, only: %i[create update destroy] do

--- a/spec/requests/api/v2/stats_spec.rb
+++ b/spec/requests/api/v2/stats_spec.rb
@@ -168,4 +168,50 @@ RSpec.describe 'Api::V2::Stats', type: :request do
       )
     end
   end
+
+  describe 'GET /api/v2/stats/hit_locations' do
+    it 'returns 401 when not authenticated' do
+      get '/api/v2/stats/hit_locations'
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns 200 with points array' do
+      get('/api/v2/stats/hit_locations', headers:)
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json).to include('points')
+      expect(json['points']).to be_an(Array)
+    end
+  end
+
+  describe 'GET /api/v2/stats/out_type_breakdown' do
+    it 'returns 401 when not authenticated' do
+      get '/api/v2/stats/out_type_breakdown'
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns 200 with breakdown of out_type enum categories' do
+      get('/api/v2/stats/out_type_breakdown', headers:)
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json).to include('breakdown', 'total')
+      expect(json['breakdown']).to be_an(Array)
+      expect(json['breakdown'].first).to include('category', 'count', 'percentage')
+    end
+  end
+
+  describe 'GET /api/v2/stats/hit_directions (拡張済みフィールド)' do
+    it 'returns directions with at_bats / hits / total_bases / two_base_hit / three_base_hit / home_run' do
+      get('/api/v2/stats/hit_directions', headers:)
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json['directions'].first).to include(
+        'id', 'label', 'count', 'top_category',
+        'at_bats', 'hits', 'two_base_hit', 'three_base_hit', 'home_run', 'total_bases'
+      )
+    end
+  end
 end

--- a/spec/services/stats/hit_direction_aggregator_spec.rb
+++ b/spec/services/stats/hit_direction_aggregator_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Stats::HitDirectionAggregator, type: :service do
+  let(:user) { create(:user) }
+  let(:game_result) { create(:game_result, user:) }
+
+  def create_pa(hit_direction_id:, plate_result_id:, batter_box_number: nil)
+    attrs = { game_result:, user:, hit_direction_id:, plate_result_id:, is_new_format: true }
+    attrs[:batter_box_number] = batter_box_number if batter_box_number
+    create(:plate_appearance, **attrs)
+  end
+
+  describe '#call' do
+    context 'when no plate appearances' do
+      it 'returns directions with all zero stats' do
+        result = described_class.new(user_id: user.id).call
+
+        left = result[:directions].find { |d| d[:id] == 8 }
+        aggregate_failures do
+          expect(left[:count]).to eq(0)
+          expect(left[:at_bats]).to eq(0)
+          expect(left[:hits]).to eq(0)
+          expect(left[:total_bases]).to eq(0)
+        end
+        expect(result[:home_runs]).to be_empty
+      end
+    end
+
+    context 'with mixed results in 左方向 (id=8)' do
+      before do
+        # 単打 / 三振 / 四球 / 二塁打 / 本塁打 が左方向に混在
+        create_pa(hit_direction_id: 8, plate_result_id: 7)  # 単打
+        create_pa(hit_direction_id: 8, plate_result_id: 13) # 三振
+        create_pa(hit_direction_id: 8, plate_result_id: 15) # 四球（打数外）
+        create_pa(hit_direction_id: 8, plate_result_id: 8)  # 二塁打
+        create_pa(hit_direction_id: 8, plate_result_id: 10) # 本塁打
+      end
+
+      it 'aggregates at_bats / hits / two_base_hit / total_bases / home_run for that direction' do
+        result = described_class.new(user_id: user.id).call
+        left = result[:directions].find { |d| d[:id] == 8 }
+
+        aggregate_failures do
+          # 単打 + 三振 + 二塁打 + 本塁打 = 4打数 (四球は除外)
+          expect(left[:at_bats]).to eq(4)
+          # 単打 + 二塁打 + 本塁打
+          expect(left[:hits]).to eq(3)
+          expect(left[:two_base_hit]).to eq(1)
+          expect(left[:three_base_hit]).to eq(0)
+          expect(left[:home_run]).to eq(1)
+          # 単打1 + 二塁打2 + 本塁打4
+          expect(left[:total_bases]).to eq(7)
+        end
+      end
+
+      it 'returns home_runs with that direction' do
+        result = described_class.new(user_id: user.id).call
+
+        expect(result[:home_runs].pluck(:id)).to include(8)
+      end
+    end
+
+    context 'with three_base_hit' do
+      before do
+        create_pa(hit_direction_id: 9, plate_result_id: 9) # 左中への三塁打
+      end
+
+      it 'counts three_base_hit and total_bases correctly' do
+        result = described_class.new(user_id: user.id).call
+        left_center = result[:directions].find { |d| d[:id] == 9 }
+
+        aggregate_failures do
+          expect(left_center[:at_bats]).to eq(1)
+          expect(left_center[:hits]).to eq(1)
+          expect(left_center[:three_base_hit]).to eq(1)
+          expect(left_center[:total_bases]).to eq(3)
+        end
+      end
+    end
+
+    context 'with year filter' do
+      before do
+        old_game = create(:game_result, user:)
+        old_game.match_result.update!(date_and_time: Time.zone.parse('2025-09-30'))
+        create(:plate_appearance, game_result: old_game, user:, batter_box_number: 1,
+                                  hit_direction_id: 8, plate_result_id: 7, is_new_format: true)
+
+        new_game = create(:game_result, user:)
+        new_game.match_result.update!(date_and_time: Time.zone.parse('2026-04-01'))
+        create(:plate_appearance, game_result: new_game, user:, batter_box_number: 1,
+                                  hit_direction_id: 8, plate_result_id: 8, is_new_format: true)
+      end
+
+      it 'only counts plate_appearances within the year' do
+        result = described_class.new(user_id: user.id, year: 2026).call
+        left = result[:directions].find { |d| d[:id] == 8 }
+
+        aggregate_failures do
+          expect(left[:at_bats]).to eq(1)
+          expect(left[:two_base_hit]).to eq(1)
+          expect(left[:total_bases]).to eq(2)
+        end
+      end
+    end
+
+    context 'with legacy batting_position_id (旧仕様)' do
+      before do
+        # batting_position_id=7 (旧仕様の左) → hit_direction_id=8 にマップされる
+        create(:plate_appearance, game_result:, user:, batter_box_number: 1,
+                                  batting_position_id: 7, plate_result_id: 7, is_new_format: false)
+      end
+
+      it 'maps legacy batting_position_id to direction id' do
+        result = described_class.new(user_id: user.id).call
+        left = result[:directions].find { |d| d[:id] == 8 }
+
+        aggregate_failures do
+          expect(left[:count]).to eq(1)
+          expect(left[:at_bats]).to eq(1)
+          expect(left[:hits]).to eq(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/stats/hit_location_aggregator_spec.rb
+++ b/spec/services/stats/hit_location_aggregator_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Stats::HitLocationAggregator, type: :service do
+  let(:user) { create(:user) }
+  let(:game_result) { create(:game_result, user:) }
+
+  def create_pa(loc_x:, loc_y:, plate_result_id:, batter_box_number: nil)
+    attrs = {
+      game_result:, user:, hit_location_x: loc_x, hit_location_y: loc_y,
+      plate_result_id:, is_new_format: true
+    }
+    attrs[:batter_box_number] = batter_box_number if batter_box_number
+    create(:plate_appearance, **attrs)
+  end
+
+  describe '#call' do
+    context 'when no plate appearances' do
+      it 'returns empty points' do
+        result = described_class.new(user_id: user.id).call
+
+        expect(result[:points]).to eq([])
+      end
+    end
+
+    context 'with categorized plate_results' do
+      before do
+        create_pa(loc_x: 0.30, loc_y: 0.40, plate_result_id: 7)  # 単打 → hit
+        create_pa(loc_x: 0.50, loc_y: 0.20, plate_result_id: 10) # 本塁打 → hit
+        create_pa(loc_x: 0.40, loc_y: 0.60, plate_result_id: 1)  # ゴロ → out
+        create_pa(loc_x: 0.60, loc_y: 0.45, plate_result_id: 2)  # フライ → out
+        create_pa(loc_x: 0.55, loc_y: 0.50, plate_result_id: 17) # 失策 → other
+      end
+
+      it 'categorizes each point as hit / out / other' do
+        result = described_class.new(user_id: user.id).call
+
+        categories = result[:points].pluck(:category)
+        aggregate_failures do
+          expect(categories).to contain_exactly('hit', 'hit', 'out', 'out', 'other')
+          expect(result[:points].first).to include(:x, :y, :category, :plate_result_id)
+        end
+      end
+    end
+
+    context 'when hit_location_x or y is NULL' do
+      before do
+        create_pa(loc_x: 0.5, loc_y: 0.5, plate_result_id: 7)
+        create(:plate_appearance, game_result:, user:, batter_box_number: 99,
+                                  hit_location_x: nil, hit_location_y: nil,
+                                  plate_result_id: 7, is_new_format: false)
+      end
+
+      it 'excludes plate appearances with NULL coordinates' do
+        result = described_class.new(user_id: user.id).call
+
+        expect(result[:points].length).to eq(1)
+      end
+    end
+
+    context 'with year filter' do
+      before do
+        old_game = create(:game_result, user:)
+        old_game.match_result.update!(date_and_time: Time.zone.parse('2025-09-30'))
+        create(:plate_appearance, game_result: old_game, user:, batter_box_number: 1,
+                                  hit_location_x: 0.4, hit_location_y: 0.4,
+                                  plate_result_id: 7, is_new_format: true)
+
+        new_game = create(:game_result, user:)
+        new_game.match_result.update!(date_and_time: Time.zone.parse('2026-04-01'))
+        create(:plate_appearance, game_result: new_game, user:, batter_box_number: 1,
+                                  hit_location_x: 0.6, hit_location_y: 0.6,
+                                  plate_result_id: 7, is_new_format: true)
+      end
+
+      it 'only returns points within the year' do
+        result = described_class.new(user_id: user.id, year: 2026).call
+
+        aggregate_failures do
+          expect(result[:points].length).to eq(1)
+          expect(result[:points].first[:x]).to eq(0.6)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/stats/out_type_breakdown_service_spec.rb
+++ b/spec/services/stats/out_type_breakdown_service_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Stats::OutTypeBreakdownService, type: :service do
+  let(:user) { create(:user) }
+  let(:game_result) { create(:game_result, user:) }
+
+  def create_pa(out_type:, batter_box_number: nil)
+    attrs = { game_result:, user:, out_type:, is_new_format: true }
+    attrs[:batter_box_number] = batter_box_number if batter_box_number
+    create(:plate_appearance, **attrs)
+  end
+
+  describe '#call' do
+    context 'when no plate appearances' do
+      it 'returns all enum categories with zero count and total 0' do
+        result = described_class.new(user_id: user.id).call
+
+        aggregate_failures do
+          expect(result[:total]).to eq(0)
+          expect(result[:breakdown].pluck(:category))
+            .to contain_exactly('ゴロ', 'フライ', 'ライナー', '併殺打', 'ファールフライ')
+          expect(result[:breakdown].pluck(:count)).to all(eq(0))
+          expect(result[:breakdown].pluck(:percentage)).to all(eq(0.0))
+        end
+      end
+    end
+
+    context 'with mixed out_type values' do
+      before do
+        create_pa(out_type: :ground_ball)
+        create_pa(out_type: :ground_ball)
+        create_pa(out_type: :fly_ball)
+        create_pa(out_type: :line_drive)
+        # out_type NULL の PA は集計対象外
+        create(:plate_appearance, game_result:, user:, batter_box_number: 99,
+                                  out_type: nil, is_new_format: false)
+      end
+
+      it 'aggregates count / percentage for each enum, excluding NULL' do
+        result = described_class.new(user_id: user.id).call
+
+        ground = result[:breakdown].find { |b| b[:category] == 'ゴロ' }
+        fly = result[:breakdown].find { |b| b[:category] == 'フライ' }
+        liner = result[:breakdown].find { |b| b[:category] == 'ライナー' }
+        foul = result[:breakdown].find { |b| b[:category] == 'ファールフライ' }
+        aggregate_failures do
+          expect(result[:total]).to eq(4)
+          expect(ground[:count]).to eq(2)
+          expect(ground[:percentage]).to eq(50.0)
+          expect(fly[:count]).to eq(1)
+          expect(fly[:percentage]).to eq(25.0)
+          expect(liner[:count]).to eq(1)
+          expect(foul[:count]).to eq(0)
+        end
+      end
+    end
+
+    context 'with year filter' do
+      before do
+        old_game = create(:game_result, user:)
+        old_game.match_result.update!(date_and_time: Time.zone.parse('2025-09-30'))
+        create(:plate_appearance, game_result: old_game, user:, batter_box_number: 1,
+                                  out_type: :ground_ball, is_new_format: true)
+
+        new_game = create(:game_result, user:)
+        new_game.match_result.update!(date_and_time: Time.zone.parse('2026-04-01'))
+        create(:plate_appearance, game_result: new_game, user:, batter_box_number: 1,
+                                  out_type: :fly_ball, is_new_format: true)
+      end
+
+      it 'only counts plate_appearances within the year' do
+        result = described_class.new(user_id: user.id, year: 2026).call
+        fly = result[:breakdown].find { |b| b[:category] == 'フライ' }
+
+        aggregate_failures do
+          expect(result[:total]).to eq(1)
+          expect(fly[:count]).to eq(1)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Sub Issue ippei-shimizu/buzzbase#367 「打球分析（A-1 絶対座標 / A-2 方向別テーブル / D-1 打球種類）」の back 実装。

## 変更内容

| サービス | 役割 |
|---|---|
| `Stats::HitDirectionAggregator` 拡張（A-2） | 各 direction の返り値に `at_bats / hits / two_base_hit / three_base_hit / home_run / total_bases` を追加。既存 `count / top_category` キーは維持。 |
| `Stats::HitLocationAggregator` 新規（A-1） | `plate_appearances.hit_location_x/y` から絶対座標 points 配列を返す。category を `hit / out / other` で分類。 |
| `Stats::OutTypeBreakdownService` 新規（D-1） | `plate_appearances.out_type` の enum 5 種別 count / percentage を返す。 |

## エンドポイント

- 既存 `GET /api/v2/stats/hit_directions` のレスポンスに新フィールド追加
- 新規 `GET /api/v2/stats/hit_locations`
- 新規 `GET /api/v2/stats/out_type_breakdown`

すべて既存と同じフィルタ（`year` / `match_type` / `season_id` / `tournament_id`）を受け取る。

## 旧データの扱い

| 機能 | 旧 PA の反映 |
|---|---|
| A-1 点プロット | × `hit_location_x/y` NULL の旧 PA は対象外。バブルモード（既存挙動）でカバー |
| A-2 方向別テーブル | △ `hit_direction_id` 持ち（約 39%）のみ反映。打数は `plate_results.counted_in_at_bats` ベースで正しく計上 |
| D-1 打球種類 | × `out_type` NULL の旧 PA は対象外（mobile 側で「対象データなし」表示） |

## 検証

- `bundle exec rspec spec/services/stats/hit_direction_aggregator_spec.rb spec/services/stats/hit_location_aggregator_spec.rb spec/services/stats/out_type_breakdown_service_spec.rb spec/requests/api/v2/stats_spec.rb` 全 35 例 PASS
- `bundle exec rubocop app/services/stats/ app/controllers/api/v2/stats_controller.rb config/routes.rb spec/services/stats/ spec/requests/api/v2/stats_spec.rb` no offense
