### PR TITLE
Refactor: stats Aggregator の apply_*_filter を FilterableConcern に集約

### DIFF
--- a/app/services/stats/additional_stats_aggregator.rb
+++ b/app/services/stats/additional_stats_aggregator.rb
@@ -10,6 +10,8 @@ module Stats
   # フィルタは HeadlineStatsAggregator と同じ 5 項目（year / match_type /
   # season_id / tournament_id）を踏襲する。
   class AdditionalStatsAggregator
+    include Concerns::FilterableConcern
+
     SUM_COLUMNS = %i[
       plate_appearances at_bats hit total_bases
       two_base_hit three_base_hit
@@ -85,34 +87,6 @@ module Stats
         scope = apply_season_filter(scope)
         apply_tournament_filter(scope)
       end
-    end
-
-    def apply_year_filter(scope)
-      return scope if @year.blank? || @year.to_s == '通算'
-
-      yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1)
-      range_end = Time.zone.local(yr + 1, 1, 1)
-      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  range_start, range_end)
-    end
-
-    def apply_match_type_filter(scope)
-      return scope if @match_type.blank? || @match_type == '全て'
-
-      scope.where(match_results: { match_type: @match_type })
-    end
-
-    def apply_season_filter(scope)
-      return scope if @season_id.blank?
-
-      scope.where(game_results: { season_id: @season_id })
-    end
-
-    def apply_tournament_filter(scope)
-      return scope if @tournament_id.blank?
-
-      scope.where(match_results: { tournament_id: @tournament_id })
     end
 
     def safe_divide(numerator, denominator)

--- a/app/services/stats/batting_trend_aggregator.rb
+++ b/app/services/stats/batting_trend_aggregator.rb
@@ -11,6 +11,8 @@ module Stats
   # granularity=game は **累積** を返す（最初の試合から各時点までの通算成績）。
   # granularity=month は **その月単独** を返す（各月でリセット）。
   class BattingTrendAggregator # rubocop:disable Metrics/ClassLength
+    include Concerns::FilterableConcern
+
     SUM_COLUMNS = %i[at_bats hit total_bases base_on_balls hit_by_pitch sacrifice_fly].freeze
 
     # 受け付ける granularity:
@@ -196,34 +198,6 @@ module Stats
         scope = apply_season_filter(scope)
         apply_tournament_filter(scope)
       end
-    end
-
-    def apply_year_filter(scope)
-      return scope if @year.blank? || @year.to_s == '通算'
-
-      yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1)
-      range_end = Time.zone.local(yr + 1, 1, 1)
-      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  range_start, range_end)
-    end
-
-    def apply_match_type_filter(scope)
-      return scope if @match_type.blank? || @match_type == '全て'
-
-      scope.where(match_results: { match_type: @match_type })
-    end
-
-    def apply_season_filter(scope)
-      return scope if @season_id.blank?
-
-      scope.where(game_results: { season_id: @season_id })
-    end
-
-    def apply_tournament_filter(scope)
-      return scope if @tournament_id.blank?
-
-      scope.where(match_results: { tournament_id: @tournament_id })
     end
 
     def safe_divide(numerator, denominator)

--- a/app/services/stats/concerns/filterable_concern.rb
+++ b/app/services/stats/concerns/filterable_concern.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Stats
+  module Concerns
+    # stats 系 Aggregator / Service が共通で受け取るフィルタ 4 種を提供する。
+    # include 側は `@year` / `@match_type` / `@season_id` / `@tournament_id`
+    # を `initialize` で必ずセットしている前提（未設定時は blank? で素通り）。
+    module FilterableConcern
+      extend ActiveSupport::Concern
+
+      private
+
+      def apply_year_filter(scope)
+        return scope if @year.blank? || @year.to_s == '通算'
+
+        yr = @year.to_i
+        range_start = Time.zone.local(yr, 1, 1)
+        range_end = Time.zone.local(yr + 1, 1, 1)
+        scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
+                    range_start, range_end)
+      end
+
+      def apply_match_type_filter(scope)
+        return scope if @match_type.blank? || @match_type == '全て'
+
+        scope.where(match_results: { match_type: @match_type })
+      end
+
+      def apply_season_filter(scope)
+        return scope if @season_id.blank?
+
+        scope.where(game_results: { season_id: @season_id })
+      end
+
+      def apply_tournament_filter(scope)
+        return scope if @tournament_id.blank?
+
+        scope.where(match_results: { tournament_id: @tournament_id })
+      end
+    end
+  end
+end

