### PR TITLE
Feature: stats 打撃 - 詳細分析 API（C-1 / E-1 / 対戦投手別）

### DIFF
--- a/app/controllers/api/v2/stats_controller.rb
+++ b/app/controllers/api/v2/stats_controller.rb
@@ -124,6 +124,39 @@ module Api
         render json: result
       end
 
+      def contact_qualities
+        result = Stats::ContactQualityAggregator.new(
+          user_id: target_user_id,
+          year: params[:year],
+          match_type: convert_match_type(params[:match_type]),
+          season_id: params[:season_id],
+          tournament_id: params[:tournament_id]
+        ).call
+        render json: result
+      end
+
+      def pitch_types
+        result = Stats::PitchTypeAggregator.new(
+          user_id: target_user_id,
+          year: params[:year],
+          match_type: convert_match_type(params[:match_type]),
+          season_id: params[:season_id],
+          tournament_id: params[:tournament_id]
+        ).call
+        render json: result
+      end
+
+      def pitcher_faceoffs
+        result = Stats::PitcherFaceoffAggregator.new(
+          user_id: target_user_id,
+          year: params[:year],
+          match_type: convert_match_type(params[:match_type]),
+          season_id: params[:season_id],
+          tournament_id: params[:tournament_id]
+        ).call
+        render json: result
+      end
+
       private
 
       # 他ユーザーの成績も参照可能（公開プロフィール設計）

--- a/app/services/stats/contact_quality_aggregator.rb
+++ b/app/services/stats/contact_quality_aggregator.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Stats
+  # 打球の質（contact_qualities マスタ）別の集計サービス。
+  #
+  # contact_quality_id が記録された新仕様 PA を対象に、マスタ display_order 順で
+  # count / percentage を返す。母数 0 でも全 5 カテゴリの行を出してフロント側で
+  # 安定して描画できるようにする。
+  class ContactQualityAggregator
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+      @user_id = user_id
+      @year = year
+      @match_type = match_type
+      @season_id = season_id
+      @tournament_id = tournament_id
+    end
+
+    # @return [Hash] breakdown: [{ id, label, count, percentage }], total: 集計対象の総数
+    def call
+      counts_by_id = filtered_scope.where.not(contact_quality_id: nil)
+                                   .group(:contact_quality_id).count
+      total = counts_by_id.values.sum
+
+      breakdown = ContactQuality.order(:display_order).map do |cq|
+        count = counts_by_id.fetch(cq.id, 0)
+        percentage = total.zero? ? 0.0 : (count.to_f / total * 100).round(1)
+        { id: cq.id, label: cq.name, count:, percentage: }
+      end
+
+      { breakdown:, total: }
+    end
+
+    private
+
+    def filtered_scope
+      @filtered_scope ||= begin
+        scope = PlateAppearance.joins(game_result: :match_result)
+                               .where(user_id: @user_id, is_new_format: true)
+        scope = apply_year_filter(scope)
+        scope = apply_match_type_filter(scope)
+        scope = apply_season_filter(scope)
+        apply_tournament_filter(scope)
+      end
+    end
+
+    def apply_year_filter(scope)
+      return scope if @year.blank? || @year.to_s == '通算'
+
+      yr = @year.to_i
+      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
+                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+    end
+
+    def apply_match_type_filter(scope)
+      return scope if @match_type.blank? || @match_type == '全て'
+
+      scope.where(match_results: { match_type: @match_type })
+    end
+
+    def apply_season_filter(scope)
+      return scope if @season_id.blank?
+
+      scope.where(game_results: { season_id: @season_id })
+    end
+
+    def apply_tournament_filter(scope)
+      return scope if @tournament_id.blank?
+
+      scope.where(match_results: { tournament_id: @tournament_id })
+    end
+  end
+end

