### PR TITLE
Refactor: stats 系の月境界フィルタを JST 評価に統一

### DIFF
--- a/app/services/stats/batting_stats_table_service.rb
+++ b/app/services/stats/batting_stats_table_service.rb
@@ -44,7 +44,7 @@ module Stats
     # --- yearly ---
     def yearly_rows
       scope = base_scope
-      years = scope.select(Arel.sql('DISTINCT EXTRACT(YEAR FROM match_results.date_and_time)::int AS yr'))
+      years = scope.select(Arel.sql("DISTINCT #{Stats::JstDateSql::YEAR_JST_INT_SQL} AS yr"))
                    .filter_map(&:yr).sort
 
       rows = years.map { |year| build_row(label: year.to_s, scope: scope_for_year(scope, year)) }
@@ -55,7 +55,7 @@ module Stats
     # --- monthly ---
     def monthly_rows
       scope = @year.present? ? scope_for_year(base_scope, @year.to_i) : base_scope
-      months = scope.select(Arel.sql('DISTINCT EXTRACT(MONTH FROM match_results.date_and_time)::int AS mon'))
+      months = scope.select(Arel.sql("DISTINCT #{Stats::JstDateSql::MONTH_JST_INT_SQL} AS mon"))
                     .filter_map(&:mon).sort
 
       rows = months.map { |mon| build_row(label: "#{mon}月", scope: scope_for_month(scope, mon)) }

--- a/app/services/stats/batting_trend_aggregator.rb
+++ b/app/services/stats/batting_trend_aggregator.rb
@@ -132,8 +132,8 @@ module Stats
     end
 
     def aggregate_per_month_rows
-      year_sql = 'EXTRACT(YEAR FROM match_results.date_and_time)::int'
-      month_sql = 'EXTRACT(MONTH FROM match_results.date_and_time)::int'
+      year_sql = Stats::JstDateSql::YEAR_JST_INT_SQL
+      month_sql = Stats::JstDateSql::MONTH_JST_INT_SQL
       sum_sql = SUM_COLUMNS.map { |col| "SUM(COALESCE(batting_averages.#{col}, 0)) AS #{col}" }.join(', ')
       rows = filtered_scope
              .group(Arel.sql("#{year_sql}, #{month_sql}"))
@@ -151,7 +151,7 @@ module Stats
     end
 
     def aggregate_per_year_rows
-      year_sql = 'EXTRACT(YEAR FROM match_results.date_and_time)::int'
+      year_sql = Stats::JstDateSql::YEAR_JST_INT_SQL
       sum_sql = SUM_COLUMNS.map { |col| "SUM(COALESCE(batting_averages.#{col}, 0)) AS #{col}" }.join(', ')
       rows = filtered_scope
              .group(Arel.sql(year_sql))

--- a/app/services/stats/concerns/table_service_concern.rb
+++ b/app/services/stats/concerns/table_service_concern.rb
@@ -19,11 +19,12 @@ module Stats
           year = @year.to_i
           next_month = mon == 12 ? 1 : mon + 1
           next_year = mon == 12 ? year + 1 : year
+          range_start = Time.zone.local(year, mon, 1)
+          range_end = Time.zone.local(next_year, next_month, 1)
           scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                      "#{year}-#{format('%02d', mon)}-01 00:00:00",
-                      "#{next_year}-#{format('%02d', next_month)}-01 00:00:00")
+                      range_start, range_end)
         else
-          scope.where('EXTRACT(MONTH FROM match_results.date_and_time) = ?', mon)
+          scope.where("#{Stats::JstDateSql::MONTH_JST_INT_SQL} = ?", mon)
         end
       end
 