--- a/app/services/stats/concerns/filterable_concern.rb
+++ b/app/services/stats/concerns/filterable_concern.rb
@@ -13,9 +13,9 @@ module Stats
       def apply_year_filter(scope)
         return scope if @year.blank? || @year.to_s == '通算'
 
-        yr = @year.to_i
-        range_start = Time.zone.local(yr, 1, 1)
-        range_end = Time.zone.local(yr + 1, 1, 1)
+        year = @year.to_i
+        range_start = Time.zone.local(year, 1, 1)
+        range_end = Time.zone.local(year + 1, 1, 1)
         scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
                     range_start, range_end)
       end

--- a/app/services/stats/contact_quality_aggregator.rb
+++ b/app/services/stats/contact_quality_aggregator.rb
@@ -7,6 +7,8 @@ module Stats
   # count / percentage を返す。母数 0 でも全 5 カテゴリの行を出してフロント側で
   # 安定して描画できるようにする。
   class ContactQualityAggregator
+    include Concerns::FilterableConcern
+
     def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
       @user_id = user_id
       @year = year
@@ -41,34 +43,6 @@ module Stats
         scope = apply_season_filter(scope)
         apply_tournament_filter(scope)
       end
-    end
-
-    def apply_year_filter(scope)
-      return scope if @year.blank? || @year.to_s == '通算'
-
-      yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1)
-      range_end = Time.zone.local(yr + 1, 1, 1)
-      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  range_start, range_end)
-    end
-
-    def apply_match_type_filter(scope)
-      return scope if @match_type.blank? || @match_type == '全て'
-
-      scope.where(match_results: { match_type: @match_type })
-    end
-
-    def apply_season_filter(scope)
-      return scope if @season_id.blank?
-
-      scope.where(game_results: { season_id: @season_id })
-    end
-
-    def apply_tournament_filter(scope)
-      return scope if @tournament_id.blank?
-
-      scope.where(match_results: { tournament_id: @tournament_id })
     end
   end
 end

--- a/app/services/stats/count_situation_aggregator.rb
+++ b/app/services/stats/count_situation_aggregator.rb
@@ -11,6 +11,8 @@ module Stats
   # 母数 0 のときは batting_average を 0.0 で返し、クライアント側で
   # 「対象データなし」UI に分岐させる。
   class CountSituationAggregator
+    include Concerns::FilterableConcern
+
     HIT_RESULT_IDS = ::Stats::BattingAverageRecalculator::HIT_RESULT_IDS
 
     SITUATIONS = {
@@ -96,34 +98,6 @@ module Stats
         scope = apply_season_filter(scope)
         apply_tournament_filter(scope)
       end
-    end
-
-    def apply_year_filter(scope)
-      return scope if @year.blank? || @year.to_s == '通算'
-
-      yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1)
-      range_end = Time.zone.local(yr + 1, 1, 1)
-      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  range_start, range_end)
-    end
-
-    def apply_match_type_filter(scope)
-      return scope if @match_type.blank? || @match_type == '全て'
-
-      scope.where(match_results: { match_type: @match_type })
-    end
-
-    def apply_season_filter(scope)
-      return scope if @season_id.blank?
-
-      scope.where(game_results: { season_id: @season_id })
-    end
-
-    def apply_tournament_filter(scope)
-      return scope if @tournament_id.blank?
-
-      scope.where(match_results: { tournament_id: @tournament_id })
     end
 
     def safe_divide(numerator, denominator)

--- a/app/services/stats/era_trend_service.rb
+++ b/app/services/stats/era_trend_service.rb
@@ -44,9 +44,9 @@ module Stats
                             .where('pitching_results.innings_pitched > 0')
 
       if @year.present? && @year.to_s != '通算'
-        yr = @year.to_i
-        range_start = Time.zone.local(yr, 1, 1)
-        range_end = Time.zone.local(yr + 1, 1, 1)
+        year = @year.to_i
+        range_start = Time.zone.local(year, 1, 1)
+        range_end = Time.zone.local(year + 1, 1, 1)
         scope = scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
                             range_start, range_end)
       end

