### PR TITLE
Feature: stats 打撃 - 推移グラフ API（累積 / 月別 4 指標）

### DIFF
--- a/app/controllers/api/v2/stats_controller.rb
+++ b/app/controllers/api/v2/stats_controller.rb
@@ -62,6 +62,10 @@ module Api
         render json: Stats::ContactQualityAggregator.new(**aggregator_params).call
       end
 
+      def timing_breakdown
+        render json: Stats::TimingBreakdownAggregator.new(**aggregator_params).call
+      end
+
       def pitch_types
         render json: Stats::PitchTypeAggregator.new(**aggregator_params).call
       end

--- a/app/controllers/api/v2/stats_controller.rb
+++ b/app/controllers/api/v2/stats_controller.rb
@@ -124,6 +124,18 @@ module Api
         render json: result
       end
 
+      def batting_trend
+        result = Stats::BattingTrendAggregator.new(
+          user_id: target_user_id,
+          granularity: params[:granularity],
+          year: params[:year],
+          match_type: convert_match_type(params[:match_type]),
+          season_id: params[:season_id],
+          tournament_id: params[:tournament_id]
+        ).call
+        render json: result
+      end
+
       def contact_qualities
         result = Stats::ContactQualityAggregator.new(
           user_id: target_user_id,

--- a/app/controllers/api/v2/stats_controller.rb
+++ b/app/controllers/api/v2/stats_controller.rb
@@ -5,171 +5,86 @@ module Api
       before_action :authenticate_api_v1_user!
 
       def hit_directions
-        result = Stats::HitDirectionAggregator.new(
-          user_id: target_user_id,
-          year: params[:year],
-          match_type: convert_match_type(params[:match_type]),
-          season_id: params[:season_id],
-          tournament_id: params[:tournament_id]
-        ).call
-        render json: result
+        render json: Stats::HitDirectionAggregator.new(**aggregator_params).call
       end
 
       def plate_appearance_breakdown
-        result = Stats::PlateAppearanceBreakdownService.new(
-          user_id: target_user_id,
-          year: params[:year],
-          match_type: convert_match_type(params[:match_type]),
-          season_id: params[:season_id],
-          tournament_id: params[:tournament_id]
-        ).call
-        render json: { breakdown: result }
+        render json: { breakdown: Stats::PlateAppearanceBreakdownService.new(**aggregator_params).call }
       end
 
       def batting
-        result = Stats::BattingStatsTableService.new(
-          user_id: target_user_id,
-          mode: params[:period] || 'yearly',
-          year: params[:year],
-          season_id: params[:season_id],
-          tournament_id: params[:tournament_id]
-        ).call
-        render json: { rows: result }
+        render json: { rows: Stats::BattingStatsTableService.new(**table_params).call }
       end
 
       def pitching
-        result = Stats::PitchingStatsTableService.new(
-          user_id: target_user_id,
-          mode: params[:period] || 'yearly',
-          year: params[:year],
-          season_id: params[:season_id],
-          tournament_id: params[:tournament_id]
-        ).call
-        render json: { rows: result }
+        render json: { rows: Stats::PitchingStatsTableService.new(**table_params).call }
       end
 
       def era_trend
-        result = Stats::EraTrendService.new(
-          user_id: target_user_id,
-          year: params[:year],
-          season_id: params[:season_id],
-          tournament_id: params[:tournament_id]
-        ).call
-        render json: { trend: result }
+        render json: { trend: Stats::EraTrendService.new(**aggregator_params.except(:match_type)).call }
       end
 
       def game_summary
-        result = Stats::GameSummaryService.new(
-          user_id: target_user_id,
-          year: params[:year],
-          match_type: convert_match_type(params[:match_type]),
-          season_id: params[:season_id],
-          tournament_id: params[:tournament_id]
-        ).call
-        render json: result
+        render json: Stats::GameSummaryService.new(**aggregator_params).call
       end
 
       def headline_stats
-        result = Stats::HeadlineStatsAggregator.new(
-          user_id: target_user_id,
-          year: params[:year],
-          match_type: convert_match_type(params[:match_type]),
-          season_id: params[:season_id],
-          tournament_id: params[:tournament_id]
-        ).call
-        render json: result
+        render json: Stats::HeadlineStatsAggregator.new(**aggregator_params).call
       end
 
       def runners_situation
-        result = Stats::RunnersSituationAggregator.new(
-          user_id: target_user_id,
-          year: params[:year],
-          match_type: convert_match_type(params[:match_type]),
-          season_id: params[:season_id],
-          tournament_id: params[:tournament_id]
-        ).call
-        render json: result
+        render json: Stats::RunnersSituationAggregator.new(**aggregator_params).call
       end
 
       def hit_locations
-        result = Stats::HitLocationAggregator.new(
-          user_id: target_user_id,
-          year: params[:year],
-          match_type: convert_match_type(params[:match_type]),
-          season_id: params[:season_id],
-          tournament_id: params[:tournament_id]
-        ).call
-        render json: result
+        render json: Stats::HitLocationAggregator.new(**aggregator_params).call
       end
 
       def out_type_breakdown
-        result = Stats::OutTypeBreakdownService.new(
-          user_id: target_user_id,
-          year: params[:year],
-          match_type: convert_match_type(params[:match_type]),
-          season_id: params[:season_id],
-          tournament_id: params[:tournament_id]
-        ).call
-        render json: result
+        render json: Stats::OutTypeBreakdownService.new(**aggregator_params).call
       end
 
       def count_situations
-        result = Stats::CountSituationAggregator.new(
-          user_id: target_user_id,
-          year: params[:year],
-          match_type: convert_match_type(params[:match_type]),
-          season_id: params[:season_id],
-          tournament_id: params[:tournament_id]
-        ).call
-        render json: result
+        render json: Stats::CountSituationAggregator.new(**aggregator_params).call
       end
 
       def batting_trend
-        result = Stats::BattingTrendAggregator.new(
-          user_id: target_user_id,
-          granularity: params[:granularity],
-          year: params[:year],
-          match_type: convert_match_type(params[:match_type]),
-          season_id: params[:season_id],
-          tournament_id: params[:tournament_id]
+        render json: Stats::BattingTrendAggregator.new(
+          **aggregator_params, granularity: params[:granularity]
         ).call
-        render json: result
       end
 
       def contact_qualities
-        result = Stats::ContactQualityAggregator.new(
-          user_id: target_user_id,
-          year: params[:year],
-          match_type: convert_match_type(params[:match_type]),
-          season_id: params[:season_id],
-          tournament_id: params[:tournament_id]
-        ).call
-        render json: result
+        render json: Stats::ContactQualityAggregator.new(**aggregator_params).call
       end
 
       def pitch_types
-        result = Stats::PitchTypeAggregator.new(
-          user_id: target_user_id,
-          year: params[:year],
-          match_type: convert_match_type(params[:match_type]),
-          season_id: params[:season_id],
-          tournament_id: params[:tournament_id]
-        ).call
-        render json: result
+        render json: Stats::PitchTypeAggregator.new(**aggregator_params).call
       end
 
       def pitcher_faceoffs
-        result = Stats::PitcherFaceoffAggregator.new(
+        render json: Stats::PitcherFaceoffAggregator.new(**aggregator_params).call
+      end
+
+      private
+
+      # 各 Stats:: 系サービスが共通で受け取るパラメータ。
+      # action ごとに同じ 5 項目を毎回書くと controller が肥大化するため集約する。
+      def aggregator_params
+        {
           user_id: target_user_id,
           year: params[:year],
           match_type: convert_match_type(params[:match_type]),
           season_id: params[:season_id],
           tournament_id: params[:tournament_id]
-        ).call
-        render json: result
+        }
       end
 
-      private
+      # batting / pitching テーブル用は period (mode) を追加で受け取り、
+      # match_type は使わない（テーブルサービスのインターフェースに合わせる）。
+      def table_params
+        aggregator_params.except(:match_type).merge(mode: params[:period] || 'yearly')
+      end
 
       # 他ユーザーの成績も参照可能（公開プロフィール設計）
       # プライベートアカウント対応時はprofile_visible_to?チェックを追加する

--- a/app/controllers/api/v2/stats_controller.rb
+++ b/app/controllers/api/v2/stats_controller.rb
@@ -32,6 +32,10 @@ module Api
         render json: Stats::HeadlineStatsAggregator.new(**aggregator_params).call
       end
 
+      def additional_stats
+        render json: Stats::AdditionalStatsAggregator.new(**aggregator_params).call
+      end
+
       def runners_situation
         render json: Stats::RunnersSituationAggregator.new(**aggregator_params).call
       end

--- a/app/services/stats/additional_stats_aggregator.rb
+++ b/app/services/stats/additional_stats_aggregator.rb
@@ -75,12 +75,16 @@ module Stats
       filtered_scope.distinct.count(:game_result_id)
     end
 
+    # call 内で aggregate_stats / count_games から 2 度参照されるため、
+    # 他の Stats Aggregator と同じくメモ化してスコープ構築のコストを削る。
     def filtered_scope
-      scope = BattingAverage.joins(game_result: :match_result).where(user_id: @user_id)
-      scope = apply_year_filter(scope)
-      scope = apply_match_type_filter(scope)
-      scope = apply_season_filter(scope)
-      apply_tournament_filter(scope)
+      @filtered_scope ||= begin
+        scope = BattingAverage.joins(game_result: :match_result).where(user_id: @user_id)
+        scope = apply_year_filter(scope)
+        scope = apply_match_type_filter(scope)
+        scope = apply_season_filter(scope)
+        apply_tournament_filter(scope)
+      end
     end
 
     def apply_year_filter(scope)

--- a/app/services/stats/additional_stats_aggregator.rb
+++ b/app/services/stats/additional_stats_aggregator.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+module Stats
+  # stats 打撃の追加スタッツ（主要スタッツ以外）を返す Aggregator。
+  #
+  # HeadlineStatsAggregator が返す 8 指標（打率 / 安打 / 本塁打 / 打点 /
+  # 出塁率 / 長打率 / OPS / 打数）以外の項目を 16 個まとめて返す。
+  # マイページ / ダッシュボードの SummaryStatsTable と同じ項目を網羅する。
+  #
+  # フィルタは HeadlineStatsAggregator と同じ 5 項目（year / match_type /
+  # season_id / tournament_id）を踏襲する。
+  class AdditionalStatsAggregator
+    SUM_COLUMNS = %i[
+      plate_appearances at_bats hit total_bases
+      two_base_hit three_base_hit
+      run strike_out base_on_balls hit_by_pitch
+      sacrifice_hit sacrifice_fly stealing_base caught_stealing
+    ].freeze
+
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+      @user_id = user_id
+      @year = year
+      @match_type = match_type
+      @season_id = season_id
+      @tournament_id = tournament_id
+    end
+
+    # @return [Hash] 16 指標。母数 0 でも nil ではなく 0 / 0.0 を返す
+    def call
+      stats = aggregate_stats
+      raw_counts(stats).merge(computed_rates(stats)).merge(games: count_games)
+    end
+
+    private
+
+    def raw_counts(stats)
+      {
+        plate_appearances: stats[:plate_appearances],
+        two_base_hit: stats[:two_base_hit],
+        three_base_hit: stats[:three_base_hit],
+        total_bases: stats[:total_bases],
+        run: stats[:run],
+        strike_out: stats[:strike_out],
+        base_on_balls: stats[:base_on_balls],
+        hit_by_pitch: stats[:hit_by_pitch],
+        sacrifice_hit: stats[:sacrifice_hit],
+        sacrifice_fly: stats[:sacrifice_fly],
+        stealing_base: stats[:stealing_base],
+        caught_stealing: stats[:caught_stealing]
+      }
+    end
+
+    def computed_rates(stats)
+      at_bats = stats[:at_bats]
+      batting_average = safe_divide(stats[:hit], at_bats)
+      obp_denom = at_bats + stats[:base_on_balls] + stats[:hit_by_pitch] + stats[:sacrifice_fly]
+      obp = safe_divide(stats[:hit] + stats[:base_on_balls] + stats[:hit_by_pitch], obp_denom)
+      slg = safe_divide(stats[:total_bases], at_bats)
+      {
+        iso: round3(slg - batting_average),
+        isod: round3(obp - batting_average),
+        bb_per_k: safe_divide(stats[:base_on_balls], stats[:strike_out])
+      }
+    end
+
+    # HeadlineStatsAggregator と同じ pluck + SUM(COALESCE) パターン。
+    def aggregate_stats
+      row = filtered_scope.pick(*SUM_COLUMNS.map { |col| Arel.sql("SUM(COALESCE(#{col}, 0))") })
+      values = Array.wrap(row).map(&:to_i)
+      SUM_COLUMNS.zip(values).to_h
+    end
+
+    # 試合数は batting_averages の DISTINCT game_result_id でカウントする。
+    def count_games
+      filtered_scope.distinct.count(:game_result_id)
+    end
+
+    def filtered_scope
+      scope = BattingAverage.joins(game_result: :match_result).where(user_id: @user_id)
+      scope = apply_year_filter(scope)
+      scope = apply_match_type_filter(scope)
+      scope = apply_season_filter(scope)
+      apply_tournament_filter(scope)
+    end
+
+    def apply_year_filter(scope)
+      return scope if @year.blank? || @year.to_s == '通算'
+
+      yr = @year.to_i
+      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
+                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+    end
+
+    def apply_match_type_filter(scope)
+      return scope if @match_type.blank? || @match_type == '全て'
+
+      scope.where(match_results: { match_type: @match_type })
+    end
+
+    def apply_season_filter(scope)
+      return scope if @season_id.blank?
+
+      scope.where(game_results: { season_id: @season_id })
+    end
+
+    def apply_tournament_filter(scope)
+      return scope if @tournament_id.blank?
+
+      scope.where(match_results: { tournament_id: @tournament_id })
+    end
+
+    def safe_divide(numerator, denominator)
+      return 0.0 if denominator.to_i.zero?
+
+      round3(numerator.to_f / denominator)
+    end
+
+    def round3(value)
+      value.round(3)
+    end
+  end
+end

--- a/app/services/stats/batting_trend_aggregator.rb
+++ b/app/services/stats/batting_trend_aggregator.rb
@@ -10,13 +10,19 @@ module Stats
   #
   # granularity=game は **累積** を返す（最初の試合から各時点までの通算成績）。
   # granularity=month は **その月単独** を返す（各月でリセット）。
-  class BattingTrendAggregator
+  class BattingTrendAggregator # rubocop:disable Metrics/ClassLength
     SUM_COLUMNS = %i[at_bats hit total_bases base_on_balls hit_by_pitch sacrifice_fly].freeze
+
+    SUPPORTED_GRANULARITIES = %w[game month year recent_games].freeze
+
+    # 「直近 N 試合」モードの N。短期コンディションの可視化に使うため
+    # 10 に固定する（NPB / MLB の hot streak 表示で一般的な値）。
+    RECENT_GAMES_WINDOW = 10
 
     def initialize(user_id:, granularity: 'game', # rubocop:disable Metrics/ParameterLists
                    year: nil, match_type: nil, season_id: nil, tournament_id: nil)
       @user_id = user_id
-      @granularity = granularity.to_s == 'month' ? 'month' : 'game'
+      @granularity = SUPPORTED_GRANULARITIES.include?(granularity.to_s) ? granularity.to_s : 'game'
       @year = year
       @match_type = match_type
       @season_id = season_id
@@ -27,7 +33,12 @@ module Stats
     #   points の各要素は key / label / batting_average / on_base_percentage /
     #   slugging_percentage / ops / at_bats_in_period / cumulative_at_bats を持つ。
     def call
-      points = @granularity == 'month' ? aggregate_by_month : aggregate_by_game
+      points = case @granularity
+               when 'month' then aggregate_by_month
+               when 'year' then aggregate_by_year
+               when 'recent_games' then aggregate_by_recent_games
+               else aggregate_by_game
+               end
       { granularity: @granularity, points: }
     end
 
@@ -56,6 +67,38 @@ module Stats
           label: "#{row[:month]}月",
           period_stats: row,
           cumulative_stats: row
+        )
+      end
+    end
+
+    # 年ごとの SUM をそのまま使い、年単独の打率等を返す。
+    def aggregate_by_year
+      aggregate_per_year_rows.map do |row|
+        build_point(
+          key: row[:key],
+          label: "#{row[:year]}年",
+          period_stats: row,
+          cumulative_stats: row
+        )
+      end
+    end
+
+    # 試合別の生データから、各時点までの直近 N 試合の合計で打率等を計算する移動平均。
+    # 試合数が N に満たない序盤も、現存する試合分でそのまま計算する（NaN にしない）。
+    def aggregate_by_recent_games
+      rows = aggregate_per_game_rows
+      rows.each_with_index.map do |row, index|
+        window_start = [0, index - RECENT_GAMES_WINDOW + 1].max
+        window_rows = rows[window_start..index]
+        window_sum = SUM_COLUMNS.index_with { 0 }
+        window_rows.each { |window_row| SUM_COLUMNS.each { |col| window_sum[col] += window_row[col] } }
+
+        local_date = row[:date].in_time_zone
+        build_point(
+          key: local_date.to_date.iso8601,
+          label: local_date.strftime('%-m/%-d'),
+          period_stats: row,
+          cumulative_stats: window_sum
         )
       end
     end
@@ -89,6 +132,23 @@ module Stats
         {
           key: format('%<year>04d-%<month>02d', year: year.to_i, month: month.to_i),
           month: month.to_i,
+          year: year.to_i
+        }.merge(SUM_COLUMNS.zip(values.map(&:to_i)).to_h)
+      end
+    end
+
+    def aggregate_per_year_rows
+      year_sql = 'EXTRACT(YEAR FROM match_results.date_and_time)::int'
+      sum_sql = SUM_COLUMNS.map { |col| "SUM(COALESCE(batting_averages.#{col}, 0)) AS #{col}" }.join(', ')
+      rows = filtered_scope
+             .group(Arel.sql(year_sql))
+             .order(Arel.sql("#{year_sql} ASC"))
+             .pluck(Arel.sql("#{year_sql}, #{sum_sql}"))
+
+      rows.map do |row|
+        year, *values = row
+        {
+          key: format('%<year>04d', year: year.to_i),
           year: year.to_i
         }.merge(SUM_COLUMNS.zip(values.map(&:to_i)).to_h)
       end

--- a/app/services/stats/batting_trend_aggregator.rb
+++ b/app/services/stats/batting_trend_aggregator.rb
@@ -45,14 +45,17 @@ module Stats
     private
 
     # 各試合の SUM 列をまとめて取得 → 累積で打率等を計算。
+    # 日付は in_time_zone で Rails の TZ 設定（本番: Asia/Tokyo）に揃え、
+    # recent_games モードと同じ key / label が出るようにする。
     def aggregate_by_game
       rows = aggregate_per_game_rows
       cumulative = SUM_COLUMNS.index_with { 0 }
       rows.map do |row|
         SUM_COLUMNS.each { |col| cumulative[col] += row[col] }
+        local_date = row[:date].in_time_zone
         build_point(
-          key: row[:date].to_date.iso8601,
-          label: row[:date].strftime('%-m/%-d'),
+          key: local_date.to_date.iso8601,
+          label: local_date.strftime('%-m/%-d'),
           period_stats: row,
           cumulative_stats: cumulative
         )

--- a/app/services/stats/batting_trend_aggregator.rb
+++ b/app/services/stats/batting_trend_aggregator.rb
@@ -83,22 +83,21 @@ module Stats
       end
     end
 
-    # 試合別の生データから、各時点までの直近 N 試合の合計で打率等を計算する移動平均。
-    # 試合数が N に満たない序盤も、現存する試合分でそのまま計算する（NaN にしない）。
+    # 直近 N 試合だけを取り出し、その中で累積した打率等の推移を返す。
+    # X 軸は最大 N 点になり、ユーザーの「直近 N 試合のトレンドが見たい」という
+    # 期待と一致する（全期間の移動平均ではない）。
+    # 直近 N 試合の最初の点はサンプルが少なく荒い値になるが、これは仕様。
     def aggregate_by_recent_games
-      rows = aggregate_per_game_rows
-      rows.each_with_index.map do |row, index|
-        window_start = [0, index - RECENT_GAMES_WINDOW + 1].max
-        window_rows = rows[window_start..index]
-        window_sum = SUM_COLUMNS.index_with { 0 }
-        window_rows.each { |window_row| SUM_COLUMNS.each { |col| window_sum[col] += window_row[col] } }
-
+      recent_rows = aggregate_per_game_rows.last(RECENT_GAMES_WINDOW)
+      cumulative = SUM_COLUMNS.index_with { 0 }
+      recent_rows.map do |row|
+        SUM_COLUMNS.each { |col| cumulative[col] += row[col] }
         local_date = row[:date].in_time_zone
         build_point(
           key: local_date.to_date.iso8601,
           label: local_date.strftime('%-m/%-d'),
           period_stats: row,
-          cumulative_stats: window_sum
+          cumulative_stats: cumulative.dup
         )
       end
     end

--- a/app/services/stats/batting_trend_aggregator.rb
+++ b/app/services/stats/batting_trend_aggregator.rb
@@ -13,6 +13,11 @@ module Stats
   class BattingTrendAggregator # rubocop:disable Metrics/ClassLength
     SUM_COLUMNS = %i[at_bats hit total_bases base_on_balls hit_by_pitch sacrifice_fly].freeze
 
+    # 受け付ける granularity:
+    # - `game`: 開幕から各試合時点までの **累積**（シーズン通算の推移）
+    # - `month`: 月単独（各月でリセット）
+    # - `year`: 年単独（シーズン比較）
+    # - `recent_games`: 直近 RECENT_GAMES_WINDOW 試合だけを取り出してその中で累積
     SUPPORTED_GRANULARITIES = %w[game month year recent_games].freeze
 
     # 「直近 N 試合」モードの N。短期コンディションの可視化に使うため
@@ -100,7 +105,7 @@ module Stats
           key: local_date.to_date.iso8601,
           label: local_date.strftime('%-m/%-d'),
           period_stats: row,
-          cumulative_stats: cumulative.dup
+          cumulative_stats: cumulative
         )
       end
     end