--- a/app/services/stats/era_trend_service.rb
+++ b/app/services/stats/era_trend_service.rb
@@ -20,11 +20,11 @@ module Stats
       # 月ごとに集計（earned_run には inning_format を係数として掛けて加重する）
       monthly = scope
                 .select(Arel.sql(
-                          'EXTRACT(MONTH FROM match_results.date_and_time)::int AS month, ' \
+                          "#{Stats::JstDateSql::MONTH_JST_INT_SQL} AS month, " \
                           'SUM(pitching_results.innings_pitched) AS total_ip, ' \
                           'SUM(pitching_results.earned_run * match_results.inning_format) AS total_weighted_er'
                         ))
-                .group(Arel.sql('EXTRACT(MONTH FROM match_results.date_and_time)::int'))
+                .group(Arel.sql(Stats::JstDateSql::MONTH_JST_INT_SQL))
                 .order(Arel.sql('month'))
 
       monthly.filter_map do |r|

--- a/app/services/stats/game_summary_service.rb
+++ b/app/services/stats/game_summary_service.rb
@@ -136,8 +136,8 @@ module Stats
     # --- monthly games ---
     def monthly_games
       base_scope
-        .select(Arel.sql('EXTRACT(MONTH FROM match_results.date_and_time)::int AS month, COUNT(*) AS count'))
-        .group(Arel.sql('EXTRACT(MONTH FROM match_results.date_and_time)::int'))
+        .select(Arel.sql("#{Stats::JstDateSql::MONTH_JST_INT_SQL} AS month, COUNT(*) AS count"))
+        .group(Arel.sql(Stats::JstDateSql::MONTH_JST_INT_SQL))
         .order(Arel.sql('month'))
         .map { |r| { month: r.month, count: r.count } }
     end

--- a/app/services/stats/jst_date_sql.rb
+++ b/app/services/stats/jst_date_sql.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Stats
+  # `match_results.date_and_time` は timestamp without time zone で Rails が UTC
+  # で書き込むため、PostgreSQL の EXTRACT(YEAR/MONTH FROM ...) を素のまま使うと
+  # UTC ベースで月・年が抽出され、JST 元日早朝の試合が前年・前月にバケットされる。
+  # 各 stats Aggregator / Service で JST に揃った SQL を組み立てるための共通定数。
+  module JstDateSql
+    # AT TIME ZONE 'UTC' で unzoned timestamp を timestamptz として解釈し、
+    # AT TIME ZONE 'Asia/Tokyo' で JST 表現の timestamp without time zone に戻す。
+    DATE_AND_TIME_JST_SQL = "(match_results.date_and_time AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Tokyo'"
+    MONTH_JST_INT_SQL = "EXTRACT(MONTH FROM #{DATE_AND_TIME_JST_SQL})::int".freeze
+    YEAR_JST_INT_SQL = "EXTRACT(YEAR FROM #{DATE_AND_TIME_JST_SQL})::int".freeze
+  end
+end

--- a/app/services/stats/pitching_stats_table_service.rb
+++ b/app/services/stats/pitching_stats_table_service.rb
@@ -44,7 +44,7 @@ module Stats
     # --- yearly ---
     def yearly_rows
       scope = base_scope
-      years = scope.select(Arel.sql('DISTINCT EXTRACT(YEAR FROM match_results.date_and_time)::int AS yr'))
+      years = scope.select(Arel.sql("DISTINCT #{Stats::JstDateSql::YEAR_JST_INT_SQL} AS yr"))
                    .filter_map(&:yr).sort
 
       rows = years.map { |year| build_row(label: year.to_s, scope: scope_for_year(scope, year)) }
@@ -55,7 +55,7 @@ module Stats
     # --- monthly ---
     def monthly_rows
       scope = @year.present? ? scope_for_year(base_scope, @year.to_i) : base_scope
-      months = scope.select(Arel.sql('DISTINCT EXTRACT(MONTH FROM match_results.date_and_time)::int AS mon'))
+      months = scope.select(Arel.sql("DISTINCT #{Stats::JstDateSql::MONTH_JST_INT_SQL} AS mon"))
                     .filter_map(&:mon).sort
 
       rows = months.map { |mon| build_row(label: "#{mon}月", scope: scope_for_month(scope, mon)) }