--- a/app/services/stats/game_summary_service.rb
+++ b/app/services/stats/game_summary_service.rb
@@ -2,6 +2,8 @@
 
 module Stats
   class GameSummaryService
+    include Concerns::FilterableConcern
+
     def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
       @user_id = user_id
       @year = year
@@ -33,34 +35,6 @@ module Stats
       scope = apply_match_type_filter(scope)
       scope = apply_season_filter(scope)
       apply_tournament_filter(scope)
-    end
-
-    def apply_year_filter(scope)
-      return scope if @year.blank? || @year.to_s == '通算'
-
-      yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1)
-      range_end = Time.zone.local(yr + 1, 1, 1)
-      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  range_start, range_end)
-    end
-
-    def apply_match_type_filter(scope)
-      return scope if @match_type.blank? || @match_type == '全て'
-
-      scope.where(match_results: { match_type: @match_type })
-    end
-
-    def apply_season_filter(scope)
-      return scope if @season_id.blank?
-
-      scope.where(game_results: { season_id: @season_id })
-    end
-
-    def apply_tournament_filter(scope)
-      return scope if @tournament_id.blank?
-
-      scope.where(match_results: { tournament_id: @tournament_id })
     end
 
     # --- win/loss summary ---

--- a/app/services/stats/headline_stats_aggregator.rb
+++ b/app/services/stats/headline_stats_aggregator.rb
@@ -10,6 +10,8 @@ module Stats
   # フィルタは HitDirectionAggregator と同じ 5 項目（year / match_type /
   # season_id / tournament_id）を踏襲する。
   class HeadlineStatsAggregator
+    include Concerns::FilterableConcern
+
     def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
       @user_id = user_id
       @year = year
@@ -58,34 +60,6 @@ module Stats
       scope = apply_match_type_filter(scope)
       scope = apply_season_filter(scope)
       apply_tournament_filter(scope)
-    end
-
-    def apply_year_filter(scope)
-      return scope if @year.blank? || @year.to_s == '通算'
-
-      yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1)
-      range_end = Time.zone.local(yr + 1, 1, 1)
-      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  range_start, range_end)
-    end
-
-    def apply_match_type_filter(scope)
-      return scope if @match_type.blank? || @match_type == '全て'
-
-      scope.where(match_results: { match_type: @match_type })
-    end
-
-    def apply_season_filter(scope)
-      return scope if @season_id.blank?
-
-      scope.where(game_results: { season_id: @season_id })
-    end
-
-    def apply_tournament_filter(scope)
-      return scope if @tournament_id.blank?
-
-      scope.where(match_results: { tournament_id: @tournament_id })
     end
 
     # 0 除算を 0.0 に丸めて、率指標は小数 3 桁に揃える。

--- a/app/services/stats/hit_direction_aggregator.rb
+++ b/app/services/stats/hit_direction_aggregator.rb
@@ -2,6 +2,8 @@
 
 module Stats
   class HitDirectionAggregator
+    include Concerns::FilterableConcern
+
     DIRECTION_LABELS = {
       1 => '投', 2 => '捕', 3 => '一', 4 => '二', 5 => '三',
       6 => '遊', 7 => '左線', 8 => '左', 9 => '左中',
@@ -161,34 +163,6 @@ module Stats
         scope = apply_season_filter(scope)
         apply_tournament_filter(scope)
       end
-    end
-
-    def apply_year_filter(scope)
-      return scope if @year.blank? || @year.to_s == '通算'
-
-      yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1)
-      range_end = Time.zone.local(yr + 1, 1, 1)
-      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  range_start, range_end)
-    end
-
-    def apply_match_type_filter(scope)
-      return scope if @match_type.blank? || @match_type == '全て'
-
-      scope.where(match_results: { match_type: @match_type })
-    end
-
-    def apply_season_filter(scope)
-      return scope if @season_id.blank?
-
-      scope.where(game_results: { season_id: @season_id })
-    end
-
-    def apply_tournament_filter(scope)
-      return scope if @tournament_id.blank?
-
-      scope.where(match_results: { tournament_id: @tournament_id })
     end
   end
 end

--- a/app/services/stats/hit_location_aggregator.rb
+++ b/app/services/stats/hit_location_aggregator.rb
@@ -2,6 +2,8 @@
 
 module Stats
   class HitLocationAggregator