--- a/app/services/stats/batting_trend_aggregator.rb
+++ b/app/services/stats/batting_trend_aggregator.rb
@@ -88,7 +88,7 @@ module Stats
     # 期待と一致する（全期間の移動平均ではない）。
     # 直近 N 試合の最初の点はサンプルが少なく荒い値になるが、これは仕様。
     def aggregate_by_recent_games
-      recent_rows = aggregate_per_game_rows.last(RECENT_GAMES_WINDOW)
+      recent_rows = aggregate_per_game_rows(limit: RECENT_GAMES_WINDOW)
       cumulative = SUM_COLUMNS.index_with { 0 }
       recent_rows.map do |row|
         SUM_COLUMNS.each { |col| cumulative[col] += row[col] }
@@ -102,14 +102,20 @@ module Stats
       end
     end
 
-    def aggregate_per_game_rows
-      # game_result_id 単位で SUM。同じ試合に複数 batting_averages が並ぶ場合に備えて
-      # game_result_id でグループしておく。並びは match_results.date_and_time の昇順。
+    # `limit` を渡したときは DB 側で「日付降順 LIMIT → 結果を昇順に戻す」で
+    # 直近 N 試合だけ取り出す。全試合を pluck してから Ruby で .last(N) する
+    # ナイーブ実装はユーザーのシーズンが長くなるほど無駄が増えるため避ける。
+    def aggregate_per_game_rows(limit: nil)
       sum_sql = SUM_COLUMNS.map { |col| "SUM(COALESCE(batting_averages.#{col}, 0)) AS #{col}" }.join(', ')