--- a/app/services/stats/pitch_type_aggregator.rb
+++ b/app/services/stats/pitch_type_aggregator.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module Stats
+  # 球種（pitch_types マスタ）別の打席集計サービス。
+  #
+  # pitch_type_id が記録された新仕様 PA を対象に、マスタ display_order 順で
+  # at_bats / hits / total_bases / batting_average / slugging_percentage を返す。
+  # 母数 0 でも全 10 行（マスタ全件）を出してフロント側で安定して描画できるようにする。
+  class PitchTypeAggregator
+    HIT_RESULT_IDS = ::Stats::BattingAverageRecalculator::HIT_RESULT_IDS
+    TOTAL_BASES_PER_RESULT = { 7 => 1, 8 => 2, 9 => 3, 10 => 4 }.freeze
+
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+      @user_id = user_id
+      @year = year
+      @match_type = match_type
+      @season_id = season_id
+      @tournament_id = tournament_id
+    end
+
+    # @return [Hash] rows: [{ id, label, at_bats, hits, total_bases,
+    #   batting_average, slugging_percentage }], total_target_pa: 対象打席数
+    def call
+      stats_by_pitch_type = aggregate_stats
+      total_target_pa = filtered_scope.where.not(pitch_type_id: nil).count
+
+      rows = PitchType.order(:display_order).map do |pt|
+        stats = stats_by_pitch_type[pt.id] || zero_stats
+        {
+          id: pt.id,
+          label: pt.name,
+          at_bats: stats[:at_bats],
+          hits: stats[:hits],
+          total_bases: stats[:total_bases],
+          batting_average: safe_divide(stats[:hits], stats[:at_bats]),
+          slugging_percentage: safe_divide(stats[:total_bases], stats[:at_bats])
+        }
+      end
+
+      { rows:, total_target_pa: }
+    end
+
+    private
+
+    def aggregate_stats
+      cross = filtered_scope.joins(:plate_result)
+                            .where.not(pitch_type_id: nil)
+                            .group(:pitch_type_id, :plate_result_id,
+                                   'plate_results.counted_in_at_bats')
+                            .count
+
+      stats = Hash.new { |h, k| h[k] = zero_stats.dup }
+      cross.each do |(pitch_type_id, result_id, counted), cnt| # rubocop:disable Style/HashEachMethods
+        bucket = stats[pitch_type_id]
+        bucket[:at_bats] += cnt if counted
+        next unless HIT_RESULT_IDS.include?(result_id)
+
+        bucket[:hits] += cnt
+        bucket[:total_bases] += cnt * TOTAL_BASES_PER_RESULT.fetch(result_id, 0)
+      end
+      stats
+    end
+
+    def zero_stats
+      { at_bats: 0, hits: 0, total_bases: 0 }
+    end
+
+    def safe_divide(numerator, denominator)
+      return 0.0 if denominator.to_i.zero?
+
+      (numerator.to_f / denominator).round(3)
+    end
+
+    def filtered_scope
+      @filtered_scope ||= begin
+        scope = PlateAppearance.joins(game_result: :match_result)
+                               .where(user_id: @user_id, is_new_format: true)
+        scope = apply_year_filter(scope)
+        scope = apply_match_type_filter(scope)
+        scope = apply_season_filter(scope)
+        apply_tournament_filter(scope)
+      end
+    end
+
+    def apply_year_filter(scope)
+      return scope if @year.blank? || @year.to_s == '通算'
+
+      yr = @year.to_i
+      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
+                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+    end
+
+    def apply_match_type_filter(scope)
+      return scope if @match_type.blank? || @match_type == '全て'
+
+      scope.where(match_results: { match_type: @match_type })
+    end
+
+    def apply_season_filter(scope)
+      return scope if @season_id.blank?
+
+      scope.where(game_results: { season_id: @season_id })
+    end
+
+    def apply_tournament_filter(scope)
+      return scope if @tournament_id.blank?
+
+      scope.where(match_results: { tournament_id: @tournament_id })
+    end
+  end
+end

--- a/app/services/stats/pitch_type_aggregator.rb
+++ b/app/services/stats/pitch_type_aggregator.rb
@@ -71,10 +71,15 @@ module Stats
       (numerator.to_f / denominator).round(3)
     end
 
+    # aggregate_stats が joins(:plate_result) を使うため、ここでも
+    # plate_result_id IS NULL の PA を弾いておく。これにより
+    # total_target_pa（このスコープに対する .count）と aggregate_stats の
+    # 母数が必ず一致する（行合計 == total_target_pa を保証）。
     def filtered_scope
       @filtered_scope ||= begin
         scope = PlateAppearance.joins(game_result: :match_result)
                                .where(user_id: @user_id, is_new_format: true)
+                               .where.not(plate_result_id: nil)
         scope = apply_year_filter(scope)
         scope = apply_match_type_filter(scope)
         scope = apply_season_filter(scope)