+    include Concerns::FilterableConcern
+
     # 値の食い違いを避けるため BattingAverageRecalculator の HIT_RESULT_IDS を SSoT として参照する。
     HIT_RESULT_IDS = ::Stats::BattingAverageRecalculator::HIT_RESULT_IDS
     # PlateAppearanceBreakdownService::CATEGORIES と分類を揃える。
@@ -55,34 +57,6 @@ module Stats
       scope = apply_match_type_filter(scope)
       scope = apply_season_filter(scope)
       apply_tournament_filter(scope)
-    end
-
-    def apply_year_filter(scope)
-      return scope if @year.blank? || @year.to_s == '通算'
-
-      yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1)
-      range_end = Time.zone.local(yr + 1, 1, 1)
-      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  range_start, range_end)
-    end
-
-    def apply_match_type_filter(scope)
-      return scope if @match_type.blank? || @match_type == '全て'
-
-      scope.where(match_results: { match_type: @match_type })
-    end
-
-    def apply_season_filter(scope)
-      return scope if @season_id.blank?
-
-      scope.where(game_results: { season_id: @season_id })
-    end
-
-    def apply_tournament_filter(scope)
-      return scope if @tournament_id.blank?
-
-      scope.where(match_results: { tournament_id: @tournament_id })
     end
   end
 end

--- a/app/services/stats/out_type_breakdown_service.rb
+++ b/app/services/stats/out_type_breakdown_service.rb
@@ -2,6 +2,8 @@
 
 module Stats
   class OutTypeBreakdownService
+    include Concerns::FilterableConcern
+
     # PlateAppearance.out_types の enum 値順を SSoT として保つために、enum 定義を参照する。
     CATEGORY_LABELS = {
       'ground_ball' => 'ゴロ',
@@ -42,34 +44,6 @@ module Stats
       scope = apply_match_type_filter(scope)
       scope = apply_season_filter(scope)
       apply_tournament_filter(scope)
-    end
-
-    def apply_year_filter(scope)
-      return scope if @year.blank? || @year.to_s == '通算'
-
-      yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1)
-      range_end = Time.zone.local(yr + 1, 1, 1)
-      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  range_start, range_end)
-    end
-
-    def apply_match_type_filter(scope)
-      return scope if @match_type.blank? || @match_type == '全て'
-
-      scope.where(match_results: { match_type: @match_type })
-    end
-
-    def apply_season_filter(scope)
-      return scope if @season_id.blank?
-
-      scope.where(game_results: { season_id: @season_id })
-    end
-
-    def apply_tournament_filter(scope)
-      return scope if @tournament_id.blank?
-
-      scope.where(match_results: { tournament_id: @tournament_id })
     end
   end
 end

--- a/app/services/stats/pitch_type_aggregator.rb
+++ b/app/services/stats/pitch_type_aggregator.rb
@@ -7,6 +7,8 @@ module Stats
   # at_bats / hits / total_bases / batting_average / slugging_percentage を返す。
   # 母数 0 でも全 10 行（マスタ全件）を出してフロント側で安定して描画できるようにする。
   class PitchTypeAggregator
+    include Concerns::FilterableConcern
+
     HIT_RESULT_IDS = ::Stats::BattingAverageRecalculator::HIT_RESULT_IDS
     TOTAL_BASES_PER_RESULT = { 7 => 1, 8 => 2, 9 => 3, 10 => 4 }.freeze
 
@@ -85,34 +87,6 @@ module Stats
         scope = apply_season_filter(scope)
         apply_tournament_filter(scope)
       end
-    end
-
-    def apply_year_filter(scope)
-      return scope if @year.blank? || @year.to_s == '通算'
-
-      yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1)
-      range_end = Time.zone.local(yr + 1, 1, 1)
-      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  range_start, range_end)
-    end
-
-    def apply_match_type_filter(scope)
-      return scope if @match_type.blank? || @match_type == '全て'
-
-      scope.where(match_results: { match_type: @match_type })
-    end
-
-    def apply_season_filter(scope)
-      return scope if @season_id.blank?
-
-      scope.where(game_results: { season_id: @season_id })
-    end
-
-    def apply_tournament_filter(scope)
-      return scope if @tournament_id.blank?
-
-      scope.where(match_results: { tournament_id: @tournament_id })
     end
   end
 end