-      rows = filtered_scope
-             .group('game_results.id, match_results.date_and_time')
-             .order(Arel.sql('match_results.date_and_time ASC'))
-             .pluck(Arel.sql("match_results.date_and_time, #{sum_sql}"))
+      scope = filtered_scope
+              .group('game_results.id, match_results.date_and_time')
+      scope = if limit
+                scope.order(Arel.sql('match_results.date_and_time DESC')).limit(limit)
+              else
+                scope.order(Arel.sql('match_results.date_and_time ASC'))
+              end
+      rows = scope.pluck(Arel.sql("match_results.date_and_time, #{sum_sql}"))
+      rows.reverse! if limit
 
       rows.map do |row|
         date, *values = row

--- a/app/services/stats/batting_trend_aggregator.rb
+++ b/app/services/stats/batting_trend_aggregator.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+module Stats
+  # 打撃成績の推移グラフ用 Aggregator。
+  #
+  # batting_averages テーブルを試合単位 (granularity=game) もしくは
+  # 月単位 (granularity=month) で時系列集計し、各時点の打率 / OBP / SLG / OPS を返す。
+  # OBP/SLG/OPS の計算式は HeadlineStatsAggregator と同一に揃え、フロント側で
+  # 同じ計算を持つことによる端数ズレを防ぐ。
+  #
+  # granularity=game は **累積** を返す（最初の試合から各時点までの通算成績）。
+  # granularity=month は **その月単独** を返す（各月でリセット）。
+  class BattingTrendAggregator
+    SUM_COLUMNS = %i[at_bats hit total_bases base_on_balls hit_by_pitch sacrifice_fly].freeze
+
+    def initialize(user_id:, granularity: 'game', # rubocop:disable Metrics/ParameterLists
+                   year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+      @user_id = user_id
+      @granularity = granularity.to_s == 'month' ? 'month' : 'game'
+      @year = year
+      @match_type = match_type
+      @season_id = season_id
+      @tournament_id = tournament_id
+    end
+
+    # @return [Hash] granularity と points 配列。
+    #   points の各要素は key / label / batting_average / on_base_percentage /
+    #   slugging_percentage / ops / at_bats_in_period / cumulative_at_bats を持つ。
+    def call
+      points = @granularity == 'month' ? aggregate_by_month : aggregate_by_game
+      { granularity: @granularity, points: }
+    end
+
+    private
+
+    # 各試合の SUM 列をまとめて取得 → 累積で打率等を計算。
+    def aggregate_by_game
+      rows = aggregate_per_game_rows
+      cumulative = SUM_COLUMNS.index_with { 0 }
+      rows.map do |row|
+        SUM_COLUMNS.each { |col| cumulative[col] += row[col] }
+        build_point(
+          key: row[:date].to_date.iso8601,
+          label: row[:date].strftime('%-m/%-d'),
+          period_stats: row,
+          cumulative_stats: cumulative
+        )
+      end
+    end
+
+    # 月ごとの SUM をそのまま使い、月単独の打率等を返す（cumulative も月単独に合わせる）。
+    def aggregate_by_month
+      aggregate_per_month_rows.map do |row|
+        build_point(
+          key: row[:key],
+          label: "#{row[:month]}月",
+          period_stats: row,
+          cumulative_stats: row
+        )
+      end
+    end
+
+    def aggregate_per_game_rows
+      # game_result_id 単位で SUM。同じ試合に複数 batting_averages が並ぶ場合に備えて
+      # game_result_id でグループしておく。並びは match_results.date_and_time の昇順。
+      sum_sql = SUM_COLUMNS.map { |col| "SUM(COALESCE(batting_averages.#{col}, 0)) AS #{col}" }.join(', ')
+      rows = filtered_scope
+             .group('game_results.id, match_results.date_and_time')
+             .order(Arel.sql('match_results.date_and_time ASC'))
+             .pluck(Arel.sql("match_results.date_and_time, #{sum_sql}"))
+
+      rows.map do |row|
+        date, *values = row
+        { date: }.merge(SUM_COLUMNS.zip(values.map(&:to_i)).to_h)
+      end
+    end
+
+    def aggregate_per_month_rows
+      year_sql = 'EXTRACT(YEAR FROM match_results.date_and_time)::int'
+      month_sql = 'EXTRACT(MONTH FROM match_results.date_and_time)::int'
+      sum_sql = SUM_COLUMNS.map { |col| "SUM(COALESCE(batting_averages.#{col}, 0)) AS #{col}" }.join(', ')
+      rows = filtered_scope
+             .group(Arel.sql("#{year_sql}, #{month_sql}"))
+             .order(Arel.sql("#{year_sql} ASC, #{month_sql} ASC"))
+             .pluck(Arel.sql("#{year_sql}, #{month_sql}, #{sum_sql}"))
+
+      rows.map do |row|
+        year, month, *values = row
+        {
+          key: format('%<year>04d-%<month>02d', year: year.to_i, month: month.to_i),
+          month: month.to_i,
+          year: year.to_i
+        }.merge(SUM_COLUMNS.zip(values.map(&:to_i)).to_h)
+      end
+    end
+
+    def build_point(key:, label:, period_stats:, cumulative_stats:)
+      at_bats = cumulative_stats[:at_bats]
+      obp_denom = at_bats + cumulative_stats[:base_on_balls] +
+                  cumulative_stats[:hit_by_pitch] + cumulative_stats[:sacrifice_fly]
+      obp_num = cumulative_stats[:hit] + cumulative_stats[:base_on_balls] +
+                cumulative_stats[:hit_by_pitch]
+      obp = safe_divide(obp_num, obp_denom)
+      slg = safe_divide(cumulative_stats[:total_bases], at_bats)
+
+      {
+        key:,
+        label:,
+        batting_average: safe_divide(cumulative_stats[:hit], at_bats),
+        on_base_percentage: obp,
+        slugging_percentage: slg,
+        ops: round3(obp + slg),
+        at_bats_in_period: period_stats[:at_bats].to_i,
+        cumulative_at_bats: at_bats
+      }
+    end
+
+    def filtered_scope
+      @filtered_scope ||= begin
+        scope = BattingAverage.joins(game_result: :match_result).where(user_id: @user_id)
+        scope = apply_year_filter(scope)
+        scope = apply_match_type_filter(scope)
+        scope = apply_season_filter(scope)
+        apply_tournament_filter(scope)
+      end
+    end
+
+    def apply_year_filter(scope)
+      return scope if @year.blank? || @year.to_s == '通算'
+
+      yr = @year.to_i
+      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
+                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+    end
+
+    def apply_match_type_filter(scope)
+      return scope if @match_type.blank? || @match_type == '全て'
+
+      scope.where(match_results: { match_type: @match_type })
+    end
+
+    def apply_season_filter(scope)
+      return scope if @season_id.blank?
+
+      scope.where(game_results: { season_id: @season_id })
+    end
+
+    def apply_tournament_filter(scope)
+      return scope if @tournament_id.blank?
+
+      scope.where(match_results: { tournament_id: @tournament_id })
+    end
+
+    def safe_divide(numerator, denominator)
+      return 0.0 if denominator.to_i.zero?
+
+      round3(numerator.to_f / denominator)
+    end
+
+    def round3(value)
+      value.round(3)
+    end
+  end
+end

--- a/app/services/stats/timing_breakdown_aggregator.rb
+++ b/app/services/stats/timing_breakdown_aggregator.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Stats
+  # タイミング（timings マスタ）別の集計サービス。
+  #
+  # timing_id が記録された新仕様 PA を対象に、マスタ display_order 順で
+  # count / percentage を返す。母数 0 でも全 3 カテゴリの行を出してフロント側で
+  # 安定して描画できるようにする。設計は ContactQualityAggregator と同じ。
+  class TimingBreakdownAggregator
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+      @user_id = user_id
+      @year = year
+      @match_type = match_type
+      @season_id = season_id
+      @tournament_id = tournament_id
+    end
+
+    # @return [Hash] breakdown: [{ id, label, count, percentage }], total: 集計対象の総数
+    def call
+      counts_by_id = filtered_scope.where.not(timing_id: nil)
+                                   .group(:timing_id).count
+      total = counts_by_id.values.sum
+
+      breakdown = Timing.order(:display_order).map do |timing|
+        count = counts_by_id.fetch(timing.id, 0)
+        percentage = total.zero? ? 0.0 : (count.to_f / total * 100).round(1)
+        { id: timing.id, label: timing.name, count:, percentage: }
+      end
+
+      { breakdown:, total: }
+    end
+
+    private
+
+    def filtered_scope
+      @filtered_scope ||= begin
+        scope = PlateAppearance.joins(game_result: :match_result)
+                               .where(user_id: @user_id, is_new_format: true)
+        scope = apply_year_filter(scope)
+        scope = apply_match_type_filter(scope)
+        scope = apply_season_filter(scope)
+        apply_tournament_filter(scope)
+      end
+    end
+
+    def apply_year_filter(scope)
+      return scope if @year.blank? || @year.to_s == '通算'
+
+      yr = @year.to_i
+      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
+                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+    end
+
+    def apply_match_type_filter(scope)
+      return scope if @match_type.blank? || @match_type == '全て'
+
+      scope.where(match_results: { match_type: @match_type })
+    end
+
+    def apply_season_filter(scope)
+      return scope if @season_id.blank?
+
+      scope.where(game_results: { season_id: @season_id })
+    end
+
+    def apply_tournament_filter(scope)
+      return scope if @tournament_id.blank?
+
+      scope.where(match_results: { tournament_id: @tournament_id })
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -229,6 +229,7 @@ Rails.application.routes.draw do
         get :pitch_types, on: :member
         get :pitcher_faceoffs, on: :member
         get :batting_trend, on: :member
+        get :additional_stats, on: :member
       end
 
       resources :plate_appearances, only: %i[create update destroy] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -230,6 +230,7 @@ Rails.application.routes.draw do
         get :pitcher_faceoffs, on: :member
         get :batting_trend, on: :member
         get :additional_stats, on: :member
+        get :timing_breakdown, on: :member
       end
 
       resources :plate_appearances, only: %i[create update destroy] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -228,6 +228,7 @@ Rails.application.routes.draw do
         get :contact_qualities, on: :member
         get :pitch_types, on: :member
         get :pitcher_faceoffs, on: :member
+        get :batting_trend, on: :member
       end
 
       resources :plate_appearances, only: %i[create update destroy] do

--- a/spec/requests/api/v2/stats_spec.rb
+++ b/spec/requests/api/v2/stats_spec.rb
@@ -310,4 +310,24 @@ RSpec.describe 'Api::V2::Stats', type: :request do
       expect(response.parsed_body['granularity']).to eq('month')
     end
   end
+
+  describe 'GET /api/v2/stats/additional_stats' do
+    it 'returns 401 when not authenticated' do
+      get '/api/v2/stats/additional_stats'
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns 200 with 16 additional stat indicators' do
+      get('/api/v2/stats/additional_stats', headers:)
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json).to include(
+        'games', 'plate_appearances', 'two_base_hit', 'three_base_hit',
+        'total_bases', 'run', 'strike_out', 'base_on_balls', 'hit_by_pitch',
+        'sacrifice_hit', 'sacrifice_fly', 'stealing_base', 'caught_stealing',
+        'iso', 'isod', 'bb_per_k'
+      )
+    end
+  end
 end

