### PR TITLE
Refactor: stats 系の年度フィルタを Time.zone ベースに統一

### DIFF
--- a/app/services/stats/additional_stats_aggregator.rb
+++ b/app/services/stats/additional_stats_aggregator.rb
@@ -91,8 +91,8 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
-      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
+      range_start = Time.zone.local(yr, 1, 1)
+      range_end = Time.zone.local(yr + 1, 1, 1)
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
                   range_start, range_end)
     end

--- a/app/services/stats/additional_stats_aggregator.rb
+++ b/app/services/stats/additional_stats_aggregator.rb
@@ -91,8 +91,10 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
+      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
+      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+                  range_start, range_end)
     end
 
     def apply_match_type_filter(scope)

--- a/app/services/stats/batting_trend_aggregator.rb
+++ b/app/services/stats/batting_trend_aggregator.rb
@@ -202,8 +202,10 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
+      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
+      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+                  range_start, range_end)
     end
 
     def apply_match_type_filter(scope)

--- a/app/services/stats/batting_trend_aggregator.rb
+++ b/app/services/stats/batting_trend_aggregator.rb
@@ -202,8 +202,8 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
-      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
+      range_start = Time.zone.local(yr, 1, 1)
+      range_end = Time.zone.local(yr + 1, 1, 1)
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
                   range_start, range_end)
     end

--- a/app/services/stats/concerns/table_service_concern.rb
+++ b/app/services/stats/concerns/table_service_concern.rb
@@ -10,8 +10,8 @@ module Stats
       private
 
       def scope_for_year(scope, year)
-        range_start = Time.zone.local(year, 1, 1).beginning_of_day
-        range_end = Time.zone.local(year + 1, 1, 1).beginning_of_day
+        range_start = Time.zone.local(year, 1, 1)
+        range_end = Time.zone.local(year + 1, 1, 1)
         scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
                     range_start, range_end)
       end

--- a/app/services/stats/concerns/table_service_concern.rb
+++ b/app/services/stats/concerns/table_service_concern.rb
@@ -10,8 +10,10 @@ module Stats
       private
 
       def scope_for_year(scope, year)
+        range_start = Time.zone.local(year, 1, 1).beginning_of_day
+        range_end = Time.zone.local(year + 1, 1, 1).beginning_of_day
         scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                    "#{year}-01-01 00:00:00", "#{year + 1}-01-01 00:00:00")
+                    range_start, range_end)
       end
 
       def scope_for_month(scope, mon)

--- a/app/services/stats/contact_quality_aggregator.rb
+++ b/app/services/stats/contact_quality_aggregator.rb
@@ -47,8 +47,8 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
-      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
+      range_start = Time.zone.local(yr, 1, 1)
+      range_end = Time.zone.local(yr + 1, 1, 1)
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
                   range_start, range_end)
     end

--- a/app/services/stats/contact_quality_aggregator.rb
+++ b/app/services/stats/contact_quality_aggregator.rb
@@ -47,8 +47,10 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
+      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
+      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+                  range_start, range_end)
     end
 
     def apply_match_type_filter(scope)

--- a/app/services/stats/count_situation_aggregator.rb
+++ b/app/services/stats/count_situation_aggregator.rb
@@ -102,8 +102,10 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
+      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
+      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+                  range_start, range_end)
     end
 
     def apply_match_type_filter(scope)

--- a/app/services/stats/count_situation_aggregator.rb
+++ b/app/services/stats/count_situation_aggregator.rb
@@ -102,8 +102,8 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
-      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
+      range_start = Time.zone.local(yr, 1, 1)
+      range_end = Time.zone.local(yr + 1, 1, 1)
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
                   range_start, range_end)
     end

--- a/app/services/stats/era_trend_service.rb
+++ b/app/services/stats/era_trend_service.rb
@@ -45,8 +45,10 @@ module Stats
 
       if @year.present? && @year.to_s != '通算'
         yr = @year.to_i
+        range_start = Time.zone.local(yr, 1, 1).beginning_of_day
+        range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
         scope = scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                            "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+                            range_start, range_end)
       end
 
       scope = scope.where(game_results: { season_id: @season_id }) if @season_id.present?

--- a/app/services/stats/era_trend_service.rb
+++ b/app/services/stats/era_trend_service.rb
@@ -45,8 +45,8 @@ module Stats
 
       if @year.present? && @year.to_s != '通算'
         yr = @year.to_i
-        range_start = Time.zone.local(yr, 1, 1).beginning_of_day
-        range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
+        range_start = Time.zone.local(yr, 1, 1)
+        range_end = Time.zone.local(yr + 1, 1, 1)
         scope = scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
                             range_start, range_end)
       end

--- a/app/services/stats/game_summary_service.rb
+++ b/app/services/stats/game_summary_service.rb
@@ -39,8 +39,8 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
-      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
+      range_start = Time.zone.local(yr, 1, 1)
+      range_end = Time.zone.local(yr + 1, 1, 1)
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
                   range_start, range_end)
     end

