### PR TITLE
Add: Api::V2::StatsController に非公開アカウント可視性チェックを追加

### DIFF
--- a/app/controllers/api/v2/application_controller.rb
+++ b/app/controllers/api/v2/application_controller.rb
@@ -29,10 +29,12 @@ module Api
       # @param user [User] アクセス対象のユーザー
       # @return [TrueClass, nil] 非公開で render した場合 truthy / 公開で何もしない場合 nil
       #
-      # 呼び出し側は戻り値で短絡（early return）すること:
+      # action 内で続けて render したい場合は戻り値で短絡（early return）する:
       #   return if render_forbidden_if_private!(target_user)
       #
-      # （`render` 後に追加の `render` を呼ぶと DoubleRenderError になるため）
+      # `before_action` から呼ぶ場合は、render 済みであれば Rails が後続 action を
+      # 自動で止めるため明示の `return if` は不要。いずれのケースでも、`render` 後に
+      # 追加の `render` を呼ぶと DoubleRenderError になる点に注意。
       def render_forbidden_if_private!(user)
         return if user.profile_visible_to?(current_api_v1_user)
 

--- a/app/controllers/api/v2/stats_controller.rb
+++ b/app/controllers/api/v2/stats_controller.rb
@@ -105,8 +105,8 @@ module Api
         @target_user ||= params[:user_id] ? User.find(params[:user_id]) : current_api_v1_user
       end
 
-      # 非公開アカウントの集計データ流出を防ぐ。render_forbidden_if_private!
-      # が render すると Rails の before_action 規約で後続 action は実行されない。
+      # 非公開アカウントの集計データ流出を防ぐ。before_action として使うと
+      # render 後に Rails が後続 action を自動で止めるため、明示 return は不要。
       def authorize_target_user!
         render_forbidden_if_private!(target_user)
       end

--- a/app/controllers/api/v2/stats_controller.rb
+++ b/app/controllers/api/v2/stats_controller.rb
@@ -3,6 +3,7 @@ module Api
     class StatsController < Api::V2::ApplicationController
       include MatchTypeConvertible
       before_action :authenticate_api_v1_user!
+      before_action :authorize_target_user!
 
       def hit_directions
         render json: Stats::HitDirectionAggregator.new(**aggregator_params).call
@@ -94,10 +95,18 @@ module Api
         aggregator_params.except(:match_type).merge(mode: params[:period] || 'yearly')
       end
 
-      # 他ユーザーの成績も参照可能（公開プロフィール設計）
-      # プライベートアカウント対応時はprofile_visible_to?チェックを追加する
       def target_user_id
         params[:user_id] || current_api_v1_user.id
+      end
+
+      def target_user
+        @target_user ||= User.find(target_user_id)
+      end
+
+      # 非公開アカウントの集計データ流出を防ぐ。render_forbidden_if_private!
+      # が render すると Rails の before_action 規約で後続 action は実行されない。
+      def authorize_target_user!
+        render_forbidden_if_private!(target_user)
       end
     end
   end

--- a/app/controllers/api/v2/stats_controller.rb
+++ b/app/controllers/api/v2/stats_controller.rb
@@ -99,8 +99,10 @@ module Api
         params[:user_id] || current_api_v1_user.id
       end
 
+      # 自分自身を参照するケース（user_id 未指定）が最頻のため、既に持っている
+      # current_api_v1_user を再利用して User.find の追加クエリを避ける。
       def target_user
-        @target_user ||= User.find(target_user_id)
+        @target_user ||= params[:user_id] ? User.find(params[:user_id]) : current_api_v1_user
       end
 
       # 非公開アカウントの集計データ流出を防ぐ。render_forbidden_if_private!

--- a/spec/requests/api/v2/stats_spec.rb
+++ b/spec/requests/api/v2/stats_spec.rb
@@ -330,4 +330,55 @@ RSpec.describe 'Api::V2::Stats', type: :request do
       )
     end
   end