--- a/app/services/stats/pitcher_faceoff_aggregator.rb
+++ b/app/services/stats/pitcher_faceoff_aggregator.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+module Stats
+  # 対戦投手別の対戦成績集計サービス。
+  #
+  # pitcher_id が記録された新仕様 PA を対象に、投手別の
+  # 対戦数 / at_bats / hits / batting_average / 最頻 plate_result（「主な結果」）を返す。
+  # 最低対戦回数 MIN_PLATE_APPEARANCES（3 打席）未満の投手は除外し、
+  # 対戦多い順 → 投手名昇順でソートする。
+  class PitcherFaceoffAggregator
+    HIT_RESULT_IDS = ::Stats::BattingAverageRecalculator::HIT_RESULT_IDS
+
+    # しきい値未満の投手は表示に含めない。サンプルサイズの少ない打率を
+    # ランキング表示で誤読しないための下限。
+    MIN_PLATE_APPEARANCES = 3
+
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+      @user_id = user_id
+      @year = year
+      @match_type = match_type
+      @season_id = season_id
+      @tournament_id = tournament_id
+    end
+
+    # @return [Hash] rows: [{ pitcher_id, pitcher_name, plate_appearances,
+    #   at_bats, hits, batting_average, top_result }],
+    #   total_target_pa: pitcher_id 付き打席の総数,
+    #   min_plate_appearances: しきい値
+    def call
+      stats = aggregate_stats
+      total_target_pa = stats.values.sum { |s| s[:plate_appearances] }
+      pitchers_by_id = Pitcher.where(id: stats.keys).index_by(&:id)
+      plate_results_by_id = PlateResult.all.index_by(&:id)
+
+      rows = stats.filter_map do |pitcher_id, s|
+        next if s[:plate_appearances] < MIN_PLATE_APPEARANCES
+
+        pitcher = pitchers_by_id[pitcher_id]
+        next if pitcher.nil?
+
+        build_row(pitcher, s, plate_results_by_id)
+      end
+
+      rows.sort_by! { |row| [-row[:plate_appearances], row[:pitcher_name]] }
+
+      { rows:, total_target_pa:, min_plate_appearances: MIN_PLATE_APPEARANCES }
+    end
+
+    private
+
+    def build_row(pitcher, stats, plate_results_by_id)
+      top_result_id = stats[:result_counts].max_by { |_, c| c }&.first
+      top_result_name = plate_results_by_id[top_result_id]&.name || ''
+      {
+        pitcher_id: pitcher.id,
+        pitcher_name: pitcher.name,
+        plate_appearances: stats[:plate_appearances],
+        at_bats: stats[:at_bats],
+        hits: stats[:hits],
+        batting_average: safe_divide(stats[:hits], stats[:at_bats]),
+        top_result: top_result_name
+      }
+    end
+
+    # group(:pitcher_id, :plate_result_id, counted_in_at_bats).count から
+    # pitcher 単位の at_bats / hits / 結果別 count を 1 クエリで導出する。
+    def aggregate_stats
+      cross = filtered_scope.joins(:plate_result)
+                            .where.not(pitcher_id: nil)
+                            .group(:pitcher_id, :plate_result_id,
+                                   'plate_results.counted_in_at_bats')
+                            .count
+
+      stats = Hash.new { |h, k| h[k] = zero_stats.dup }
+      cross.each do |(pitcher_id, result_id, counted), cnt| # rubocop:disable Style/HashEachMethods
+        bucket = stats[pitcher_id]
+        bucket[:plate_appearances] += cnt
+        bucket[:at_bats] += cnt if counted
+        bucket[:hits] += cnt if HIT_RESULT_IDS.include?(result_id)
+        bucket[:result_counts][result_id] = bucket[:result_counts].fetch(result_id, 0) + cnt
+      end
+      stats
+    end
+
+    def zero_stats
+      { plate_appearances: 0, at_bats: 0, hits: 0, result_counts: {} }
+    end
+
+    def safe_divide(numerator, denominator)
+      return 0.0 if denominator.to_i.zero?
+
+      (numerator.to_f / denominator).round(3)
+    end
+
+    def filtered_scope
+      @filtered_scope ||= begin
+        scope = PlateAppearance.joins(game_result: :match_result)
+                               .where(user_id: @user_id, is_new_format: true)
+        scope = apply_year_filter(scope)
+        scope = apply_match_type_filter(scope)
+        scope = apply_season_filter(scope)
+        apply_tournament_filter(scope)
+      end
+    end
+
+    def apply_year_filter(scope)
+      return scope if @year.blank? || @year.to_s == '通算'
+
+      yr = @year.to_i
+      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
+                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+    end
+
+    def apply_match_type_filter(scope)
+      return scope if @match_type.blank? || @match_type == '全て'
+
+      scope.where(match_results: { match_type: @match_type })
+    end
+
+    def apply_season_filter(scope)
+      return scope if @season_id.blank?
+
+      scope.where(game_results: { season_id: @season_id })
+    end
+
+    def apply_tournament_filter(scope)
+      return scope if @tournament_id.blank?
+
+      scope.where(match_results: { tournament_id: @tournament_id })
+    end
+  end
+end

