### PR TITLE
Feature: stats 打撃 - カウント別分析 API（初球 / 有利 / 追い込み）

### DIFF
--- a/app/controllers/api/v2/stats_controller.rb
+++ b/app/controllers/api/v2/stats_controller.rb
@@ -113,6 +113,17 @@ module Api
         render json: result
       end
 
+      def count_situations
+        result = Stats::CountSituationAggregator.new(
+          user_id: target_user_id,
+          year: params[:year],
+          match_type: convert_match_type(params[:match_type]),
+          season_id: params[:season_id],
+          tournament_id: params[:tournament_id]
+        ).call
+        render json: result
+      end
+
       private
 
       # 他ユーザーの成績も参照可能（公開プロフィール設計）

--- a/app/services/stats/count_situation_aggregator.rb
+++ b/app/services/stats/count_situation_aggregator.rb
@@ -29,6 +29,13 @@ module Stats
 
     # @return [Hash] :first_pitch / :favorable_count / :pinch_count の各セットと
     #   :total_target_pa（新仕様で記録された対象打席数）
+    #
+    # 注意: 3 カテゴリは排他ではない。特に **フルカウント (final_balls=3,
+    # final_strikes=2)** は `final_balls > final_strikes` と `final_strikes = 2` の
+    # 両方を満たすため、`favorable_count` と `pinch_count` の両方に同じ打席が
+    # 計上される。これは意図的な設計（「有利カウントで打てたか」と「追い込みから
+    # 粘れたか」を独立した指標として見たいため）で、フロントの母数表示でも
+    # 重複を考慮しない。
     def call
       counts = aggregate_counts
       {

--- a/app/services/stats/count_situation_aggregator.rb
+++ b/app/services/stats/count_situation_aggregator.rb
@@ -76,9 +76,13 @@ module Stats
 
     def filtered_scope
       @filtered_scope ||= begin
+        # joins(:plate_result) は INNER JOIN なので plate_result_id IS NULL の PA は
+        # 結果セットから静かに除外される。total_target_pa を「joins 後 / 前」のどちらに
+        # 揃えるか曖昧にならないよう、scope 段階で明示的に NULL を弾く。
         scope = PlateAppearance.joins(game_result: :match_result)
                                .where(user_id: @user_id)
                                .where.not(final_strikes: nil)
+                               .where.not(plate_result_id: nil)
         scope = apply_year_filter(scope)
         scope = apply_match_type_filter(scope)
         scope = apply_season_filter(scope)

--- a/app/services/stats/count_situation_aggregator.rb
+++ b/app/services/stats/count_situation_aggregator.rb
@@ -76,11 +76,12 @@ module Stats
 
     def filtered_scope
       @filtered_scope ||= begin
-        # joins(:plate_result) は INNER JOIN なので plate_result_id IS NULL の PA は
-        # 結果セットから静かに除外される。total_target_pa を「joins 後 / 前」のどちらに
-        # 揃えるか曖昧にならないよう、scope 段階で明示的に NULL を弾く。
+        # is_new_format には index があるため、先頭でこれを当てて新仕様 PA に
+        # 絞ってから final_strikes / plate_result_id NULL の防御を重ねる。
+        # final_strikes / final_balls / first_pitch_swing 自体には index が
+        # 無く、データ量が増えるとフルスキャンになる懸念があるための前段。
         scope = PlateAppearance.joins(game_result: :match_result)
-                               .where(user_id: @user_id)
+                               .where(user_id: @user_id, is_new_format: true)
                                .where.not(final_strikes: nil)
                                .where.not(plate_result_id: nil)
         scope = apply_year_filter(scope)

--- a/app/services/stats/count_situation_aggregator.rb
+++ b/app/services/stats/count_situation_aggregator.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+module Stats
+  # カウント状況別（初球 / 有利カウント / 追い込み）の打席集計サービス。
+  #
+  # plate_appearances の first_pitch_swing / final_balls / final_strikes は
+  # 新仕様で記録されたカラムなので、これらが NULL の旧 PA は集計対象外。
+  # filtered_scope 段階で `final_strikes IS NOT NULL` を入れることで、
+  # 新仕様の PA だけを 3 条件で抽出する。
+  #
+  # 母数 0 のときは batting_average を 0.0 で返し、クライアント側で
+  # 「対象データなし」UI に分岐させる。
+  class CountSituationAggregator
+    HIT_RESULT_IDS = ::Stats::BattingAverageRecalculator::HIT_RESULT_IDS
+
+    SITUATIONS = {
+      first_pitch: 'plate_appearances.first_pitch_swing = TRUE',
+      favorable_count: 'plate_appearances.final_balls > plate_appearances.final_strikes',
+      pinch_count: 'plate_appearances.final_strikes = 2'
+    }.freeze
+
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+      @user_id = user_id
+      @year = year
+      @match_type = match_type
+      @season_id = season_id
+      @tournament_id = tournament_id
+    end
+
+    # @return [Hash] :first_pitch / :favorable_count / :pinch_count の各セットと
+    #   :total_target_pa（新仕様で記録された対象打席数）
+    def call
+      counts = aggregate_counts
+      {
+        first_pitch: build_result(counts[:first_pitch_at_bats], counts[:first_pitch_hits]),
+        favorable_count: build_result(counts[:favorable_at_bats], counts[:favorable_hits]),
+        pinch_count: build_result(counts[:pinch_at_bats], counts[:pinch_hits]),
+        total_target_pa: counts[:total_target_pa]
+      }
+    end
+
+    private
+
+    # 3 条件 × (at_bats, hits) + total_target_pa を 1 クエリで集約する。
+    def aggregate_counts
+      sql = <<~SQL.squish
+        COUNT(*) AS total_target_pa,
+        COUNT(*) FILTER (WHERE plate_results.counted_in_at_bats = TRUE
+                           AND #{SITUATIONS[:first_pitch]}) AS first_pitch_at_bats,
+        COUNT(*) FILTER (WHERE plate_appearances.plate_result_id IN (#{HIT_RESULT_IDS.join(',')})
+                           AND #{SITUATIONS[:first_pitch]}) AS first_pitch_hits,
+        COUNT(*) FILTER (WHERE plate_results.counted_in_at_bats = TRUE
+                           AND #{SITUATIONS[:favorable_count]}) AS favorable_at_bats,
+        COUNT(*) FILTER (WHERE plate_appearances.plate_result_id IN (#{HIT_RESULT_IDS.join(',')})
+                           AND #{SITUATIONS[:favorable_count]}) AS favorable_hits,
+        COUNT(*) FILTER (WHERE plate_results.counted_in_at_bats = TRUE
+                           AND #{SITUATIONS[:pinch_count]}) AS pinch_at_bats,
+        COUNT(*) FILTER (WHERE plate_appearances.plate_result_id IN (#{HIT_RESULT_IDS.join(',')})
+                           AND #{SITUATIONS[:pinch_count]}) AS pinch_hits
+      SQL
+      row = filtered_scope.joins(:plate_result).pick(Arel.sql(sql))
+      values = Array.wrap(row).map(&:to_i)
+      %i[total_target_pa
+         first_pitch_at_bats first_pitch_hits
+         favorable_at_bats favorable_hits
+         pinch_at_bats pinch_hits].zip(values).to_h
+    end
+
+    def build_result(at_bats, hits)
+      {
+        at_bats:,
+        hits:,
+        batting_average: safe_divide(hits, at_bats)
+      }
+    end
+
+    def filtered_scope
+      @filtered_scope ||= begin
+        scope = PlateAppearance.joins(game_result: :match_result)
+                               .where(user_id: @user_id)
+                               .where.not(final_strikes: nil)
+        scope = apply_year_filter(scope)
+        scope = apply_match_type_filter(scope)
+        scope = apply_season_filter(scope)
+        apply_tournament_filter(scope)
+      end
+    end
+
+    def apply_year_filter(scope)
+      return scope if @year.blank? || @year.to_s == '通算'
+
+      yr = @year.to_i
+      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
+                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+    end
+
+    def apply_match_type_filter(scope)
+      return scope if @match_type.blank? || @match_type == '全て'
+
+      scope.where(match_results: { match_type: @match_type })
+    end
+
+    def apply_season_filter(scope)
+      return scope if @season_id.blank?
+
+      scope.where(game_results: { season_id: @season_id })
+    end
+
+    def apply_tournament_filter(scope)
+      return scope if @tournament_id.blank?
+
+      scope.where(match_results: { tournament_id: @tournament_id })
+    end
+
+    def safe_divide(numerator, denominator)
+      return 0.0 if denominator.to_i.zero?
+
+      (numerator.to_f / denominator).round(3)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -224,6 +224,7 @@ Rails.application.routes.draw do
         get :runners_situation, on: :member
         get :hit_locations, on: :member
         get :out_type_breakdown, on: :member
+        get :count_situations, on: :member
       end
 
       resources :plate_appearances, only: %i[create update destroy] do

--- a/spec/requests/api/v2/stats_spec.rb
+++ b/spec/requests/api/v2/stats_spec.rb
@@ -214,4 +214,22 @@ RSpec.describe 'Api::V2::Stats', type: :request do
       )
     end
   end
+
+  describe 'GET /api/v2/stats/count_situations' do
+    it 'returns 401 when not authenticated' do
+      get '/api/v2/stats/count_situations'
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns 200 with first_pitch / favorable_count / pinch_count + total_target_pa' do
+      get('/api/v2/stats/count_situations', headers:)
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json).to include('first_pitch', 'favorable_count', 'pinch_count', 'total_target_pa')
+      %w[first_pitch favorable_count pinch_count].each do |key|
+        expect(json[key]).to include('at_bats', 'hits', 'batting_average')
+      end
+    end
+  end
 end

--- a/spec/services/stats/count_situation_aggregator_spec.rb
+++ b/spec/services/stats/count_situation_aggregator_spec.rb
@@ -129,6 +129,26 @@ RSpec.describe Stats::CountSituationAggregator, type: :service do
       end
     end
 
+    context 'with full count (3-2) PA' do
+      before do
+        # フルカウント: final_balls > final_strikes と final_strikes = 2 の両方を満たす
+        create_pa(plate_result_id: 7, first_pitch_swing: false, final_balls: 3, final_strikes: 2)
+      end
+
+      it 'counts the same PA in both favorable_count and pinch_count (排他ではない仕様)' do
+        result = described_class.new(user_id: user.id).call
+
+        aggregate_failures do
+          expect(result[:favorable_count][:at_bats]).to eq(1)
+          expect(result[:favorable_count][:hits]).to eq(1)
+          expect(result[:pinch_count][:at_bats]).to eq(1)
+          expect(result[:pinch_count][:hits]).to eq(1)
+          # 母数 (total_target_pa) は 1 のままで、重複計上はカテゴリ内のみ
+          expect(result[:total_target_pa]).to eq(1)
+        end
+      end
+    end
+
     context 'with year filter' do
       before do
         old_game = create(:game_result, user:)

--- a/spec/services/stats/count_situation_aggregator_spec.rb
+++ b/spec/services/stats/count_situation_aggregator_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Stats::CountSituationAggregator, type: :service do
+  let(:user) { create(:user) }
+  let(:game_result) { create(:game_result, user:) }
+
+  def create_pa(plate_result_id:, first_pitch_swing: nil, final_balls: nil, final_strikes: nil, batter_box_number: nil)
+    attrs = {
+      game_result:, user:, plate_result_id:,
+      first_pitch_swing:, final_balls:, final_strikes:, is_new_format: true
+    }
+    attrs[:batter_box_number] = batter_box_number if batter_box_number
+    create(:plate_appearance, **attrs)
+  end
+
+  describe '#call' do
+    context 'when no new-format plate appearances' do
+      it 'returns zero母数 for all situations' do
+        result = described_class.new(user_id: user.id).call
+
+        aggregate_failures do
+          expect(result[:total_target_pa]).to eq(0)
+          expect(result[:first_pitch][:at_bats]).to eq(0)
+          expect(result[:first_pitch][:hits]).to eq(0)
+          expect(result[:first_pitch][:batting_average]).to eq(0.0)
+          expect(result[:favorable_count][:at_bats]).to eq(0)
+          expect(result[:pinch_count][:at_bats]).to eq(0)
+        end
+      end
+    end
+
+    context 'with first_pitch_swing PAs' do
+      before do
+        # 初球を振ってヒット
+        create_pa(plate_result_id: 7, first_pitch_swing: true, final_balls: 0, final_strikes: 1)
+        # 初球を振って三振
+        create_pa(plate_result_id: 13, first_pitch_swing: true, final_balls: 0, final_strikes: 1)
+        # 初球を振らずヒット（first_pitch のカウントから除外）
+        create_pa(plate_result_id: 7, first_pitch_swing: false, final_balls: 2, final_strikes: 1)
+      end
+
+      it 'aggregates only PAs where first_pitch_swing = TRUE for first_pitch' do
+        result = described_class.new(user_id: user.id).call
+        first_pitch = result[:first_pitch]
+
+        aggregate_failures do
+          expect(first_pitch[:at_bats]).to eq(2)
+          expect(first_pitch[:hits]).to eq(1)
+          expect(first_pitch[:batting_average]).to eq((1.0 / 2).round(3))
+        end
+      end
+    end
+
+    context 'with favorable_count PAs' do
+      before do
+        # 有利カウント (final_balls > final_strikes): ヒット
+        create_pa(plate_result_id: 7, first_pitch_swing: false, final_balls: 2, final_strikes: 1)
+        # 有利カウント: 三振
+        create_pa(plate_result_id: 13, first_pitch_swing: false, final_balls: 3, final_strikes: 2)
+        # 不利カウント (final_balls <= final_strikes): 除外
+        create_pa(plate_result_id: 7, first_pitch_swing: false, final_balls: 1, final_strikes: 2)
+      end
+
+      it 'aggregates only PAs where final_balls > final_strikes for favorable_count' do
+        result = described_class.new(user_id: user.id).call
+        favorable = result[:favorable_count]
+
+        aggregate_failures do
+          expect(favorable[:at_bats]).to eq(2)
+          expect(favorable[:hits]).to eq(1)
+          expect(favorable[:batting_average]).to eq((1.0 / 2).round(3))
+        end
+      end
+    end
+
+    context 'with pinch_count PAs' do
+      before do
+        # 追い込みカウント (final_strikes = 2): ヒット
+        create_pa(plate_result_id: 7, first_pitch_swing: false, final_balls: 1, final_strikes: 2)
+        # 追い込みカウント: 三振
+        create_pa(plate_result_id: 13, first_pitch_swing: false, final_balls: 0, final_strikes: 2)
+        # 追い込みではない (final_strikes < 2): 除外
+        create_pa(plate_result_id: 7, first_pitch_swing: false, final_balls: 0, final_strikes: 1)
+      end
+
+      it 'aggregates only PAs where final_strikes = 2 for pinch_count' do
+        result = described_class.new(user_id: user.id).call
+        pinch = result[:pinch_count]
+
+        aggregate_failures do
+          expect(pinch[:at_bats]).to eq(2)
+          expect(pinch[:hits]).to eq(1)
+          expect(pinch[:batting_average]).to eq((1.0 / 2).round(3))
+        end
+      end
+    end
+
+    context 'when old-format PA only (NULL final_strikes)' do
+      before do
+        create(:plate_appearance, game_result:, user:, batter_box_number: 99,
+                                  plate_result_id: 7,
+                                  first_pitch_swing: nil, final_balls: nil, final_strikes: nil,
+                                  is_new_format: false)
+      end
+
+      it 'excludes old-format PAs from filtered_scope' do
+        result = described_class.new(user_id: user.id).call
+
+        expect(result[:total_target_pa]).to eq(0)
+      end
+    end
+
+    context 'with year filter' do
+      before do
+        old_game = create(:game_result, user:)
+        old_game.match_result.update!(date_and_time: Time.zone.parse('2025-09-30'))
+        create(:plate_appearance, game_result: old_game, user:, batter_box_number: 1,
+                                  plate_result_id: 7, first_pitch_swing: true,
+                                  final_balls: 0, final_strikes: 1, is_new_format: true)
+
+        new_game = create(:game_result, user:)
+        new_game.match_result.update!(date_and_time: Time.zone.parse('2026-04-01'))
+        create(:plate_appearance, game_result: new_game, user:, batter_box_number: 1,
+                                  plate_result_id: 8, first_pitch_swing: true,
+                                  final_balls: 0, final_strikes: 1, is_new_format: true)
+      end
+
+      it 'only counts plate_appearances within the year' do
+        result = described_class.new(user_id: user.id, year: 2026).call
+
+        aggregate_failures do
+          expect(result[:total_target_pa]).to eq(1)
+          expect(result[:first_pitch][:at_bats]).to eq(1)
+          expect(result[:first_pitch][:hits]).to eq(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/stats/count_situation_aggregator_spec.rb
+++ b/spec/services/stats/count_situation_aggregator_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Stats::CountSituationAggregator, type: :service do
+  # plate_result_id の SSoT は Stats::BattingAverageRecalculator::HIT_RESULT_IDS。
+  # spec ではテスト意図（単打 / 三振 など）を明示するために let で別名を持たせる。
+  let(:single_result_id) { Stats::BattingAverageRecalculator::HIT_RESULT_IDS.first } # 7 (単打)
+  let(:double_result_id) { 8 } # 二塁打
+  let(:strikeout_result_id) { 13 } # 三振
+
   let(:user) { create(:user) }
   let(:game_result) { create(:game_result, user:) }
 
@@ -34,11 +40,14 @@ RSpec.describe Stats::CountSituationAggregator, type: :service do
     context 'with first_pitch_swing PAs' do
       before do
         # 初球を振ってヒット
-        create_pa(plate_result_id: 7, first_pitch_swing: true, final_balls: 0, final_strikes: 1)
+        create_pa(plate_result_id: single_result_id, first_pitch_swing: true,
+                  final_balls: 0, final_strikes: 1)
         # 初球を振って三振
-        create_pa(plate_result_id: 13, first_pitch_swing: true, final_balls: 0, final_strikes: 1)
+        create_pa(plate_result_id: strikeout_result_id, first_pitch_swing: true,
+                  final_balls: 0, final_strikes: 1)
         # 初球を振らずヒット（first_pitch のカウントから除外）
-        create_pa(plate_result_id: 7, first_pitch_swing: false, final_balls: 2, final_strikes: 1)
+        create_pa(plate_result_id: single_result_id, first_pitch_swing: false,
+                  final_balls: 2, final_strikes: 1)
       end
 
       it 'aggregates only PAs where first_pitch_swing = TRUE for first_pitch' do
@@ -56,11 +65,14 @@ RSpec.describe Stats::CountSituationAggregator, type: :service do
     context 'with favorable_count PAs' do
       before do
         # 有利カウント (final_balls > final_strikes): ヒット
-        create_pa(plate_result_id: 7, first_pitch_swing: false, final_balls: 2, final_strikes: 1)
+        create_pa(plate_result_id: single_result_id, first_pitch_swing: false,
+                  final_balls: 2, final_strikes: 1)
         # 有利カウント: 三振
-        create_pa(plate_result_id: 13, first_pitch_swing: false, final_balls: 3, final_strikes: 2)
+        create_pa(plate_result_id: strikeout_result_id, first_pitch_swing: false,
+                  final_balls: 3, final_strikes: 2)
         # 不利カウント (final_balls <= final_strikes): 除外
-        create_pa(plate_result_id: 7, first_pitch_swing: false, final_balls: 1, final_strikes: 2)
+        create_pa(plate_result_id: single_result_id, first_pitch_swing: false,
+                  final_balls: 1, final_strikes: 2)
       end
 
       it 'aggregates only PAs where final_balls > final_strikes for favorable_count' do
@@ -78,11 +90,14 @@ RSpec.describe Stats::CountSituationAggregator, type: :service do
     context 'with pinch_count PAs' do
       before do
         # 追い込みカウント (final_strikes = 2): ヒット
-        create_pa(plate_result_id: 7, first_pitch_swing: false, final_balls: 1, final_strikes: 2)
+        create_pa(plate_result_id: single_result_id, first_pitch_swing: false,
+                  final_balls: 1, final_strikes: 2)
         # 追い込みカウント: 三振
-        create_pa(plate_result_id: 13, first_pitch_swing: false, final_balls: 0, final_strikes: 2)
+        create_pa(plate_result_id: strikeout_result_id, first_pitch_swing: false,
+                  final_balls: 0, final_strikes: 2)
         # 追い込みではない (final_strikes < 2): 除外
-        create_pa(plate_result_id: 7, first_pitch_swing: false, final_balls: 0, final_strikes: 1)
+        create_pa(plate_result_id: single_result_id, first_pitch_swing: false,
+                  final_balls: 0, final_strikes: 1)
       end
 
       it 'aggregates only PAs where final_strikes = 2 for pinch_count' do
@@ -100,7 +115,7 @@ RSpec.describe Stats::CountSituationAggregator, type: :service do
     context 'when plate_result_id is NULL' do
       before do
         # plate_result_id 未入力（カウントは記録されているが結果未入力）の PA。
-        # joins(:plate_result) の INNER JOIN で除外されるため total_target_pa にも含めない。
+        # filtered_scope の where.not(plate_result_id: nil) で除外される。
         create(:plate_appearance, game_result:, user:, batter_box_number: 50,
                                   plate_result_id: nil,
                                   first_pitch_swing: true, final_balls: 0, final_strikes: 1,
@@ -117,7 +132,7 @@ RSpec.describe Stats::CountSituationAggregator, type: :service do
     context 'when old-format PA only (NULL final_strikes)' do
       before do
         create(:plate_appearance, game_result:, user:, batter_box_number: 99,
-                                  plate_result_id: 7,
+                                  plate_result_id: single_result_id,
                                   first_pitch_swing: nil, final_balls: nil, final_strikes: nil,
                                   is_new_format: false)
       end
@@ -132,7 +147,8 @@ RSpec.describe Stats::CountSituationAggregator, type: :service do
     context 'with full count (3-2) PA' do
       before do
         # フルカウント: final_balls > final_strikes と final_strikes = 2 の両方を満たす
-        create_pa(plate_result_id: 7, first_pitch_swing: false, final_balls: 3, final_strikes: 2)
+        create_pa(plate_result_id: single_result_id, first_pitch_swing: false,
+                  final_balls: 3, final_strikes: 2)
       end
 
       it 'counts the same PA in both favorable_count and pinch_count (排他ではない仕様)' do
@@ -154,13 +170,13 @@ RSpec.describe Stats::CountSituationAggregator, type: :service do
         old_game = create(:game_result, user:)
         old_game.match_result.update!(date_and_time: Time.zone.parse('2025-09-30'))
         create(:plate_appearance, game_result: old_game, user:, batter_box_number: 1,
-                                  plate_result_id: 7, first_pitch_swing: true,
+                                  plate_result_id: single_result_id, first_pitch_swing: true,
                                   final_balls: 0, final_strikes: 1, is_new_format: true)
 
         new_game = create(:game_result, user:)
         new_game.match_result.update!(date_and_time: Time.zone.parse('2026-04-01'))
         create(:plate_appearance, game_result: new_game, user:, batter_box_number: 1,
-                                  plate_result_id: 8, first_pitch_swing: true,
+                                  plate_result_id: double_result_id, first_pitch_swing: true,
                                   final_balls: 0, final_strikes: 1, is_new_format: true)
       end
 

--- a/spec/services/stats/count_situation_aggregator_spec.rb
+++ b/spec/services/stats/count_situation_aggregator_spec.rb
@@ -97,6 +97,23 @@ RSpec.describe Stats::CountSituationAggregator, type: :service do
       end
     end
 
+    context 'when plate_result_id is NULL' do
+      before do
+        # plate_result_id 未入力（カウントは記録されているが結果未入力）の PA。
+        # joins(:plate_result) の INNER JOIN で除外されるため total_target_pa にも含めない。
+        create(:plate_appearance, game_result:, user:, batter_box_number: 50,
+                                  plate_result_id: nil,
+                                  first_pitch_swing: true, final_balls: 0, final_strikes: 1,
+                                  is_new_format: true)
+      end
+
+      it 'excludes PAs whose plate_result_id is NULL from total_target_pa' do
+        result = described_class.new(user_id: user.id).call
+
+        expect(result[:total_target_pa]).to eq(0)
+      end
+    end
+
     context 'when old-format PA only (NULL final_strikes)' do
       before do
         create(:plate_appearance, game_result:, user:, batter_box_number: 99,


### PR DESCRIPTION
## 概要

Sub Issue ippei-shimizu/buzzbase#368 「カウント別分析（B-2 初球 / B-3 有利カウント / B-4 追い込み）」の back 実装。

## 変更内容

### `Stats::CountSituationAggregator` 新規

| キー | 抽出条件 |
|---|---|
| `first_pitch` | `first_pitch_swing = TRUE` |
| `favorable_count` | `final_balls > final_strikes` |
| `pinch_count` | `final_strikes = 2` |

- `at_bats` は `plate_results.counted_in_at_bats = TRUE` を SSoT に判定
- `hits` は `BattingAverageRecalculator::HIT_RESULT_IDS` 参照
- `batting_average` はサーバ側で `(hits / at_bats).round(3)`、0 打数は 0.0
- 3 条件 × (at_bats, hits) + total_target_pa を **1 クエリ**で COUNT FILTER により集約

### エンドポイント

- 新規 `GET /api/v2/stats/count_situations`
- 既存と同じフィルタ（`year` / `match_type` / `season_id` / `tournament_id`）

### レスポンス形

```json
{
  "first_pitch":     { "at_bats": 5, "hits": 2, "batting_average": 0.4 },
  "favorable_count": { "at_bats": 12, "hits": 5, "batting_average": 0.417 },
  "pinch_count":     { "at_bats": 8, "hits": 1, "batting_average": 0.125 },
  "total_target_pa": 30
}
```

`total_target_pa` は「対象 N 打席」UI 表示用。

## 旧データの扱い

- 旧仕様 PA は `final_strikes` 等が NULL なので、`filtered_scope` 段階で `where.not(final_strikes: nil)` により除外
- 母数 0 のときも `0.0` を返すので、フロント側で「対象データなし」UI 判定可能

## 検証

- `bundle exec rspec spec/services/stats/count_situation_aggregator_spec.rb spec/requests/api/v2/stats_spec.rb` PASS（30 例）
- `bundle exec rubocop` no offense