+
+  describe '非公開アカウントの可視性ガード' do
+    let(:private_user) { create(:user, is_private: true) }
+
+    context 'when viewer is not a follower' do
+      it 'returns 403 for headline_stats' do
+        get '/api/v2/stats/headline_stats',
+            params: { user_id: private_user.id },
+            headers: auth_headers_for(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'returns 403 for batting table' do
+        get '/api/v2/stats/batting',
+            params: { user_id: private_user.id },
+            headers: auth_headers_for(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'returns 403 for era_trend' do
+        get '/api/v2/stats/era_trend',
+            params: { user_id: private_user.id },
+            headers: auth_headers_for(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'when viewer is an accepted follower' do
+      before do
+        Relationship.create!(follower: user, followed: private_user, status: :accepted)
+      end
+
+      it 'returns 200 for headline_stats' do
+        get '/api/v2/stats/headline_stats',
+            params: { user_id: private_user.id },
+            headers: auth_headers_for(user)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when target is self (private)' do
+      let(:user) { create(:user, is_private: true) }
+
+      it 'returns 200 for headline_stats' do
+        get '/api/v2/stats/headline_stats',
+            params: { user_id: user.id },
+            headers: auth_headers_for(user)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v2/stats_spec.rb
+++ b/spec/requests/api/v2/stats_spec.rb
@@ -370,6 +370,19 @@ RSpec.describe 'Api::V2::Stats', type: :request do
       end
     end
 
+    context 'when viewer has a pending follow request' do
+      before do
+        Relationship.create!(follower: user, followed: private_user, status: :pending)
+      end
+
+      it 'returns 403 for headline_stats' do
+        get '/api/v2/stats/headline_stats',
+            params: { user_id: private_user.id },
+            headers: auth_headers_for(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
     context 'when target is self (private)' do
       let(:user) { create(:user, is_private: true) }
 


### PR DESCRIPTION
## Summary

- ippei-shimizu/buzzbase#372 対応。`Api::V2::StatsController` の全 16 endpoint で他ユーザーの `user_id` を指定できるが、非公開アカウント (`is_private=true`) への可視性チェックが入っておらず、TODO コメントとして残っていた既存課題を塞ぐ。
- `before_action :authorize_target_user!` を追加し、既存の `render_forbidden_if_private!` / `User#profile_visible_to?` を流用して非公開ユーザーの集計データへのアクセスを 403 で遮断する。
- 1 箇所で集約することで、今後 stats endpoint を追加してもガードの貼り忘れが起きない構造になる。

## 変更点

- `app/controllers/api/v2/stats_controller.rb`
  - `before_action :authorize_target_user!` 追加（`authenticate_api_v1_user!` の次）
  - `target_user` / `authorize_target_user!` private メソッドを追加
  - 旧 TODO コメントを削除
- `spec/requests/api/v2/stats_spec.rb`
  - 「非公開ユーザー → 403」「accepted フォロワー → 200」「自分自身（非公開）→ 200」のケースを追加（代表 endpoint: `headline_stats` / `batting` / `era_trend`）

## 影響範囲

- 自分自身の参照（`user_id` 無し）は `profile_visible_to?(self) == true` で素通りするので既存 UX は変わらない
- 公開ユーザーへの参照も影響なし
- 存在しない `user_id` は Rails 既定の 404 ハンドラに任せる（既存挙動と一致）

## 後続（本 PR スコープ外）

- `Api::V1::StatsController` の同等ガード追加
- v2 全体の可視性監査

## Test plan

- [x] `docker compose exec back bundle exec rspec spec/requests/api/v2/stats_spec.rb` → 40 examples PASS
- [x] `docker compose exec back bundle exec rubocop app/controllers/api/v2/stats_controller.rb spec/requests/api/v2/stats_spec.rb` → 0 offenses
- [ ] devuser1（公開）でログイン → devuser8（非公開、未フォロー）の stats 任意 endpoint → 403
- [ ] devuser1 → devuser8 を accepted フォロー後、同 endpoint → 200
- [ ] devuser8 自身でログイン → 自分の stats → 200
- [ ] 既存の自分自身参照（`user_id` 無し）→ 200 で regression なし