--- a/app/services/stats/pitcher_faceoff_aggregator.rb
+++ b/app/services/stats/pitcher_faceoff_aggregator.rb
@@ -8,6 +8,8 @@ module Stats
   # 最低対戦回数 MIN_PLATE_APPEARANCES（3 打席）未満の投手は除外し、
   # 対戦多い順 → 投手名昇順でソートする。
   class PitcherFaceoffAggregator
+    include Concerns::FilterableConcern
+
     HIT_RESULT_IDS = ::Stats::BattingAverageRecalculator::HIT_RESULT_IDS
 
     # しきい値未満の投手は表示に含めない。サンプルサイズの少ない打率を
@@ -104,34 +106,6 @@ module Stats
         scope = apply_season_filter(scope)
         apply_tournament_filter(scope)
       end
-    end
-
-    def apply_year_filter(scope)
-      return scope if @year.blank? || @year.to_s == '通算'
-
-      yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1)
-      range_end = Time.zone.local(yr + 1, 1, 1)
-      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  range_start, range_end)
-    end
-
-    def apply_match_type_filter(scope)
-      return scope if @match_type.blank? || @match_type == '全て'
-
-      scope.where(match_results: { match_type: @match_type })
-    end
-
-    def apply_season_filter(scope)
-      return scope if @season_id.blank?
-
-      scope.where(game_results: { season_id: @season_id })
-    end
-
-    def apply_tournament_filter(scope)
-      return scope if @tournament_id.blank?
-
-      scope.where(match_results: { tournament_id: @tournament_id })
     end
   end
 end

--- a/app/services/stats/plate_appearance_breakdown_service.rb
+++ b/app/services/stats/plate_appearance_breakdown_service.rb
@@ -2,6 +2,8 @@
 
 module Stats
   class PlateAppearanceBreakdownService
+    include Concerns::FilterableConcern
+
     CATEGORIES = {
       '単打' => [7],
       '長打' => [8, 9],
@@ -45,34 +47,6 @@ module Stats
       scope = apply_match_type_filter(scope)
       scope = apply_season_filter(scope)
       apply_tournament_filter(scope)
-    end
-
-    def apply_year_filter(scope)
-      return scope if @year.blank? || @year.to_s == '通算'
-
-      yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1)
-      range_end = Time.zone.local(yr + 1, 1, 1)
-      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  range_start, range_end)
-    end
-
-    def apply_match_type_filter(scope)
-      return scope if @match_type.blank? || @match_type == '全て'
-
-      scope.where(match_results: { match_type: @match_type })
-    end
-
-    def apply_season_filter(scope)
-      return scope if @season_id.blank?
-
-      scope.where(game_results: { season_id: @season_id })
-    end
-
-    def apply_tournament_filter(scope)
-      return scope if @tournament_id.blank?
-
-      scope.where(match_results: { tournament_id: @tournament_id })
     end
   end
 end

--- a/app/services/stats/runners_situation_aggregator.rb
+++ b/app/services/stats/runners_situation_aggregator.rb
@@ -10,6 +10,8 @@ module Stats
   # 新仕様カラム (runners_state) が必須のため、旧 PA は集計対象外。
   # 母数 0 のときも nil ではなく 0 / 0.0 を返す（クライアント側で「対象データなし」UI に分岐）。
   class RunnersSituationAggregator
+    include Concerns::FilterableConcern
+
     HIT_RESULT_IDS = ::Stats::BattingAverageRecalculator::HIT_RESULT_IDS
     DOUBLE_HIT_ID = ::Stats::BattingAverageRecalculator::DOUBLE_HIT_ID
     TRIPLE_HIT_ID = ::Stats::BattingAverageRecalculator::TRIPLE_HIT_ID
@@ -63,34 +65,6 @@ module Stats
       scope = apply_match_type_filter(scope)
       scope = apply_season_filter(scope)
       apply_tournament_filter(scope)
-    end
-
-    def apply_year_filter(scope)
-      return scope if @year.blank? || @year.to_s == '通算'
-
-      yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1)
-      range_end = Time.zone.local(yr + 1, 1, 1)
-      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  range_start, range_end)
-    end
-
-    def apply_match_type_filter(scope)
-      return scope if @match_type.blank? || @match_type == '全て'
-
-      scope.where(match_results: { match_type: @match_type })
-    end
-
-    def apply_season_filter(scope)
-      return scope if @season_id.blank?
-
-      scope.where(game_results: { season_id: @season_id })
-    end
-
-    def apply_tournament_filter(scope)
-      return scope if @tournament_id.blank?
-
-      scope.where(match_results: { tournament_id: @tournament_id })
     end
 
     def safe_divide(numerator, denominator)