--- a/app/services/stats/pitcher_faceoff_aggregator.rb
+++ b/app/services/stats/pitcher_faceoff_aggregator.rb
@@ -73,7 +73,12 @@ module Stats
                                    'plate_results.counted_in_at_bats')
                             .count
 
-      stats = Hash.new { |h, k| h[k] = zero_stats.dup }
+      # Hash.new のブロックで直接ハッシュリテラルを生成し、result_counts の {}
+      # も投手ごとに独立して作られることを明示する（dup の shallow copy で
+      # 共有されないかを読み手に考えさせない）。
+      stats = Hash.new do |h, k|
+        h[k] = { plate_appearances: 0, at_bats: 0, hits: 0, result_counts: {} }
+      end
       cross.each do |(pitcher_id, result_id, counted), cnt| # rubocop:disable Style/HashEachMethods
         bucket = stats[pitcher_id]
         bucket[:plate_appearances] += cnt
@@ -82,10 +87,6 @@ module Stats
         bucket[:result_counts][result_id] = bucket[:result_counts].fetch(result_id, 0) + cnt
       end
       stats
-    end
-
-    def zero_stats
-      { plate_appearances: 0, at_bats: 0, hits: 0, result_counts: {} }
     end
 
     def safe_divide(numerator, denominator)

--- a/app/services/stats/pitcher_faceoff_aggregator.rb
+++ b/app/services/stats/pitcher_faceoff_aggregator.rb
@@ -30,7 +30,9 @@ module Stats
       stats = aggregate_stats
       total_target_pa = stats.values.sum { |s| s[:plate_appearances] }
       pitchers_by_id = Pitcher.where(id: stats.keys).index_by(&:id)
-      plate_results_by_id = PlateResult.all.index_by(&:id)
+      # AR オブジェクトを介さず id → name の Hash だけ作る。マスタ件数は少なくても
+      # 集計対象投手ごとに 1 名引くだけなので余計なオブジェクト生成を避ける。
+      plate_result_names_by_id = PlateResult.pluck(:id, :name).to_h
 
       rows = stats.filter_map do |pitcher_id, s|
         next if s[:plate_appearances] < MIN_PLATE_APPEARANCES
@@ -38,7 +40,7 @@ module Stats
         pitcher = pitchers_by_id[pitcher_id]
         next if pitcher.nil?
 
-        build_row(pitcher, s, plate_results_by_id)
+        build_row(pitcher, s, plate_result_names_by_id)
       end
 
       rows.sort_by! { |row| [-row[:plate_appearances], row[:pitcher_name]] }
@@ -48,9 +50,9 @@ module Stats
 
     private
 
-    def build_row(pitcher, stats, plate_results_by_id)
+    def build_row(pitcher, stats, plate_result_names_by_id)
       top_result_id = stats[:result_counts].max_by { |_, c| c }&.first
-      top_result_name = plate_results_by_id[top_result_id]&.name || ''
+      top_result_name = plate_result_names_by_id[top_result_id] || ''
       {
         pitcher_id: pitcher.id,
         pitcher_name: pitcher.name,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -225,6 +225,9 @@ Rails.application.routes.draw do
         get :hit_locations, on: :member
         get :out_type_breakdown, on: :member
         get :count_situations, on: :member
+        get :contact_qualities, on: :member
+        get :pitch_types, on: :member
+        get :pitcher_faceoffs, on: :member
       end
 
       resources :plate_appearances, only: %i[create update destroy] do

--- a/lib/tasks/masters.rake
+++ b/lib/tasks/masters.rake
@@ -9,6 +9,9 @@ GAME_RECORD_MASTER_TABLES = %w[
   pitch_types
   contact_qualities
   timings
+  arm_angles
+  velocity_zones
+  pitcher_styles
 ].freeze
 
 namespace :masters do

--- a/spec/requests/api/v2/stats_spec.rb
+++ b/spec/requests/api/v2/stats_spec.rb
@@ -232,4 +232,58 @@ RSpec.describe 'Api::V2::Stats', type: :request do
       end
     end
   end
+
+  describe 'GET /api/v2/stats/contact_qualities' do
+    it 'returns 401 when not authenticated' do
+      get '/api/v2/stats/contact_qualities'
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns 200 with breakdown of all 5 master categories' do
+      get('/api/v2/stats/contact_qualities', headers:)
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json).to include('breakdown', 'total')
+      expect(json['breakdown']).to be_an(Array)
+      expect(json['breakdown'].first).to include('id', 'label', 'count', 'percentage')
+    end
+  end
+
+  describe 'GET /api/v2/stats/pitch_types' do
+    it 'returns 401 when not authenticated' do
+      get '/api/v2/stats/pitch_types'
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns 200 with rows for all 10 master pitch types + total_target_pa' do
+      get('/api/v2/stats/pitch_types', headers:)
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json).to include('rows', 'total_target_pa')
+      expect(json['rows']).to be_an(Array)
+      expect(json['rows'].first).to include(
+        'id', 'label', 'at_bats', 'hits', 'total_bases',
+        'batting_average', 'slugging_percentage'
+      )
+    end
+  end
+
+  describe 'GET /api/v2/stats/pitcher_faceoffs' do
+    it 'returns 401 when not authenticated' do
+      get '/api/v2/stats/pitcher_faceoffs'
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns 200 with rows + total_target_pa + min_plate_appearances' do
+      get('/api/v2/stats/pitcher_faceoffs', headers:)
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json).to include('rows', 'total_target_pa', 'min_plate_appearances')
+      expect(json['rows']).to be_an(Array)
+      expect(json['min_plate_appearances']).to eq(3)
+    end
+  end
 end