--- a/app/services/stats/game_summary_service.rb
+++ b/app/services/stats/game_summary_service.rb
@@ -39,8 +39,10 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
+      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
+      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+                  range_start, range_end)
     end
 
     def apply_match_type_filter(scope)

--- a/app/services/stats/headline_stats_aggregator.rb
+++ b/app/services/stats/headline_stats_aggregator.rb
@@ -64,8 +64,10 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
+      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
+      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+                  range_start, range_end)
     end
 
     def apply_match_type_filter(scope)

--- a/app/services/stats/headline_stats_aggregator.rb
+++ b/app/services/stats/headline_stats_aggregator.rb
@@ -64,8 +64,8 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
-      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
+      range_start = Time.zone.local(yr, 1, 1)
+      range_end = Time.zone.local(yr + 1, 1, 1)
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
                   range_start, range_end)
     end

--- a/app/services/stats/hit_direction_aggregator.rb
+++ b/app/services/stats/hit_direction_aggregator.rb
@@ -167,8 +167,8 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
-      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
+      range_start = Time.zone.local(yr, 1, 1)
+      range_end = Time.zone.local(yr + 1, 1, 1)
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
                   range_start, range_end)
     end

--- a/app/services/stats/hit_direction_aggregator.rb
+++ b/app/services/stats/hit_direction_aggregator.rb
@@ -167,8 +167,10 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
+      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
+      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+                  range_start, range_end)
     end
 
     def apply_match_type_filter(scope)

--- a/app/services/stats/hit_location_aggregator.rb
+++ b/app/services/stats/hit_location_aggregator.rb
@@ -61,8 +61,10 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
+      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
+      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+                  range_start, range_end)
     end
 
     def apply_match_type_filter(scope)

--- a/app/services/stats/hit_location_aggregator.rb
+++ b/app/services/stats/hit_location_aggregator.rb
@@ -61,8 +61,8 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
-      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
+      range_start = Time.zone.local(yr, 1, 1)
+      range_end = Time.zone.local(yr + 1, 1, 1)
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
                   range_start, range_end)
     end

--- a/app/services/stats/out_type_breakdown_service.rb
+++ b/app/services/stats/out_type_breakdown_service.rb
@@ -48,8 +48,10 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
+      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
+      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+                  range_start, range_end)
     end
 
     def apply_match_type_filter(scope)

--- a/app/services/stats/out_type_breakdown_service.rb
+++ b/app/services/stats/out_type_breakdown_service.rb
@@ -48,8 +48,8 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
-      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
+      range_start = Time.zone.local(yr, 1, 1)
+      range_end = Time.zone.local(yr + 1, 1, 1)
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
                   range_start, range_end)
     end

--- a/app/services/stats/pitch_type_aggregator.rb
+++ b/app/services/stats/pitch_type_aggregator.rb
@@ -91,8 +91,8 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
-      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
+      range_start = Time.zone.local(yr, 1, 1)
+      range_end = Time.zone.local(yr + 1, 1, 1)
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
                   range_start, range_end)
     end

--- a/app/services/stats/pitch_type_aggregator.rb
+++ b/app/services/stats/pitch_type_aggregator.rb
@@ -91,8 +91,10 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
+      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
+      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+                  range_start, range_end)
     end
 
     def apply_match_type_filter(scope)

--- a/app/services/stats/pitcher_faceoff_aggregator.rb
+++ b/app/services/stats/pitcher_faceoff_aggregator.rb
@@ -110,8 +110,10 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
+      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
+      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+                  range_start, range_end)
     end
 
     def apply_match_type_filter(scope)

--- a/app/services/stats/pitcher_faceoff_aggregator.rb
+++ b/app/services/stats/pitcher_faceoff_aggregator.rb
@@ -110,8 +110,8 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
-      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
+      range_start = Time.zone.local(yr, 1, 1)
+      range_end = Time.zone.local(yr + 1, 1, 1)
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
                   range_start, range_end)
     end

--- a/app/services/stats/plate_appearance_breakdown_service.rb
+++ b/app/services/stats/plate_appearance_breakdown_service.rb
@@ -51,8 +51,8 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
-      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
+      range_start = Time.zone.local(yr, 1, 1)
+      range_end = Time.zone.local(yr + 1, 1, 1)
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
                   range_start, range_end)
     end

--- a/app/services/stats/plate_appearance_breakdown_service.rb
+++ b/app/services/stats/plate_appearance_breakdown_service.rb
@@ -51,8 +51,10 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
+      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
+      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+                  range_start, range_end)
     end
 
     def apply_match_type_filter(scope)

--- a/app/services/stats/runners_situation_aggregator.rb
+++ b/app/services/stats/runners_situation_aggregator.rb
@@ -69,8 +69,10 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
+      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
+      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+                  range_start, range_end)
     end
 
     def apply_match_type_filter(scope)

--- a/app/services/stats/runners_situation_aggregator.rb
+++ b/app/services/stats/runners_situation_aggregator.rb
@@ -69,8 +69,8 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
-      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
+      range_start = Time.zone.local(yr, 1, 1)
+      range_end = Time.zone.local(yr + 1, 1, 1)
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
                   range_start, range_end)
     end