--- a/app/services/stats/timing_breakdown_aggregator.rb
+++ b/app/services/stats/timing_breakdown_aggregator.rb
@@ -7,6 +7,8 @@ module Stats
   # count / percentage を返す。母数 0 でも全 3 カテゴリの行を出してフロント側で
   # 安定して描画できるようにする。設計は ContactQualityAggregator と同じ。
   class TimingBreakdownAggregator
+    include Concerns::FilterableConcern
+
     def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
       @user_id = user_id
       @year = year
@@ -41,34 +43,6 @@ module Stats
         scope = apply_season_filter(scope)
         apply_tournament_filter(scope)
       end
-    end
-
-    def apply_year_filter(scope)
-      return scope if @year.blank? || @year.to_s == '通算'
-
-      yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1)
-      range_end = Time.zone.local(yr + 1, 1, 1)
-      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  range_start, range_end)
-    end
-
-    def apply_match_type_filter(scope)
-      return scope if @match_type.blank? || @match_type == '全て'
-
-      scope.where(match_results: { match_type: @match_type })
-    end
-
-    def apply_season_filter(scope)
-      return scope if @season_id.blank?
-
-      scope.where(game_results: { season_id: @season_id })
-    end
-
-    def apply_tournament_filter(scope)
-      return scope if @tournament_id.blank?
-
-      scope.where(match_results: { tournament_id: @tournament_id })
     end
   end
 end


### PR DESCRIPTION
## Summary

- ippei-shimizu/buzzbase#385 対応。PR ippei-shimizu/buzzbase_back#267 のレビューで指摘された設計上の重複に対応する。
- 14 の Stats Aggregator / Service が `apply_year_filter` / `apply_match_type_filter` / `apply_season_filter` / `apply_tournament_filter` の 4 メソッドを完全に同一実装で重複保持しており、フィルタ仕様変更時に 14 箇所を手で揃える必要があった（実際 #371 でも 14 ファイル全部を触ることになった）。
- `Stats::Concerns::FilterableConcern` に 4 メソッドを集約し、14 Aggregator を `include` に差し替える。`@year` / `@match_type` / `@season_id` / `@tournament_id` を `initialize` で必ずセットしている前提（既存の 14 ファイルすべてで満たされている）。

## 変更点

- 新規: `app/services/stats/concerns/filterable_concern.rb` — 4 フィルタメソッドを集約。`apply_year_filter` の中身は #371 の Time.zone 化を継承
- 14 Aggregator / Service に `include Concerns::FilterableConcern` を追加し、各ファイルの 4 メソッド定義を削除

## ベース / マージ順

- base branch: `release/game-stats-202605`
- このブランチは `feature/371-year-filter-timezone`（PR #267）から派生している
  - `apply_year_filter` を Concern に集約する関係で #371 と同じ箇所を触るため、#371 をベースに乗せて conflict を回避した
  - **マージ順**: PR #267 (#371) → 本 PR の順に release ブランチへマージしてください
  - #267 が先に merge されれば、本 PR は release への fast-forward 相当（マージ後に release を pull すれば本 PR 単独の差分が見える）

## スコープ外（本 PR では触らない）

- `EraTrendService` / `BattingStatsTableService` / `PitchingStatsTableService` — フィルタシグネチャが部分的に異なる（match_type を持たない / season / tournament の扱いが違う）ため対象外
- `TableServiceConcern#scope_for_year` の Concern 統合（同じ思想だが別レイヤーなので別途）

## 差分サマリ

- 削除: 各ファイル ~28 行 × 14 = 約 392 行
- 追加: Concern 40 行 + include 1 行 × 14 = 約 54 行
- 正味: 約 -340 行

## Test plan

- [x] `docker compose exec back bundle exec rspec spec/services/stats/` → 84 examples PASS（regression なし）
- [x] `docker compose exec back bundle exec rubocop app/services/stats/` → 0 offenses
- [ ] stg 反映後、stats タブの各カード（HeadlineStats / RunnersSituation / SprayChart / HitDirectionTable 等）が year / match_type / season / tournament フィルタで正しく絞り込まれることを目視確認