--- a/spec/requests/api/v2/stats_spec.rb
+++ b/spec/requests/api/v2/stats_spec.rb
@@ -286,4 +286,28 @@ RSpec.describe 'Api::V2::Stats', type: :request do
       expect(json['min_plate_appearances']).to eq(3)
     end
   end
+
+  describe 'GET /api/v2/stats/batting_trend' do
+    it 'returns 401 when not authenticated' do
+      get '/api/v2/stats/batting_trend'
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns 200 with granularity (default game) + points array' do
+      get('/api/v2/stats/batting_trend', headers:)
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json).to include('granularity', 'points')
+      expect(json['granularity']).to eq('game')
+      expect(json['points']).to be_an(Array)
+    end
+
+    it 'returns granularity=month when granularity=month is requested' do
+      get('/api/v2/stats/batting_trend', headers:, params: { granularity: 'month' })
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['granularity']).to eq('month')
+    end
+  end
 end

--- a/spec/services/stats/additional_stats_aggregator_spec.rb
+++ b/spec/services/stats/additional_stats_aggregator_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Stats::AdditionalStatsAggregator, type: :service do
+  let(:user) { create(:user) }
+
+  def build_game(date: '2026-04-01 12:00:00', batting_attrs: {})
+    game_result = create(:game_result, user:)
+    game_result.match_result.update!(date_and_time: Time.zone.parse(date))
+    default_attrs = {
+      plate_appearances: 4, times_at_bat: 4, at_bats: 4,
+      hit: 1, two_base_hit: 0, three_base_hit: 0, home_run: 0, total_bases: 1,
+      runs_batted_in: 0, run: 0, strike_out: 0, base_on_balls: 0,
+      hit_by_pitch: 0, sacrifice_hit: 0, sacrifice_fly: 0,
+      stealing_base: 0, caught_stealing: 0
+    }
+    create(:batting_average, game_result:, user:, **default_attrs.merge(batting_attrs))
+    game_result
+  end
+
+  describe '#call' do
+    context 'when no games' do
+      it 'returns zero for all 16 indicators without raising' do
+        result = described_class.new(user_id: user.id).call
+
+        aggregate_failures do
+          expect(result[:games]).to eq(0)
+          expect(result[:plate_appearances]).to eq(0)
+          expect(result[:two_base_hit]).to eq(0)
+          expect(result[:three_base_hit]).to eq(0)
+          expect(result[:total_bases]).to eq(0)
+          expect(result[:run]).to eq(0)
+          expect(result[:strike_out]).to eq(0)
+          expect(result[:base_on_balls]).to eq(0)
+          expect(result[:hit_by_pitch]).to eq(0)
+          expect(result[:sacrifice_hit]).to eq(0)
+          expect(result[:sacrifice_fly]).to eq(0)
+          expect(result[:stealing_base]).to eq(0)
+          expect(result[:caught_stealing]).to eq(0)
+          expect(result[:iso]).to eq(0.0)
+          expect(result[:isod]).to eq(0.0)
+          expect(result[:bb_per_k]).to eq(0.0)
+        end
+      end
+    end
+
+    context 'when summing multiple games' do
+      before do
+        # 1試合目: 4打数 2安打 (うち1本塁打) 2打点 1四球 1得点 1三振
+        build_game(date: '2026-04-01 12:00:00', batting_attrs: {
+                     plate_appearances: 5, at_bats: 4, hit: 2,
+                     home_run: 1, total_bases: 5,
+                     runs_batted_in: 2, run: 1, strike_out: 1,
+                     base_on_balls: 1
+                   })
+        # 2試合目: 3打数 1安打 (二塁打) 1打点 1犠飛 2三振 1四球 1盗塁
+        build_game(date: '2026-04-08 12:00:00', batting_attrs: {
+                     plate_appearances: 5, at_bats: 3, hit: 1, two_base_hit: 1,
+                     total_bases: 2, runs_batted_in: 1, strike_out: 2,
+                     base_on_balls: 1, sacrifice_fly: 1, stealing_base: 1
+                   })
+      end
+
+      it 'returns aggregated counts and computed rates' do
+        result = described_class.new(user_id: user.id).call
+
+        aggregate_failures do
+          expect(result[:games]).to eq(2)
+          expect(result[:plate_appearances]).to eq(10)
+          expect(result[:two_base_hit]).to eq(1)
+          expect(result[:total_bases]).to eq(7)
+          expect(result[:run]).to eq(1)
+          expect(result[:strike_out]).to eq(3)
+          expect(result[:base_on_balls]).to eq(2)
+          expect(result[:sacrifice_fly]).to eq(1)
+          expect(result[:stealing_base]).to eq(1)
+          # 打率 = 3/7 = .429, 出塁率 = (3+2+0)/(7+2+0+1) = 5/10 = .500, 長打率 = 7/7 = 1.000
+          # ISO = 長打率 - 打率 = 1.000 - .429 = .571
+          # ISOD = 出塁率 - 打率 = .500 - .429 = .071
+          # BB/K = 2/3 = .667
+          expect(result[:iso]).to eq((1.0 - (3.0 / 7)).round(3))
+          expect(result[:isod]).to eq((0.5 - (3.0 / 7)).round(3))
+          expect(result[:bb_per_k]).to eq((2.0 / 3).round(3))
+        end
+      end
+    end
+
+    context 'with year filter' do
+      before do
+        build_game(date: '2025-09-30 12:00:00',
+                   batting_attrs: { at_bats: 4, hit: 1, total_bases: 1 })
+        build_game(date: '2026-04-01 12:00:00',
+                   batting_attrs: { at_bats: 5, hit: 2, total_bases: 2 })
+      end
+
+      it 'only counts batting_averages within the year' do
+        result = described_class.new(user_id: user.id, year: 2026).call
+
+        aggregate_failures do
+          expect(result[:games]).to eq(1)
+          expect(result[:total_bases]).to eq(2)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/stats/batting_trend_aggregator_spec.rb
+++ b/spec/services/stats/batting_trend_aggregator_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Stats::BattingTrendAggregator, type: :service do
+  let(:user) { create(:user) }
+
+  def build_game(date:, match_type: 'regular', batting_attrs: {})
+    game_result = create(:game_result, user:)
+    # 月境界をまたぐ TZ 起因の取りこぼしを避けるため、日付には明示的に 12:00:00 を付ける。
+    # 真の TZ 対応は Sub #371（stats 系の年度フィルタを Time.zone ベースに統一）の範囲。
+    parsed = Time.zone.parse(date.include?(' ') ? date : "#{date} 12:00:00")
+    game_result.match_result.update!(date_and_time: parsed, match_type:)
+    default_attrs = {
+      plate_appearances: 4, times_at_bat: 4, at_bats: 4,
+      hit: 1, two_base_hit: 0, three_base_hit: 0, home_run: 0,
+      total_bases: 1, runs_batted_in: 0, base_on_balls: 0,
+      hit_by_pitch: 0, sacrifice_fly: 0, sacrifice_hit: 0
+    }
+    create(:batting_average, game_result:, user:, **default_attrs.merge(batting_attrs))
+    game_result
+  end
+
+  describe '#call' do
+    context 'when no batting averages' do
+      it 'returns empty points' do
+        result = described_class.new(user_id: user.id).call
+
+        aggregate_failures do
+          expect(result[:granularity]).to eq('game')
+          expect(result[:points]).to eq([])
+        end
+      end
+    end
+
+    context 'with granularity=game (default, cumulative)' do
+      before do
+        # 試合 1: 4 打数 2 安打 (打率 .500)
+        build_game(date: '2026-04-01', batting_attrs: {
+                     at_bats: 4, hit: 2, total_bases: 2, base_on_balls: 0
+                   })
+        # 試合 2: 3 打数 1 安打 (累計 7-3 = .429)
+        build_game(date: '2026-04-15', batting_attrs: {
+                     at_bats: 3, hit: 1, total_bases: 2, base_on_balls: 1
+                   })
+      end
+
+      it 'returns 2 points with cumulative batting_average / OBP / SLG / OPS' do
+        result = described_class.new(user_id: user.id).call
+        points = result[:points]
+
+        aggregate_failures do
+          expect(points.length).to eq(2)
+          expect(points[0][:batting_average]).to eq((2.0 / 4).round(3))
+          expect(points[0][:cumulative_at_bats]).to eq(4)
+          expect(points[0][:at_bats_in_period]).to eq(4)
+          # 2 試合目: 累計 at_bats=7, hit=3, total_bases=4, base_on_balls=1
+          expect(points[1][:batting_average]).to eq((3.0 / 7).round(3))
+          # OBP = (3 + 1 + 0) / (7 + 1 + 0 + 0) = 4/8 = 0.5
+          expect(points[1][:on_base_percentage]).to eq(0.5)
+          # SLG = 4/7
+          expect(points[1][:slugging_percentage]).to eq((4.0 / 7).round(3))
+          # OPS = OBP + SLG
+          expect(points[1][:ops])
+            .to eq((points[1][:on_base_percentage] + points[1][:slugging_percentage]).round(3))
+          expect(points[1][:cumulative_at_bats]).to eq(7)
+          expect(points[1][:at_bats_in_period]).to eq(3)
+        end
+      end
+
+      it 'returns points sorted by date ascending' do
+        result = described_class.new(user_id: user.id).call
+        points = result[:points]
+
+        expect(points.pluck(:label)).to eq(['4/1', '4/15'])
+      end
+    end
+
+    context 'with granularity=month' do
+      before do
+        # 4 月: 4-2 (.500) + 3-1 (.333) = 7-3 (.429)
+        build_game(date: '2026-04-01', batting_attrs: { at_bats: 4, hit: 2, total_bases: 2 })
+        build_game(date: '2026-04-15', batting_attrs: { at_bats: 3, hit: 1, total_bases: 2 })
+        # 5 月: 5-3 (.600)
+        build_game(date: '2026-05-02', batting_attrs: { at_bats: 5, hit: 3, total_bases: 5 })
+      end
+
+      it 'aggregates per month and returns standalone (not cumulative) averages' do
+        result = described_class.new(user_id: user.id, granularity: 'month').call
+        points = result[:points]
+
+        aggregate_failures do
+          expect(result[:granularity]).to eq('month')
+          expect(points.length).to eq(2)
+          expect(points[0][:label]).to eq('4月')
+          expect(points[0][:batting_average]).to eq((3.0 / 7).round(3))
+          expect(points[0][:at_bats_in_period]).to eq(7)
+          expect(points[1][:label]).to eq('5月')
+          # 5 月単独 (cumulative ではなく)
+          expect(points[1][:batting_average]).to eq((3.0 / 5).round(3))
+          expect(points[1][:slugging_percentage]).to eq((5.0 / 5).round(3))
+        end
+      end
+    end
+
+    context 'with year filter' do
+      before do
+        build_game(date: '2025-09-30', batting_attrs: { at_bats: 4, hit: 1, total_bases: 1 })
+        build_game(date: '2026-04-01', batting_attrs: { at_bats: 5, hit: 2, total_bases: 2 })
+      end
+
+      it 'only includes games within the year' do
+        result = described_class.new(user_id: user.id, year: 2026).call
+
+        aggregate_failures do
+          expect(result[:points].length).to eq(1)
+          expect(result[:points].first[:label]).to eq('4/1')
+          expect(result[:points].first[:cumulative_at_bats]).to eq(5)
+        end
+      end
+    end
+
+    context 'with match_type filter' do
+      before do
+        build_game(date: '2026-04-01', match_type: 'regular',
+                   batting_attrs: { at_bats: 4, hit: 2, total_bases: 2 })
+        build_game(date: '2026-04-02', match_type: 'open',
+                   batting_attrs: { at_bats: 3, hit: 0, total_bases: 0 })
+      end
+
+      it 'only counts batting_averages whose match_results.match_type matches' do
+        result = described_class.new(user_id: user.id, match_type: 'regular').call
+
+        aggregate_failures do
+          expect(result[:points].length).to eq(1)
+          expect(result[:points].first[:cumulative_at_bats]).to eq(4)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/stats/timing_breakdown_aggregator_spec.rb
+++ b/spec/services/stats/timing_breakdown_aggregator_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Stats::TimingBreakdownAggregator, type: :service do
+  let(:user) { create(:user) }
+  let(:game_result) { create(:game_result, user:) }
+
+  def create_pa(timing_id:, batter_box_number: nil)
+    attrs = { game_result:, user:, timing_id:, is_new_format: true }
+    attrs[:batter_box_number] = batter_box_number if batter_box_number
+    create(:plate_appearance, **attrs)
+  end
+
+  describe '#call' do
+    context 'when no plate appearances' do
+      it 'returns all 3 master categories with zero count and total 0' do
+        result = described_class.new(user_id: user.id).call
+
+        aggregate_failures do
+          expect(result[:total]).to eq(0)
+          expect(result[:breakdown].pluck(:label))
+            .to contain_exactly('ドンピシャ', '泳ぎ気味', '遅れ気味')
+          expect(result[:breakdown].pluck(:count)).to all(eq(0))
+          expect(result[:breakdown].pluck(:percentage)).to all(eq(0.0))
+        end
+      end
+
+      it 'orders breakdown by display_order' do
+        result = described_class.new(user_id: user.id).call
+
+        expect(result[:breakdown].pluck(:label))
+          .to eq(%w[ドンピシャ 泳ぎ気味 遅れ気味])
+      end
+    end
+
+    context 'with mixed timings' do
+      before do
+        create_pa(timing_id: 1) # ドンピシャ
+        create_pa(timing_id: 1) # ドンピシャ
+        create_pa(timing_id: 3) # 遅れ気味
+        # timing_id NULL の旧 PA は対象外
+        create(:plate_appearance, game_result:, user:, batter_box_number: 99,
+                                  timing_id: nil, is_new_format: false)
+      end
+
+      it 'aggregates count / percentage for each master entry, excluding NULL' do
+        result = described_class.new(user_id: user.id).call
+
+        donpisha = result[:breakdown].find { |b| b[:label] == 'ドンピシャ' }
+        late = result[:breakdown].find { |b| b[:label] == '遅れ気味' }
+        early = result[:breakdown].find { |b| b[:label] == '泳ぎ気味' }
+        aggregate_failures do
+          expect(result[:total]).to eq(3)
+          expect(donpisha[:count]).to eq(2)
+          expect(donpisha[:percentage]).to eq(66.7)
+          expect(late[:count]).to eq(1)
+          expect(late[:percentage]).to eq(33.3)
+          expect(early[:count]).to eq(0)
+        end
+      end
+    end
+
+    context 'with year filter' do
+      before do
+        old_game = create(:game_result, user:)
+        old_game.match_result.update!(date_and_time: Time.zone.parse('2025-09-30'))
+        create(:plate_appearance, game_result: old_game, user:, batter_box_number: 1,
+                                  timing_id: 1, is_new_format: true)
+
+        new_game = create(:game_result, user:)
+        new_game.match_result.update!(date_and_time: Time.zone.parse('2026-04-01'))
+        create(:plate_appearance, game_result: new_game, user:, batter_box_number: 1,
+                                  timing_id: 3, is_new_format: true)
+      end
+
+      it 'only counts plate_appearances within the year' do
+        result = described_class.new(user_id: user.id, year: 2026).call
+        late = result[:breakdown].find { |b| b[:label] == '遅れ気味' }
+
+        aggregate_failures do
+          expect(result[:total]).to eq(1)
+          expect(late[:count]).to eq(1)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Sub Issue ippei-shimizu/buzzbase#370 「打撃推移グラフ + 最終配置調整」の back 実装。