--- a/app/services/stats/timing_breakdown_aggregator.rb
+++ b/app/services/stats/timing_breakdown_aggregator.rb
@@ -47,8 +47,8 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
-      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
+      range_start = Time.zone.local(yr, 1, 1)
+      range_end = Time.zone.local(yr + 1, 1, 1)
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
                   range_start, range_end)
     end

--- a/app/services/stats/timing_breakdown_aggregator.rb
+++ b/app/services/stats/timing_breakdown_aggregator.rb
@@ -47,8 +47,10 @@ module Stats
       return scope if @year.blank? || @year.to_s == '通算'
 
       yr = @year.to_i
+      range_start = Time.zone.local(yr, 1, 1).beginning_of_day
+      range_end = Time.zone.local(yr + 1, 1, 1).beginning_of_day
       scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  "#{yr}-01-01 00:00:00", "#{yr + 1}-01-01 00:00:00")
+                  range_start, range_end)
     end
 
     def apply_match_type_filter(scope)

--- a/spec/services/stats/headline_stats_aggregator_spec.rb
+++ b/spec/services/stats/headline_stats_aggregator_spec.rb
@@ -110,5 +110,26 @@ RSpec.describe Stats::HeadlineStatsAggregator, type: :service do
         expect(result[:hit]).to eq(2)
       end
     end
+
+    context 'with JST early-morning records around the year boundary' do
+      before do
+        build_game(date: '2026-01-01 05:00', batting_attrs: { at_bats: 4, hit: 1, total_bases: 1 })
+        build_game(date: '2025-01-01 05:00', batting_attrs: { at_bats: 3, hit: 1, total_bases: 1 })
+      end
+
+      it 'JST 2026 元日 5:00 の試合が year=2026 に含まれる' do
+        result = described_class.new(user_id: user.id, year: 2026).call
+
+        expect(result[:at_bats]).to eq(4)
+        expect(result[:hit]).to eq(1)
+      end
+
+      it 'JST 2025 元日 5:00 の試合が year=2025 に含まれる（前年に流れない）' do
+        result = described_class.new(user_id: user.id, year: 2025).call
+
+        expect(result[:at_bats]).to eq(3)
+        expect(result[:hit]).to eq(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- ippei-shimizu/buzzbase#371 対応。stats 系 Aggregator / Service の年度フィルタが、年の境界を `"#{yr}-01-01 00:00:00"` の文字列リテラルで WHERE 句に渡しており、`match_results.date_and_time`（`timestamp without time zone`、Rails が UTC 書き込み）と組み合わさることで **JST 元日 0〜9 時の試合が前年扱いになり集計から欠落するリスク**を抱えていた。
- 14 Aggregator + `EraTrendService` インラインフィルタ + `TableServiceConcern#scope_for_year` を `Time.zone.local(yr, 1, 1).beginning_of_day` ベースに統一する。`config.time_zone = 'Tokyo'` 設定済みのため、Rails が UTC に変換した上で PG に投げる挙動になり、DB の `timezone` 設定に依存せず正しい年度集計が得られる。
- 本番 DB 調査時点（2026-06-14）では JST 元日早朝の試合は過去全年で 0 件のため実害は出ていないが、年初早朝の試合が記録された瞬間に顕在化するため事前に塞ぐ。

## 変更点

### `Refactor: stats 系の年度フィルタを Time.zone ベースに統一` (4ea7f52)

- 14 Aggregator / Service の `apply_year_filter` をテンプレート置換
- `EraTrendService#base_scope` インライン年度フィルタを同様に置換
- `Stats::Concerns::TableServiceConcern#scope_for_year` を同様に置換

### `Test: JST 元日早朝の試合が当該年度フィルタに含まれることを確認するケースを追加` (959653d)

- `spec/services/stats/headline_stats_aggregator_spec.rb` に JST 2025/1/1 5:00 と 2026/1/1 5:00 のエッジケースを追加
- 全 14 Aggregator は同一テンプレートなので、代表 1 ファイルで保護

## スコープ外（本 PR では触らない）

- `TableServiceConcern#scope_for_month`（月境界）の TZ 整合 → 別 issue
- `BattingAverage#apply_filters` / `PitchingResult#apply_filters` の `Date.new` Range → モデル側で別 PR
- stats 以外の controller / model にある日付比較

## Test plan

- [x] `docker compose exec back bundle exec rspec spec/services/stats/` → 82 examples PASS（JST 元日早朝 2 ケース追加で +2）
- [x] `docker compose exec back bundle exec rubocop app/services/stats/` → 0 offenses
- [ ] stg 反映後、`year=2026` フィルタで stats タブの集計と Rails console での再計算が一致することを目視確認
- [ ] Rails console で `Stats::HeadlineStatsAggregator.new(user_id: <uid>, year: 2026).call` が JST 元日 0〜9 時の試合（手動投入）を集計に含むことを確認