--- a/spec/services/stats/contact_quality_aggregator_spec.rb
+++ b/spec/services/stats/contact_quality_aggregator_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Stats::ContactQualityAggregator, type: :service do
+  let(:user) { create(:user) }
+  let(:game_result) { create(:game_result, user:) }
+
+  def create_pa(contact_quality_id:, batter_box_number: nil)
+    attrs = { game_result:, user:, contact_quality_id:, is_new_format: true }
+    attrs[:batter_box_number] = batter_box_number if batter_box_number
+    create(:plate_appearance, **attrs)
+  end
+
+  describe '#call' do
+    context 'when no plate appearances' do
+      it 'returns all 5 master categories with zero count and total 0' do
+        result = described_class.new(user_id: user.id).call
+
+        aggregate_failures do
+          expect(result[:total]).to eq(0)
+          expect(result[:breakdown].pluck(:label))
+            .to contain_exactly('真芯', '先っぽ', '詰まり', '擦り', 'ドライブ')
+          expect(result[:breakdown].pluck(:count)).to all(eq(0))
+          expect(result[:breakdown].pluck(:percentage)).to all(eq(0.0))
+        end
+      end
+
+      it 'orders breakdown by display_order' do
+        result = described_class.new(user_id: user.id).call
+
+        expect(result[:breakdown].pluck(:label))
+          .to eq(%w[真芯 先っぽ 詰まり 擦り ドライブ])
+      end
+    end
+
+    context 'with mixed contact_qualities' do
+      before do
+        create_pa(contact_quality_id: 1) # 真芯
+        create_pa(contact_quality_id: 1) # 真芯
+        create_pa(contact_quality_id: 3) # 詰まり
+        # contact_quality_id NULL の旧 PA は対象外
+        create(:plate_appearance, game_result:, user:, batter_box_number: 99,
+                                  contact_quality_id: nil, is_new_format: false)
+      end
+
+      it 'aggregates count / percentage for each master entry, excluding NULL' do
+        result = described_class.new(user_id: user.id).call
+
+        true_core = result[:breakdown].find { |b| b[:label] == '真芯' }
+        jammed = result[:breakdown].find { |b| b[:label] == '詰まり' }
+        tip = result[:breakdown].find { |b| b[:label] == '先っぽ' }
+        aggregate_failures do
+          expect(result[:total]).to eq(3)
+          expect(true_core[:count]).to eq(2)
+          expect(true_core[:percentage]).to eq(66.7)
+          expect(jammed[:count]).to eq(1)
+          expect(jammed[:percentage]).to eq(33.3)
+          expect(tip[:count]).to eq(0)
+        end
+      end
+    end
+
+    context 'with year filter' do
+      before do
+        old_game = create(:game_result, user:)
+        old_game.match_result.update!(date_and_time: Time.zone.parse('2025-09-30'))
+        create(:plate_appearance, game_result: old_game, user:, batter_box_number: 1,
+                                  contact_quality_id: 1, is_new_format: true)
+
+        new_game = create(:game_result, user:)
+        new_game.match_result.update!(date_and_time: Time.zone.parse('2026-04-01'))
+        create(:plate_appearance, game_result: new_game, user:, batter_box_number: 1,
+                                  contact_quality_id: 3, is_new_format: true)
+      end
+
+      it 'only counts plate_appearances within the year' do
+        result = described_class.new(user_id: user.id, year: 2026).call
+        jammed = result[:breakdown].find { |b| b[:label] == '詰まり' }
+
+        aggregate_failures do
+          expect(result[:total]).to eq(1)
+          expect(jammed[:count]).to eq(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/stats/pitch_type_aggregator_spec.rb
+++ b/spec/services/stats/pitch_type_aggregator_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Stats::PitchTypeAggregator, type: :service do
+  # plate_result_id の SSoT は Stats::BattingAverageRecalculator::HIT_RESULT_IDS。
+  let(:single_result_id) { Stats::BattingAverageRecalculator::HIT_RESULT_IDS.first } # 7 (単打)
+  let(:double_result_id) { 8 } # 二塁打
+  let(:home_run_result_id) { 10 } # 本塁打
+  let(:strikeout_result_id) { 13 } # 三振
+
+  let(:user) { create(:user) }
+  let(:game_result) { create(:game_result, user:) }
+
+  def create_pa(pitch_type_id:, plate_result_id:, batter_box_number: nil)
+    attrs = { game_result:, user:, pitch_type_id:, plate_result_id:, is_new_format: true }
+    attrs[:batter_box_number] = batter_box_number if batter_box_number
+    create(:plate_appearance, **attrs)
+  end
+
+  describe '#call' do
+    context 'when no plate appearances' do
+      it 'returns all 10 master rows with zero stats and total_target_pa 0' do
+        result = described_class.new(user_id: user.id).call
+
+        aggregate_failures do
+          expect(result[:total_target_pa]).to eq(0)
+          expect(result[:rows].length).to eq(10)
+          expect(result[:rows].pluck(:at_bats)).to all(eq(0))
+          expect(result[:rows].pluck(:batting_average)).to all(eq(0.0))
+        end
+      end
+
+      it 'orders rows by master display_order' do
+        result = described_class.new(user_id: user.id).call
+
+        expect(result[:rows].first[:label]).to eq('ストレート系')
+        expect(result[:rows].last[:label]).to eq('チェンジアップ系')
+      end
+    end
+
+    context 'with mixed pitch_types and results' do
+      before do
+        # ストレート系 (id=1): 単打 + 三振 = 2打数 1安打
+        create_pa(pitch_type_id: 1, plate_result_id: single_result_id)
+        create_pa(pitch_type_id: 1, plate_result_id: strikeout_result_id)
+        # スライダー系 (id=5): 二塁打 + 本塁打 = 2打数 2安打 (total_bases=6)
+        create_pa(pitch_type_id: 5, plate_result_id: double_result_id)
+        create_pa(pitch_type_id: 5, plate_result_id: home_run_result_id)
+        # pitch_type_id NULL の旧 PA は対象外
+        create(:plate_appearance, game_result:, user:, batter_box_number: 99,
+                                  pitch_type_id: nil, plate_result_id: single_result_id,
+                                  is_new_format: false)
+      end
+
+      it 'aggregates at_bats / hits / total_bases / averages per pitch_type' do
+        result = described_class.new(user_id: user.id).call
+        straight = result[:rows].find { |r| r[:label] == 'ストレート系' }
+        slider = result[:rows].find { |r| r[:label] == 'スライダー系' }
+
+        aggregate_failures do
+          expect(result[:total_target_pa]).to eq(4)
+
+          expect(straight[:at_bats]).to eq(2)
+          expect(straight[:hits]).to eq(1)
+          expect(straight[:total_bases]).to eq(1)
+          expect(straight[:batting_average]).to eq(0.5)
+          expect(straight[:slugging_percentage]).to eq(0.5)
+
+          expect(slider[:at_bats]).to eq(2)
+          expect(slider[:hits]).to eq(2)
+          expect(slider[:total_bases]).to eq(6)
+          expect(slider[:batting_average]).to eq(1.0)
+          expect(slider[:slugging_percentage]).to eq(3.0)
+        end
+      end
+    end
+
+    context 'with year filter' do
+      before do
+        old_game = create(:game_result, user:)
+        old_game.match_result.update!(date_and_time: Time.zone.parse('2025-09-30'))
+        create(:plate_appearance, game_result: old_game, user:, batter_box_number: 1,
+                                  pitch_type_id: 1, plate_result_id: single_result_id,
+                                  is_new_format: true)
+
+        new_game = create(:game_result, user:)
+        new_game.match_result.update!(date_and_time: Time.zone.parse('2026-04-01'))
+        create(:plate_appearance, game_result: new_game, user:, batter_box_number: 1,
+                                  pitch_type_id: 1, plate_result_id: double_result_id,
+                                  is_new_format: true)
+      end
+
+      it 'only counts plate_appearances within the year' do
+        result = described_class.new(user_id: user.id, year: 2026).call
+        straight = result[:rows].find { |r| r[:label] == 'ストレート系' }
+
+        aggregate_failures do
+          expect(result[:total_target_pa]).to eq(1)
+          expect(straight[:at_bats]).to eq(1)
+          expect(straight[:hits]).to eq(1)
+          expect(straight[:total_bases]).to eq(2)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/stats/pitcher_faceoff_aggregator_spec.rb
+++ b/spec/services/stats/pitcher_faceoff_aggregator_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Stats::PitcherFaceoffAggregator, type: :service do
+  let(:single_result_id) { Stats::BattingAverageRecalculator::HIT_RESULT_IDS.first } # 7 (単打)
+  let(:double_result_id) { 8 } # 二塁打
+  let(:strikeout_result_id) { 13 } # 三振
+
+  let(:user) { create(:user) }
+  let(:game_result) { create(:game_result, user:) }
+
+  def create_pitcher(name)
+    Pitcher.create!(name:, created_by_user: user)
+  end
+
+  def create_pa(pitcher_id:, plate_result_id:, batter_box_number: nil)
+    attrs = { game_result:, user:, pitcher_id:, plate_result_id:, is_new_format: true }
+    attrs[:batter_box_number] = batter_box_number if batter_box_number
+    create(:plate_appearance, **attrs)
+  end
+
+  describe '#call' do
+    context 'when no plate appearances' do
+      it 'returns empty rows and zero total' do
+        result = described_class.new(user_id: user.id).call
+
+        aggregate_failures do
+          expect(result[:rows]).to eq([])
+          expect(result[:total_target_pa]).to eq(0)
+          expect(result[:min_plate_appearances]).to eq(3)
+        end
+      end
+    end
+
+    context 'with mixed pitchers above and below threshold' do
+      let!(:ace) { create_pitcher('エース投手') }
+      let!(:rookie) { create_pitcher('新人投手') }
+      let!(:onetime) { create_pitcher('1 度だけ投手') }
+
+      before do
+        # エース投手: 3 打席（単打 / 単打 / 三振） -> at=3, h=2, bavg=.667, top=単打 (=ヒット)
+        3.times do |i|
+          plate_result_id = i < 2 ? single_result_id : strikeout_result_id
+          create_pa(pitcher_id: ace.id, plate_result_id:, batter_box_number: i + 1)
+        end
+        # 新人投手: 5 打席（二塁打 / 三振 × 4） -> at=5, h=1, bavg=.200, top=三振
+        create_pa(pitcher_id: rookie.id, plate_result_id: double_result_id, batter_box_number: 10)
+        4.times do |i|
+          create_pa(pitcher_id: rookie.id, plate_result_id: strikeout_result_id,
+                    batter_box_number: 11 + i)
+        end
+        # 1 度だけ投手: 1 打席（しきい値未満で除外）
+        create_pa(pitcher_id: onetime.id, plate_result_id: single_result_id, batter_box_number: 20)
+        # pitcher_id NULL の旧 PA は対象外
+        create(:plate_appearance, game_result:, user:, batter_box_number: 99,
+                                  pitcher_id: nil, plate_result_id: single_result_id,
+                                  is_new_format: false)
+      end
+
+      it 'includes only pitchers with >= MIN_PLATE_APPEARANCES, ordered by appearances desc' do
+        result = described_class.new(user_id: user.id).call
+
+        names = result[:rows].pluck(:pitcher_name)
+        aggregate_failures do
+          # 新人 (5 PA) → エース (3 PA)。1 度だけ投手は除外
+          expect(names).to eq(%w[新人投手 エース投手])
+          expect(result[:total_target_pa]).to eq(9)
+        end
+      end
+
+      it 'computes per-pitcher batting_average and top_result correctly' do
+        result = described_class.new(user_id: user.id).call
+        rookie_row = result[:rows].find { |r| r[:pitcher_name] == '新人投手' }
+        ace_row = result[:rows].find { |r| r[:pitcher_name] == 'エース投手' }
+
+        aggregate_failures do
+          expect(rookie_row).to include(
+            plate_appearances: 5, at_bats: 5, hits: 1,
+            batting_average: 0.2, top_result: '三振'
+          )
+          expect(ace_row).to include(
+            plate_appearances: 3, at_bats: 3, hits: 2,
+            batting_average: (2.0 / 3).round(3), top_result: 'ヒット'
+          )
+        end
+      end
+    end
+
+    context 'when tied appearances, sorts by pitcher_name asc' do
+      let!(:pitcher_b) { create_pitcher('Bさん') }
+      let!(:pitcher_a) { create_pitcher('Aさん') }
+
+      before do
+        3.times do |i|
+          create_pa(pitcher_id: pitcher_b.id, plate_result_id: single_result_id,
+                    batter_box_number: i + 1)
+        end
+        3.times do |i|
+          create_pa(pitcher_id: pitcher_a.id, plate_result_id: single_result_id,
+                    batter_box_number: 10 + i)
+        end
+      end
+
+      it 'orders ties by pitcher_name ascending' do
+        result = described_class.new(user_id: user.id).call
+
+        expect(result[:rows].pluck(:pitcher_name)).to eq(%w[Aさん Bさん])
+      end
+    end
+
+    context 'with year filter' do
+      let!(:pitcher) { create_pitcher('対象投手') }
+
+      before do
+        old_game = create(:game_result, user:)
+        old_game.match_result.update!(date_and_time: Time.zone.parse('2025-09-30'))
+        3.times do |i|
+          create(:plate_appearance, game_result: old_game, user:, batter_box_number: i + 1,
+                                    pitcher_id: pitcher.id, plate_result_id: single_result_id,
+                                    is_new_format: true)
+        end
+
+        new_game = create(:game_result, user:)
+        new_game.match_result.update!(date_and_time: Time.zone.parse('2026-04-01'))
+        3.times do |i|
+          create(:plate_appearance, game_result: new_game, user:, batter_box_number: i + 1,
+                                    pitcher_id: pitcher.id, plate_result_id: double_result_id,
+                                    is_new_format: true)
+        end
+      end
+
+      it 'only counts plate_appearances within the year' do
+        result = described_class.new(user_id: user.id, year: 2026).call
+        row = result[:rows].first
+
+        aggregate_failures do
+          expect(result[:rows].length).to eq(1)
+          expect(row[:plate_appearances]).to eq(3)
+          expect(row[:hits]).to eq(3)
+          expect(row[:top_result]).to eq('二塁打')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Sub Issue ippei-shimizu/buzzbase#369 「詳細分析（C-1 コンタクト / E-1 球種別 / 対戦投手別）」の back 実装。

## 変更内容

| サービス | 役割 |
|---|---|
| `Stats::ContactQualityAggregator` 新規（C-1） | `contact_quality_id` を contact_qualities マスタの display_order 順に集計（5 カテゴリ） |
| `Stats::PitchTypeAggregator` 新規（E-1） | `pitch_type_id` を pitch_types マスタの display_order 順に at_bats / hits / total_bases / batting_average / slugging_percentage で集計（10 球種） |
| `Stats::PitcherFaceoffAggregator` 新規 | `pitcher_id` 別の対戦成績、対戦数しきい値（3 打席以上）でフィルタ、対戦数降順 + 投手名昇順ソート |

## エンドポイント

- `GET /api/v2/stats/contact_qualities`
- `GET /api/v2/stats/pitch_types`
- `GET /api/v2/stats/pitcher_faceoffs`

すべて既存と同じフィルタ（`year` / `match_type` / `season_id` / `tournament_id`）を受け取る。

## レスポンス形

```json
// contact_qualities
{ "breakdown": [{ "id": 1, "label": "真芯", "count": 10, "percentage": 33.3 }, ...], "total": 30 }

// pitch_types
{ "rows": [{ "id": 1, "label": "ストレート系", "at_bats": 12, "hits": 4, "total_bases": 7,
              "batting_average": 0.333, "slugging_percentage": 0.583 }, ...],
  "total_target_pa": 50 }

// pitcher_faceoffs
{ "rows": [{ "pitcher_id": 1, "pitcher_name": "山田太郎",
              "plate_appearances": 8, "at_bats": 7, "hits": 3,
              "batting_average": 0.429, "top_result": "ヒット" }, ...],
  "total_target_pa": 50, "min_plate_appearances": 3 }
```

## 共通方針

- `filtered_scope` 先頭に `is_new_format: true` を入れて既存 index を活用
- `where.not(contact_quality_id: nil)` / `where.not(pitch_type_id: nil)` / `where.not(pitcher_id: nil)` で必須 NULL ガード
- `filtered_scope` をメモ化
- `HIT_RESULT_IDS = ::Stats::BattingAverageRecalculator::HIT_RESULT_IDS` で SSoT 統一

## 旧データの扱い

- これら 3 カラムが NULL の旧 PA は `filtered_scope` 段階で除外
- 母数 0 のときも contact_qualities / pitch_types は全カテゴリの行を返す（フロント描画安定化）
- pitcher_faceoffs は対戦数 3 打席未満の投手を除外（UI でしきい値を明示）

## 検証

- `bundle exec rspec spec/services/stats/ spec/requests/api/v2/stats_spec.rb` 全 99 例 PASS
- `bundle exec rubocop app/services/stats/ app/controllers/api/v2/stats_controller.rb config/routes.rb spec/services/stats/ spec/requests/api/v2/stats_spec.rb` no offense