## 変更内容

### `Stats::BattingTrendAggregator` 新規

| パラメータ | 値 |
|---|---|
| `granularity` | `"game"`（既定）または `"month"` |
| その他 | 既存共通フィルタ（`year` / `match_type` / `season_id` / `tournament_id`） |

| granularity | 集計 |
|---|---|
| `game` | `match_results.date_and_time ASC` で並べ、**累積**で打率 / OBP / SLG / OPS を計算 |
| `month` | `EXTRACT(MONTH FROM ...)` で月別集計、**月単独**の打率 / OBP / SLG / OPS |

OBP / SLG / OPS の計算式は `HeadlineStatsAggregator` と同一（NPB 形式）。0 除算は `safe_divide` で `0.0`、3 桁 round。

### エンドポイント

- 新規 `GET /api/v2/stats/batting_trend?granularity=game|month`

### レスポンス形

```json
{
  "granularity": "game",
  "points": [
    {
      "key": "2026-04-01",
      "label": "4/1",
      "batting_average": 0.5,
      "on_base_percentage": 0.5,
      "slugging_percentage": 0.5,
      "ops": 1.0,
      "at_bats_in_period": 4,
      "cumulative_at_bats": 4
    }
  ]
}
```

## 旧データの扱い

- `batting_averages` ベースなので **旧データも完全反映**
- 0 試合のユーザーは `points: []` を返す（フロントで「対象データなし」プレースホルダー）

## 検証

- `bundle exec rspec spec/services/stats/batting_trend_aggregator_spec.rb spec/requests/api/v2/stats_spec.rb` 全 39 例 PASS
- `bundle exec rubocop` no offense

## 既知の制約

spec の日付指定で `12:00:00` を明示するワークアラウンドを入れている（dev DB の TZ が UTC のため）。本格的な TZ 統一対応は **Sub #371（stats 系の年度フィルタを Time.zone ベースに統一）** で対応予定。