--- a/spec/services/stats/batting_trend_aggregator_spec.rb
+++ b/spec/services/stats/batting_trend_aggregator_spec.rb
@@ -137,5 +137,28 @@ RSpec.describe Stats::BattingTrendAggregator, type: :service do
         end
       end
     end
+
+    context 'with JST early-morning records around the month boundary (granularity=month)' do
+      before do
+        # JST 2026-01-01 05:00 → UTC 2025-12-31 20:00。UTC ベース EXTRACT だと
+        # 12月扱いになるが、JST 評価では 1月にバケットされる必要がある。
+        build_game(date: '2026-01-01 05:00',
+                   batting_attrs: { at_bats: 4, hit: 1, total_bases: 1 })
+        build_game(date: '2026-02-15 12:00',
+                   batting_attrs: { at_bats: 5, hit: 2, total_bases: 2 })
+      end
+
+      it 'JST 1月1日 早朝の試合は 1月にバケットされる（12月に流れない）' do
+        result = described_class.new(user_id: user.id, granularity: 'month').call
+        points = result[:points]
+
+        aggregate_failures do
+          expect(points.length).to eq(2)
+          expect(points[0][:label]).to eq('1月')
+          expect(points[0][:at_bats_in_period]).to eq(4)
+          expect(points[1][:label]).to eq('2月')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- ippei-shimizu/buzzbase#384 対応。PR ippei-shimizu/buzzbase_back#267 のレビューで指摘された別軸の TZ 課題（月境界）に対応する。
- stats 系の月別集計が以下の 2 経路で UTC ベースに評価されており、JST 1月1日 早朝の試合が 12月にバケットされる問題があった:
  1. `TableServiceConcern#scope_for_month` の文字列リテラル比較
  2. `EXTRACT(MONTH/YEAR FROM match_results.date_and_time)` の素の SQL
- 新規モジュール `Stats::JstDateSql` に `DATE_AND_TIME_JST_SQL` / `MONTH_JST_INT_SQL` / `YEAR_JST_INT_SQL` を定数化し、対象 6 ファイルから参照する。

## 変更点

- 新規: `app/services/stats/jst_date_sql.rb` — `(date_and_time AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Tokyo'` を中核に 3 SQL 定数を定義
- `TableServiceConcern#scope_for_month`: 文字列リテラル比較を `Time.zone.local(year, mon, 1)` に置換、`EXTRACT(MONTH FROM ...)` を `MONTH_JST_INT_SQL` に統一
- `EraTrendService` / `GameSummaryService` / `BattingTrendAggregator` / `BattingStatsTableService` / `PitchingStatsTableService` の `EXTRACT(MONTH/YEAR FROM ...)` を `Stats::JstDateSql` 経由に置換
- `batting_trend_aggregator_spec.rb` に JST 1月1日 5:00 のエッジケースを追加（granularity='month' で 1月にバケットされることを保護）

## スコープ外（本 PR では触らない）

- `scope_for_year` および各 Aggregator の `apply_year_filter`（年度境界）→ PR ippei-shimizu/buzzbase_back#267 で対応中
- モデル側（`BattingAverage` / `PitchingResult`）の日付フィルタ
- stats 以外の controller / model にある日付比較

## Test plan

- [x] `docker compose exec back bundle exec rspec spec/services/stats/` → 82 examples PASS（JST 月境界 1 ケース追加で +1）
- [x] `docker compose exec back bundle exec rubocop app/services/stats/` → 0 offenses
- [ ] stg 反映後、Rails console で `Stats::BattingTrendAggregator.new(user_id: <uid>, granularity: 'month').call` が JST 1月1日 5:00 の試合（手動投入）を 1月にバケットすることを確認
- [ ] stats タブ → 月別集計（試合数 / ERA / 月別打撃テーブル）が JST 表示と一致することを目視確認

## マージ順

ippei-shimizu/buzzbase_back#267（#371 対応）と並行・独立。どちらが先にマージされても conflict は出ない設計。
