### PR TITLE
Add: 対戦投手別カードの細分化 (result_counts + 属性別サマリ endpoint)

### DIFF
--- a/app/controllers/api/v2/stats_controller.rb
+++ b/app/controllers/api/v2/stats_controller.rb
@@ -75,6 +75,10 @@ module Api
         render json: Stats::PitcherFaceoffAggregator.new(**aggregator_params).call
       end
 
+      def pitcher_attribute_summary
+        render json: Stats::PitcherAttributeSummaryAggregator.new(**aggregator_params).call
+      end
+
       private
 
       # 各 Stats:: 系サービスが共通で受け取るパラメータ。

--- a/app/services/stats/pitch_type_aggregator.rb
+++ b/app/services/stats/pitch_type_aggregator.rb
@@ -118,7 +118,7 @@ module Stats
     end
 
     def safe_divide(numerator, denominator)
-      return 0.0 if denominator.to_i.zero?
+      return 0.0 if denominator.zero?
 
       (numerator.to_f / denominator).round(3)
     end

--- a/app/services/stats/pitch_type_aggregator.rb
+++ b/app/services/stats/pitch_type_aggregator.rb
@@ -4,11 +4,21 @@ module Stats
   # 球種（pitch_types マスタ）別の打席集計サービス。
   #
   # pitch_type_id が記録された新仕様 PA を対象に、マスタ display_order 順で
-  # at_bats / hits / total_bases / batting_average / slugging_percentage を返す。
-  # 母数 0 でも全 10 行（マスタ全件）を出してフロント側で安定して描画できるようにする。
+  # plate_appearances / at_bats / hits / total_bases / 各内訳 / 打率 / OBP /
+  # SLG / OPS / result_counts を返す。母数 0 でも全 10 行（マスタ全件）を
+  # 出してフロント側で安定して描画できるようにする。
+  #
+  # mobile 側の球種別カードでは「得意 / 苦手」ハイライト表示の上、
+  # 行タップで PitcherFaceoffList と同じ詳細グリッドを展開する。
   class PitchTypeAggregator
-    HIT_RESULT_IDS = ::Stats::BattingAverageRecalculator::HIT_RESULT_IDS
-    TOTAL_BASES_PER_RESULT = { 7 => 1, 8 => 2, 9 => 3, 10 => 4 }.freeze
+    Recalc = ::Stats::BattingAverageRecalculator
+    HIT_RESULT_IDS = Recalc::HIT_RESULT_IDS
+    TOTAL_BASES_BY_RESULT_ID = {
+      Recalc::SINGLE_HIT_ID => 1,
+      Recalc::DOUBLE_HIT_ID => 2,
+      Recalc::TRIPLE_HIT_ID => 3,
+      Recalc::HOME_RUN_ID => 4
+    }.freeze
 
     def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
       @user_id = user_id
@@ -18,29 +28,61 @@ module Stats
       @tournament_id = tournament_id
     end
 
-    # @return [Hash] rows: [{ id, label, at_bats, hits, total_bases,
-    #   batting_average, slugging_percentage }], total_target_pa: 対象打席数
+    # @return [Hash] rows: [{ id, label, plate_appearances, at_bats, hits,
+    #   total_bases, base_on_balls, hit_by_pitch, sacrifice_fly,
+    #   batting_average, on_base_percentage, slugging_percentage, ops,
+    #   result_counts: [{plate_result_id, plate_result_name, count}] }],
+    #   total_target_pa: 対象打席数
     def call
       stats_by_pitch_type = aggregate_stats
       total_target_pa = filtered_scope.where.not(pitch_type_id: nil).count
+      plate_result_names_by_id = PlateResult.pluck(:id, :name).to_h
 
       rows = PitchType.order(:display_order).map do |pt|
-        stats = stats_by_pitch_type[pt.id] || zero_stats
-        {
-          id: pt.id,
-          label: pt.name,
-          at_bats: stats[:at_bats],
-          hits: stats[:hits],
-          total_bases: stats[:total_bases],
-          batting_average: safe_divide(stats[:hits], stats[:at_bats]),
-          slugging_percentage: safe_divide(stats[:total_bases], stats[:at_bats])
-        }
+        build_row(pt, stats_by_pitch_type[pt.id] || empty_bucket, plate_result_names_by_id)
       end
 
       { rows:, total_target_pa: }
     end
 
     private
+
+    def build_row(pitch_type, stats, plate_result_names_by_id)
+      at_bats = stats[:at_bats]
+      hits = stats[:hits]
+      bb = stats[:base_on_balls]
+      hbp = stats[:hit_by_pitch]
+      sf = stats[:sacrifice_fly]
+      total_bases = stats[:total_bases]
+      obp = safe_divide(hits + bb + hbp, at_bats + bb + hbp + sf)
+      slg = safe_divide(total_bases, at_bats)
+      {
+        id: pitch_type.id,
+        label: pitch_type.name,
+        plate_appearances: stats[:plate_appearances],
+        at_bats:,
+        hits:,
+        total_bases:,
+        base_on_balls: bb,
+        hit_by_pitch: hbp,
+        sacrifice_fly: sf,
+        batting_average: safe_divide(hits, at_bats),
+        on_base_percentage: obp,
+        slugging_percentage: slg,
+        ops: (obp + slg).round(3),
+        result_counts: build_result_counts(stats[:result_counts], plate_result_names_by_id)
+      }
+    end
+
+    def build_result_counts(counts, plate_result_names_by_id)
+      counts.sort_by { |id, _| id }.map do |id, count|
+        {
+          plate_result_id: id,
+          plate_result_name: plate_result_names_by_id[id] || '',
+          count:
+        }
+      end
+    end
 
     def aggregate_stats
       cross = filtered_scope.joins(:plate_result)
@@ -49,20 +91,30 @@ module Stats
                                    'plate_results.counted_in_at_bats')
                             .count
 
-      stats = Hash.new { |h, k| h[k] = zero_stats.dup }
+      stats = Hash.new { |h, k| h[k] = empty_bucket }
       cross.each do |(pitch_type_id, result_id, counted), cnt| # rubocop:disable Style/HashEachMethods
-        bucket = stats[pitch_type_id]
-        bucket[:at_bats] += cnt if counted
-        next unless HIT_RESULT_IDS.include?(result_id)
-
-        bucket[:hits] += cnt
-        bucket[:total_bases] += cnt * TOTAL_BASES_PER_RESULT.fetch(result_id, 0)
+        accumulate_into(stats[pitch_type_id], result_id, counted, cnt)
       end
       stats
     end
 
-    def zero_stats
-      { at_bats: 0, hits: 0, total_bases: 0 }
+    def accumulate_into(bucket, result_id, counted, cnt)
+      bucket[:plate_appearances] += cnt
+      bucket[:at_bats] += cnt if counted
+      bucket[:hits] += cnt if HIT_RESULT_IDS.include?(result_id)
+      bucket[:total_bases] += (TOTAL_BASES_BY_RESULT_ID[result_id] || 0) * cnt
+      bucket[:base_on_balls] += cnt if result_id == Recalc::BASE_ON_BALLS_ID
+      bucket[:hit_by_pitch] += cnt if result_id == Recalc::HIT_BY_PITCH_ID
+      bucket[:sacrifice_fly] += cnt if result_id == Recalc::SACRIFICE_FLY_ID
+      bucket[:result_counts][result_id] = bucket[:result_counts].fetch(result_id, 0) + cnt
+    end
+
+    def empty_bucket
+      {
+        plate_appearances: 0, at_bats: 0, hits: 0,
+        total_bases: 0, base_on_balls: 0, hit_by_pitch: 0, sacrifice_fly: 0,
+        result_counts: {}
+      }
     end
 
     def safe_divide(numerator, denominator)

--- a/app/services/stats/pitcher_attribute_summary_aggregator.rb
+++ b/app/services/stats/pitcher_attribute_summary_aggregator.rb
@@ -27,6 +27,10 @@ module Stats
     }.freeze
 
     THROW_HAND_LABELS = { 'right' => '対右投', 'left' => '対左投' }.freeze
+    # 利き手の並び順は「右投 → 左投」固定。Pitcher.throw_hands の enum 整数値
+    # と一致するが、enum 定義順が将来変わってもこちら側のソート意図が動かない
+    # よう定数で明示する。
+    THROW_HAND_ORDER = { 'right' => 0, 'left' => 1 }.freeze
     UNSET_LABEL = '未設定'
     UNSET_DISPLAY_ORDER = Float::INFINITY
 
@@ -216,11 +220,10 @@ module Stats
       }
     end
 
-    # right=0 / left=1 の enum 順を保ちつつ、未設定は末尾に回す。
     def display_order_for_throw_hand(key)
       return UNSET_DISPLAY_ORDER if key.nil?
 
-      Pitcher.throw_hands[key] || UNSET_DISPLAY_ORDER
+      THROW_HAND_ORDER[key] || UNSET_DISPLAY_ORDER
     end
 
     def safe_divide(numerator, denominator)

--- a/app/services/stats/pitcher_attribute_summary_aggregator.rb
+++ b/app/services/stats/pitcher_attribute_summary_aggregator.rb
@@ -113,8 +113,12 @@ module Stats
     def group_by_throw_hand(stats_by_pitcher, pitcher_attrs, ctx)
       buckets = Hash.new { |h, k| h[k] = empty_bucket }
       stats_by_pitcher.each do |pitcher_id, s|
-        key = pitcher_attrs.dig(pitcher_id, :throw_hand)
-        merge_into(buckets[key], s)
+        # 投手レコードが pluck で取れなかった場合（削除済み等）はスキップする。
+        # PitcherFaceoffAggregator と同じく、属性 nil のバケットに混入させない。
+        attrs = pitcher_attrs[pitcher_id]
+        next if attrs.nil?
+
+        merge_into(buckets[attrs[:throw_hand]], s)
       end
       finalize_throw_hand_rows(buckets, ctx)
     end
@@ -122,8 +126,10 @@ module Stats
     def group_by_master(stats_by_pitcher, pitcher_attrs, attr_key, master_index, ctx)
       buckets = Hash.new { |h, k| h[k] = empty_bucket }
       stats_by_pitcher.each do |pitcher_id, s|
-        key = pitcher_attrs.dig(pitcher_id, attr_key)
-        merge_into(buckets[key], s)
+        attrs = pitcher_attrs[pitcher_id]
+        next if attrs.nil?
+
+        merge_into(buckets[attrs[attr_key]], s)
       end
       finalize_master_rows(buckets, master_index, ctx)
     end

--- a/app/services/stats/pitcher_attribute_summary_aggregator.rb
+++ b/app/services/stats/pitcher_attribute_summary_aggregator.rb
@@ -10,13 +10,22 @@ module Stats
   # pitcher_id 付き）を踏襲し、属性ごとに plate_appearances / at_bats /
   # hits / batting_average を集計する。
   #
+  # 各バケットは PitcherFaceoffAggregator の 1 行と同じスタッツ
+  # （total_bases / BB / HBP / SF / OBP / SLG / OPS / result_counts）も
+  # 返すので、mobile 側でチップタップ展開時に同じ詳細グリッドを使える。
+  #
   # マスタが nil の投手は key: nil の「未設定」バケットに集約し、
   # mobile 側で末尾に表示する。
-  class PitcherAttributeSummaryAggregator
-    HIT_RESULT_IDS = ::Stats::BattingAverageRecalculator::HIT_RESULT_IDS
+  class PitcherAttributeSummaryAggregator # rubocop:disable Metrics/ClassLength
+    Recalc = ::Stats::BattingAverageRecalculator
+    HIT_RESULT_IDS = Recalc::HIT_RESULT_IDS
+    TOTAL_BASES_BY_RESULT_ID = {
+      Recalc::SINGLE_HIT_ID => 1,
+      Recalc::DOUBLE_HIT_ID => 2,
+      Recalc::TRIPLE_HIT_ID => 3,
+      Recalc::HOME_RUN_ID => 4
+    }.freeze
 
-    # フロントの「投手タイプ別 > 利き手」セクションは、自分の打者目線で
-    # 「対◯投」と読める表記に揃える。
     THROW_HAND_LABELS = { 'right' => '対右投', 'left' => '対左投' }.freeze
     UNSET_LABEL = '未設定'
     UNSET_DISPLAY_ORDER = Float::INFINITY
@@ -30,26 +39,34 @@ module Stats
     end
 
     # @return [Hash] by_throw_hand / by_arm_angle / by_velocity_zone / by_pitcher_style の 4 配列。
-    #   各要素: { key, label, plate_appearances, at_bats, hits, batting_average, display_order }
+    #   各要素: { key, label, plate_appearances, at_bats, hits, total_bases,
+    #             base_on_balls, hit_by_pitch, sacrifice_fly, batting_average,
+    #             on_base_percentage, slugging_percentage, ops,
+    #             result_counts: [{plate_result_id, plate_result_name, count}],
+    #             display_order }
     def call
       stats_by_pitcher = aggregate_per_pitcher
       pitcher_attrs = load_pitcher_attrs(stats_by_pitcher.keys)
       arm_angles = ArmAngle.pluck(:id, :name, :display_order).index_by(&:first)
       velocity_zones = VelocityZone.pluck(:id, :name, :display_order).index_by(&:first)
       pitcher_styles = PitcherStyle.pluck(:id, :name, :display_order).index_by(&:first)
+      plate_result_names_by_id = PlateResult.pluck(:id, :name).to_h
+
+      ctx = { plate_result_names_by_id: }
 
       {
-        by_throw_hand: group_by_throw_hand(stats_by_pitcher, pitcher_attrs),
-        by_arm_angle: group_by_master(stats_by_pitcher, pitcher_attrs, :arm_angle_id, arm_angles),
-        by_velocity_zone: group_by_master(stats_by_pitcher, pitcher_attrs, :velocity_zone_id, velocity_zones),
-        by_pitcher_style: group_by_master(stats_by_pitcher, pitcher_attrs, :pitcher_style_id, pitcher_styles)
+        by_throw_hand: group_by_throw_hand(stats_by_pitcher, pitcher_attrs, ctx),
+        by_arm_angle: group_by_master(stats_by_pitcher, pitcher_attrs, :arm_angle_id, arm_angles, ctx),
+        by_velocity_zone: group_by_master(stats_by_pitcher, pitcher_attrs, :velocity_zone_id, velocity_zones, ctx),
+        by_pitcher_style: group_by_master(stats_by_pitcher, pitcher_attrs, :pitcher_style_id, pitcher_styles, ctx)
       }
     end
 
     private
 
     # PitcherFaceoffAggregator と同形の group(:pitcher_id, ...).count を、
-    # 投手単位に畳む。
+    # 投手単位に畳む。属性別バケットでもタップ展開時に同じ詳細グリッドを
+    # 表示するため、PitcherFaceoff と同じスタッツを各 pitcher で集める。
     def aggregate_per_pitcher
       cross = filtered_scope.joins(:plate_result)
                             .where.not(pitcher_id: nil)
@@ -57,14 +74,22 @@ module Stats
                                    'plate_results.counted_in_at_bats')
                             .count
 
-      stats = Hash.new { |h, k| h[k] = { plate_appearances: 0, at_bats: 0, hits: 0 } }
+      stats = Hash.new { |h, k| h[k] = empty_bucket }
       cross.each do |(pitcher_id, result_id, counted), cnt| # rubocop:disable Style/HashEachMethods
-        bucket = stats[pitcher_id]
-        bucket[:plate_appearances] += cnt
-        bucket[:at_bats] += cnt if counted
-        bucket[:hits] += cnt if HIT_RESULT_IDS.include?(result_id)
+        accumulate_into(stats[pitcher_id], result_id, counted, cnt)
       end
       stats
+    end
+
+    def accumulate_into(bucket, result_id, counted, cnt)
+      bucket[:plate_appearances] += cnt
+      bucket[:at_bats] += cnt if counted
+      bucket[:hits] += cnt if HIT_RESULT_IDS.include?(result_id)
+      bucket[:total_bases] += (TOTAL_BASES_BY_RESULT_ID[result_id] || 0) * cnt
+      bucket[:base_on_balls] += cnt if result_id == Recalc::BASE_ON_BALLS_ID
+      bucket[:hit_by_pitch] += cnt if result_id == Recalc::HIT_BY_PITCH_ID
+      bucket[:sacrifice_fly] += cnt if result_id == Recalc::SACRIFICE_FLY_ID
+      bucket[:result_counts][result_id] = bucket[:result_counts].fetch(result_id, 0) + cnt
     end
 
     # pitcher_id → 属性 4 種を一括取得する。集計対象の投手数だけ pluck するので
@@ -85,65 +110,104 @@ module Stats
       end
     end
 
-    def group_by_throw_hand(stats_by_pitcher, pitcher_attrs)
+    def group_by_throw_hand(stats_by_pitcher, pitcher_attrs, ctx)
       buckets = Hash.new { |h, k| h[k] = empty_bucket }
       stats_by_pitcher.each do |pitcher_id, s|
         key = pitcher_attrs.dig(pitcher_id, :throw_hand)
         merge_into(buckets[key], s)
       end
-      finalize_throw_hand_rows(buckets)
+      finalize_throw_hand_rows(buckets, ctx)
     end
 
-    def group_by_master(stats_by_pitcher, pitcher_attrs, attr_key, master_index)
+    def group_by_master(stats_by_pitcher, pitcher_attrs, attr_key, master_index, ctx)
       buckets = Hash.new { |h, k| h[k] = empty_bucket }
       stats_by_pitcher.each do |pitcher_id, s|
         key = pitcher_attrs.dig(pitcher_id, attr_key)
         merge_into(buckets[key], s)
       end
-      finalize_master_rows(buckets, master_index)
+      finalize_master_rows(buckets, master_index, ctx)
     end
 
-    def finalize_throw_hand_rows(buckets)
+    def finalize_throw_hand_rows(buckets, ctx)
       rows = buckets.map do |key, bucket|
         label = key.nil? ? UNSET_LABEL : (THROW_HAND_LABELS[key] || key.to_s)
         display_order = display_order_for_throw_hand(key)
-        build_bucket_row(key:, label:, display_order:, bucket:)
+        build_bucket_row(key:, label:, display_order:, bucket:, ctx:)
       end
       rows.sort_by { |row| [row[:display_order], row[:label]] }
     end
 
-    def finalize_master_rows(buckets, master_index)
+    def finalize_master_rows(buckets, master_index, ctx)
       rows = buckets.map do |key, bucket|
         if key.nil?
-          build_bucket_row(key: nil, label: UNSET_LABEL, display_order: UNSET_DISPLAY_ORDER, bucket:)
+          build_bucket_row(key: nil, label: UNSET_LABEL, display_order: UNSET_DISPLAY_ORDER, bucket:, ctx:)
         else
           _, name, display_order = master_index[key]
-          build_bucket_row(key:, label: name || UNSET_LABEL, display_order: display_order || UNSET_DISPLAY_ORDER, bucket:)
+          build_bucket_row(key:, label: name || UNSET_LABEL,
+                           display_order: display_order || UNSET_DISPLAY_ORDER,
+                           bucket:, ctx:)
         end
       end
       rows.sort_by { |row| [row[:display_order], row[:label]] }
     end
 
-    def build_bucket_row(key:, label:, display_order:, bucket:)
+    def build_bucket_row(key:, label:, display_order:, bucket:, ctx:)
+      at_bats = bucket[:at_bats]
+      hits = bucket[:hits]
+      bb = bucket[:base_on_balls]
+      hbp = bucket[:hit_by_pitch]
+      sf = bucket[:sacrifice_fly]
+      total_bases = bucket[:total_bases]
+      obp = safe_divide(hits + bb + hbp, at_bats + bb + hbp + sf)
+      slg = safe_divide(total_bases, at_bats)
       {
         key:,
         label:,
         plate_appearances: bucket[:plate_appearances],
-        at_bats: bucket[:at_bats],
-        hits: bucket[:hits],
-        batting_average: safe_divide(bucket[:hits], bucket[:at_bats]),
+        at_bats:,
+        hits:,
+        total_bases:,
+        base_on_balls: bb,
+        hit_by_pitch: hbp,
+        sacrifice_fly: sf,
+        batting_average: safe_divide(hits, at_bats),
+        on_base_percentage: obp,
+        slugging_percentage: slg,
+        ops: (obp + slg).round(3),
+        result_counts: build_result_counts(bucket[:result_counts], ctx[:plate_result_names_by_id]),
         display_order:
       }
+    end
+
+    def build_result_counts(counts, plate_result_names_by_id)
+      counts.sort_by { |id, _| id }.map do |id, count|
+        {
+          plate_result_id: id,
+          plate_result_name: plate_result_names_by_id[id] || '',
+          count:
+        }
+      end
     end
 
     def merge_into(bucket, stats)
       bucket[:plate_appearances] += stats[:plate_appearances]
       bucket[:at_bats] += stats[:at_bats]
       bucket[:hits] += stats[:hits]
+      bucket[:total_bases] += stats[:total_bases]
+      bucket[:base_on_balls] += stats[:base_on_balls]
+      bucket[:hit_by_pitch] += stats[:hit_by_pitch]
+      bucket[:sacrifice_fly] += stats[:sacrifice_fly]
+      stats[:result_counts].each do |result_id, cnt|
+        bucket[:result_counts][result_id] = bucket[:result_counts].fetch(result_id, 0) + cnt
+      end
     end
 
     def empty_bucket
-      { plate_appearances: 0, at_bats: 0, hits: 0 }
+      {
+        plate_appearances: 0, at_bats: 0, hits: 0,
+        total_bases: 0, base_on_balls: 0, hit_by_pitch: 0, sacrifice_fly: 0,
+        result_counts: {}
+      }
     end
 
     # right=0 / left=1 の enum 順を保ちつつ、未設定は末尾に回す。

--- a/app/services/stats/pitcher_attribute_summary_aggregator.rb
+++ b/app/services/stats/pitcher_attribute_summary_aggregator.rb
@@ -15,7 +15,9 @@ module Stats
   class PitcherAttributeSummaryAggregator
     HIT_RESULT_IDS = ::Stats::BattingAverageRecalculator::HIT_RESULT_IDS
 
-    THROW_HAND_LABELS = { 'right' => '右投', 'left' => '左投' }.freeze
+    # フロントの「投手タイプ別 > 利き手」セクションは、自分の打者目線で
+    # 「対◯投」と読める表記に揃える。
+    THROW_HAND_LABELS = { 'right' => '対右投', 'left' => '対左投' }.freeze
     UNSET_LABEL = '未設定'
     UNSET_DISPLAY_ORDER = Float::INFINITY
 

--- a/app/services/stats/pitcher_attribute_summary_aggregator.rb
+++ b/app/services/stats/pitcher_attribute_summary_aggregator.rb
@@ -224,7 +224,7 @@ module Stats
     end
 
     def safe_divide(numerator, denominator)
-      return 0.0 if denominator.to_i.zero?
+      return 0.0 if denominator.zero?
 
       (numerator.to_f / denominator).round(3)
     end

--- a/app/services/stats/pitcher_attribute_summary_aggregator.rb
+++ b/app/services/stats/pitcher_attribute_summary_aggregator.rb
@@ -1,0 +1,199 @@
+# frozen_string_literal: true
+
+module Stats
+  # 対戦投手の属性別（利き手 / 腕の角度 / 球速帯 / 投手タイプ）に
+  # 打席を束ねて打率を返す Aggregator。
+  #
+  # PitcherFaceoffAggregator が 1 投手単位で集計するのに対し、こちらは
+  # 「左投相手は打ててる / オーバーハンドが苦手」といったマクロ傾向を
+  # 可視化することを目的とする。同じ filter / scope（新仕様 PA かつ
+  # pitcher_id 付き）を踏襲し、属性ごとに plate_appearances / at_bats /
+  # hits / batting_average を集計する。
+  #
+  # マスタが nil の投手は key: nil の「未設定」バケットに集約し、
+  # mobile 側で末尾に表示する。
+  class PitcherAttributeSummaryAggregator
+    HIT_RESULT_IDS = ::Stats::BattingAverageRecalculator::HIT_RESULT_IDS
+
+    THROW_HAND_LABELS = { 'right' => '右投', 'left' => '左投' }.freeze
+    UNSET_LABEL = '未設定'
+    UNSET_DISPLAY_ORDER = Float::INFINITY
+
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+      @user_id = user_id
+      @year = year
+      @match_type = match_type
+      @season_id = season_id
+      @tournament_id = tournament_id
+    end
+
+    # @return [Hash] by_throw_hand / by_arm_angle / by_velocity_zone / by_pitcher_style の 4 配列。
+    #   各要素: { key, label, plate_appearances, at_bats, hits, batting_average, display_order }
+    def call
+      stats_by_pitcher = aggregate_per_pitcher
+      pitcher_attrs = load_pitcher_attrs(stats_by_pitcher.keys)
+      arm_angles = ArmAngle.pluck(:id, :name, :display_order).index_by(&:first)
+      velocity_zones = VelocityZone.pluck(:id, :name, :display_order).index_by(&:first)
+      pitcher_styles = PitcherStyle.pluck(:id, :name, :display_order).index_by(&:first)
+
+      {
+        by_throw_hand: group_by_throw_hand(stats_by_pitcher, pitcher_attrs),
+        by_arm_angle: group_by_master(stats_by_pitcher, pitcher_attrs, :arm_angle_id, arm_angles),
+        by_velocity_zone: group_by_master(stats_by_pitcher, pitcher_attrs, :velocity_zone_id, velocity_zones),
+        by_pitcher_style: group_by_master(stats_by_pitcher, pitcher_attrs, :pitcher_style_id, pitcher_styles)
+      }
+    end
+
+    private
+
+    # PitcherFaceoffAggregator と同形の group(:pitcher_id, ...).count を、
+    # 投手単位に畳む。
+    def aggregate_per_pitcher
+      cross = filtered_scope.joins(:plate_result)
+                            .where.not(pitcher_id: nil)
+                            .group(:pitcher_id, :plate_result_id,
+                                   'plate_results.counted_in_at_bats')
+                            .count
+
+      stats = Hash.new { |h, k| h[k] = { plate_appearances: 0, at_bats: 0, hits: 0 } }
+      cross.each do |(pitcher_id, result_id, counted), cnt| # rubocop:disable Style/HashEachMethods
+        bucket = stats[pitcher_id]
+        bucket[:plate_appearances] += cnt
+        bucket[:at_bats] += cnt if counted
+        bucket[:hits] += cnt if HIT_RESULT_IDS.include?(result_id)
+      end
+      stats
+    end
+
+    # pitcher_id → 属性 4 種を一括取得する。集計対象の投手数だけ pluck するので
+    # AR オブジェクトの生成コストを避ける。
+    # `throw_hand` は enum で pluck すると Rails が "right"/"left" の文字列で返す。
+    def load_pitcher_attrs(pitcher_ids)
+      return {} if pitcher_ids.empty?
+
+      Pitcher.where(id: pitcher_ids)
+             .pluck(:id, :throw_hand, :arm_angle_id, :velocity_zone_id, :pitcher_style_id)
+             .to_h do |id, throw_hand, arm_angle_id, velocity_zone_id, pitcher_style_id|
+        [id, {
+          throw_hand:,
+          arm_angle_id:,
+          velocity_zone_id:,
+          pitcher_style_id:
+        }]
+      end
+    end
+
+    def group_by_throw_hand(stats_by_pitcher, pitcher_attrs)
+      buckets = Hash.new { |h, k| h[k] = empty_bucket }
+      stats_by_pitcher.each do |pitcher_id, s|
+        key = pitcher_attrs.dig(pitcher_id, :throw_hand)
+        merge_into(buckets[key], s)
+      end
+      finalize_throw_hand_rows(buckets)
+    end
+
+    def group_by_master(stats_by_pitcher, pitcher_attrs, attr_key, master_index)
+      buckets = Hash.new { |h, k| h[k] = empty_bucket }
+      stats_by_pitcher.each do |pitcher_id, s|
+        key = pitcher_attrs.dig(pitcher_id, attr_key)
+        merge_into(buckets[key], s)
+      end
+      finalize_master_rows(buckets, master_index)
+    end
+
+    def finalize_throw_hand_rows(buckets)
+      rows = buckets.map do |key, bucket|
+        label = key.nil? ? UNSET_LABEL : (THROW_HAND_LABELS[key] || key.to_s)
+        display_order = display_order_for_throw_hand(key)
+        build_bucket_row(key:, label:, display_order:, bucket:)
+      end
+      rows.sort_by { |row| [row[:display_order], row[:label]] }
+    end
+
+    def finalize_master_rows(buckets, master_index)
+      rows = buckets.map do |key, bucket|
+        if key.nil?
+          build_bucket_row(key: nil, label: UNSET_LABEL, display_order: UNSET_DISPLAY_ORDER, bucket:)
+        else
+          _, name, display_order = master_index[key]
+          build_bucket_row(key:, label: name || UNSET_LABEL, display_order: display_order || UNSET_DISPLAY_ORDER, bucket:)
+        end
+      end
+      rows.sort_by { |row| [row[:display_order], row[:label]] }
+    end
+
+    def build_bucket_row(key:, label:, display_order:, bucket:)
+      {
+        key:,
+        label:,
+        plate_appearances: bucket[:plate_appearances],
+        at_bats: bucket[:at_bats],
+        hits: bucket[:hits],
+        batting_average: safe_divide(bucket[:hits], bucket[:at_bats]),
+        display_order:
+      }
+    end
+
+    def merge_into(bucket, stats)
+      bucket[:plate_appearances] += stats[:plate_appearances]
+      bucket[:at_bats] += stats[:at_bats]
+      bucket[:hits] += stats[:hits]
+    end
+
+    def empty_bucket
+      { plate_appearances: 0, at_bats: 0, hits: 0 }
+    end
+
+    # right=0 / left=1 の enum 順を保ちつつ、未設定は末尾に回す。
+    def display_order_for_throw_hand(key)
+      return UNSET_DISPLAY_ORDER if key.nil?
+
+      Pitcher.throw_hands[key] || UNSET_DISPLAY_ORDER
+    end
+
+    def safe_divide(numerator, denominator)
+      return 0.0 if denominator.to_i.zero?
+
+      (numerator.to_f / denominator).round(3)
+    end
+
+    def filtered_scope
+      @filtered_scope ||= begin
+        scope = PlateAppearance.joins(game_result: :match_result)
+                               .where(user_id: @user_id, is_new_format: true)
+        scope = apply_year_filter(scope)
+        scope = apply_match_type_filter(scope)
+        scope = apply_season_filter(scope)
+        apply_tournament_filter(scope)
+      end
+    end
+
+    def apply_year_filter(scope)
+      return scope if @year.blank? || @year.to_s == '通算'
+
+      yr = @year.to_i
+      range_start = Time.zone.local(yr, 1, 1)
+      range_end = Time.zone.local(yr + 1, 1, 1)
+      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
+                  range_start, range_end)
+    end
+
+    def apply_match_type_filter(scope)
+      return scope if @match_type.blank? || @match_type == '全て'
+
+      scope.where(match_results: { match_type: @match_type })
+    end
+
+    def apply_season_filter(scope)
+      return scope if @season_id.blank?
+
+      scope.where(game_results: { season_id: @season_id })
+    end
+
+    def apply_tournament_filter(scope)
+      return scope if @tournament_id.blank?
+
+      scope.where(match_results: { tournament_id: @tournament_id })
+    end
+  end
+end

--- a/app/services/stats/pitcher_faceoff_aggregator.rb
+++ b/app/services/stats/pitcher_faceoff_aggregator.rb
@@ -140,7 +140,7 @@ module Stats
     end
 
     def safe_divide(numerator, denominator)
-      return 0.0 if denominator.to_i.zero?
+      return 0.0 if denominator.zero?
 
       (numerator.to_f / denominator).round(3)
     end

--- a/app/services/stats/pitcher_faceoff_aggregator.rb
+++ b/app/services/stats/pitcher_faceoff_aggregator.rb
@@ -8,7 +8,16 @@ module Stats
   # 最低対戦回数 MIN_PLATE_APPEARANCES（3 打席）未満の投手は除外し、
   # 対戦多い順 → 投手名昇順でソートする。
   class PitcherFaceoffAggregator
-    HIT_RESULT_IDS = ::Stats::BattingAverageRecalculator::HIT_RESULT_IDS
+    Recalc = ::Stats::BattingAverageRecalculator
+    HIT_RESULT_IDS = Recalc::HIT_RESULT_IDS
+
+    # plate_result_id → 塁打数。SLG 計算で使う。
+    TOTAL_BASES_BY_RESULT_ID = {
+      Recalc::SINGLE_HIT_ID => 1,
+      Recalc::DOUBLE_HIT_ID => 2,
+      Recalc::TRIPLE_HIT_ID => 3,
+      Recalc::HOME_RUN_ID => 4
+    }.freeze
 
     # しきい値未満の投手は表示に含めない。サンプルサイズの少ない打率を
     # ランキング表示で誤読しないための下限。
@@ -51,15 +60,31 @@ module Stats
     private
 
     def build_row(pitcher, stats, plate_result_names_by_id)
+      at_bats = stats[:at_bats]
+      hits = stats[:hits]
+      bb = stats[:base_on_balls]
+      hbp = stats[:hit_by_pitch]
+      sf = stats[:sacrifice_fly]
+      total_bases = stats[:total_bases]
+      obp = safe_divide(hits + bb + hbp, at_bats + bb + hbp + sf)
+      slg = safe_divide(total_bases, at_bats)
+
       top_result_id = stats[:result_counts].max_by { |_, c| c }&.first
       top_result_name = plate_result_names_by_id[top_result_id] || ''
       {
         pitcher_id: pitcher.id,
         pitcher_name: pitcher.name,
         plate_appearances: stats[:plate_appearances],
-        at_bats: stats[:at_bats],
-        hits: stats[:hits],
-        batting_average: safe_divide(stats[:hits], stats[:at_bats]),
+        at_bats:,
+        hits:,
+        total_bases:,
+        base_on_balls: bb,
+        hit_by_pitch: hbp,
+        sacrifice_fly: sf,
+        batting_average: safe_divide(hits, at_bats),
+        on_base_percentage: obp,
+        slugging_percentage: slg,
+        ops: (obp + slg).round(3),
         top_result: top_result_name,
         result_counts: build_result_counts(stats[:result_counts], plate_result_names_by_id)
       }
@@ -91,16 +116,27 @@ module Stats
       # も投手ごとに独立して作られることを明示する（dup の shallow copy で
       # 共有されないかを読み手に考えさせない）。
       stats = Hash.new do |h, k|
-        h[k] = { plate_appearances: 0, at_bats: 0, hits: 0, result_counts: {} }
+        h[k] = {
+          plate_appearances: 0, at_bats: 0, hits: 0,
+          total_bases: 0, base_on_balls: 0, hit_by_pitch: 0, sacrifice_fly: 0,
+          result_counts: {}
+        }
       end
       cross.each do |(pitcher_id, result_id, counted), cnt| # rubocop:disable Style/HashEachMethods
-        bucket = stats[pitcher_id]
-        bucket[:plate_appearances] += cnt
-        bucket[:at_bats] += cnt if counted
-        bucket[:hits] += cnt if HIT_RESULT_IDS.include?(result_id)
-        bucket[:result_counts][result_id] = bucket[:result_counts].fetch(result_id, 0) + cnt
+        accumulate_into(stats[pitcher_id], result_id, counted, cnt)
       end
       stats
+    end
+
+    def accumulate_into(bucket, result_id, counted, cnt)
+      bucket[:plate_appearances] += cnt
+      bucket[:at_bats] += cnt if counted
+      bucket[:hits] += cnt if HIT_RESULT_IDS.include?(result_id)
+      bucket[:total_bases] += (TOTAL_BASES_BY_RESULT_ID[result_id] || 0) * cnt
+      bucket[:base_on_balls] += cnt if result_id == Recalc::BASE_ON_BALLS_ID
+      bucket[:hit_by_pitch] += cnt if result_id == Recalc::HIT_BY_PITCH_ID
+      bucket[:sacrifice_fly] += cnt if result_id == Recalc::SACRIFICE_FLY_ID
+      bucket[:result_counts][result_id] = bucket[:result_counts].fetch(result_id, 0) + cnt
     end
 
     def safe_divide(numerator, denominator)

--- a/app/services/stats/pitcher_faceoff_aggregator.rb
+++ b/app/services/stats/pitcher_faceoff_aggregator.rb
@@ -60,8 +60,22 @@ module Stats
         at_bats: stats[:at_bats],
         hits: stats[:hits],
         batting_average: safe_divide(stats[:hits], stats[:at_bats]),
-        top_result: top_result_name
+        top_result: top_result_name,
+        result_counts: build_result_counts(stats[:result_counts], plate_result_names_by_id)
       }
+    end
+
+    # plate_result_id 昇順で並べたシリアライズ用配列。フロントは
+    # ヒット / アウト / 四死球 のカテゴライズを名前ベースで行うため、
+    # ここでは ID と name の両方を持たせる。
+    def build_result_counts(counts, plate_result_names_by_id)
+      counts.sort_by { |id, _| id }.map do |id, count|
+        {
+          plate_result_id: id,
+          plate_result_name: plate_result_names_by_id[id] || '',
+          count:
+        }
+      end
     end
 
     # group(:pitcher_id, :plate_result_id, counted_in_at_bats).count から

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -228,6 +228,7 @@ Rails.application.routes.draw do
         get :contact_qualities, on: :member
         get :pitch_types, on: :member
         get :pitcher_faceoffs, on: :member
+        get :pitcher_attribute_summary, on: :member
         get :batting_trend, on: :member
         get :additional_stats, on: :member
         get :timing_breakdown, on: :member

--- a/spec/requests/api/v2/stats_spec.rb
+++ b/spec/requests/api/v2/stats_spec.rb
@@ -331,6 +331,21 @@ RSpec.describe 'Api::V2::Stats', type: :request do
     end
   end
 
+  describe 'GET /api/v2/stats/pitcher_attribute_summary' do
+    it 'returns 401 when not authenticated' do
+      get '/api/v2/stats/pitcher_attribute_summary'
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns 200 with 4 attribute axes' do
+      get('/api/v2/stats/pitcher_attribute_summary', headers:)
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json).to include('by_throw_hand', 'by_arm_angle', 'by_velocity_zone', 'by_pitcher_style')
+    end
+  end
+
   describe '非公開アカウントの可視性ガード' do
     let(:private_user) { create(:user, is_private: true) }
 
@@ -351,6 +366,13 @@ RSpec.describe 'Api::V2::Stats', type: :request do
 
       it 'returns 403 for era_trend' do
         get '/api/v2/stats/era_trend',
+            params: { user_id: private_user.id },
+            headers: auth_headers_for(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'returns 403 for pitcher_attribute_summary' do
+        get '/api/v2/stats/pitcher_attribute_summary',
             params: { user_id: private_user.id },
             headers: auth_headers_for(user)
         expect(response).to have_http_status(:forbidden)

--- a/spec/services/stats/pitch_type_aggregator_spec.rb
+++ b/spec/services/stats/pitch_type_aggregator_spec.rb
@@ -74,6 +74,30 @@ RSpec.describe Stats::PitchTypeAggregator, type: :service do
           expect(slider[:slugging_percentage]).to eq(3.0)
         end
       end
+
+      it 'exposes extended stats (PA / BB / HBP / SF / OBP / OPS / result_counts) per row' do
+        result = described_class.new(user_id: user.id).call
+        straight = result[:rows].find { |r| r[:label] == 'ストレート系' }
+        slider = result[:rows].find { |r| r[:label] == 'スライダー系' }
+
+        aggregate_failures do
+          # ストレート: 単打 1 + 三振 1 → PA=2 AB=2 H=1 TB=1 BB=0 HBP=0 SF=0
+          expect(straight).to include(
+            plate_appearances: 2, base_on_balls: 0, hit_by_pitch: 0, sacrifice_fly: 0
+          )
+          expect(straight[:on_base_percentage]).to eq(0.5)
+          expect(straight[:ops]).to eq(1.0)
+          expect(straight[:result_counts]).to eq([
+                                                   { plate_result_id: single_result_id, plate_result_name: 'ヒット', count: 1 },
+                                                   { plate_result_id: strikeout_result_id, plate_result_name: '三振', count: 1 }
+                                                 ])
+
+          # スライダー: 二塁打 + 本塁打 → PA=2 AB=2 H=2 TB=6 / OBP=1.000 / OPS=4.000
+          expect(slider).to include(plate_appearances: 2)
+          expect(slider[:on_base_percentage]).to eq(1.0)
+          expect(slider[:ops]).to eq(4.0)
+        end
+      end
     end
 
     context 'with year filter' do

--- a/spec/services/stats/pitcher_attribute_summary_aggregator_spec.rb
+++ b/spec/services/stats/pitcher_attribute_summary_aggregator_spec.rb
@@ -104,6 +104,7 @@ RSpec.describe Stats::PitcherAttributeSummaryAggregator, type: :service do
       it 'exposes extended stats (TB / BB / HBP / SF / OBP / SLG / OPS / result_counts) per bucket' do
         result = described_class.new(user_id: user.id).call
         right_row = result[:by_throw_hand].find { |r| r[:key] == 'right' }
+        left_row = result[:by_throw_hand].find { |r| r[:key] == 'left' }
 
         aggregate_failures do
           # 右投: 右オーバー(at=4 hit=2 単打2/三振2 → TB=2) + 属性なし(at=2 hit=1 単打1/三振1 → TB=1)
@@ -115,9 +116,18 @@ RSpec.describe Stats::PitcherAttributeSummaryAggregator, type: :service do
           expect(right_row[:on_base_percentage]).to eq(0.5)
           expect(right_row[:slugging_percentage]).to eq(0.5)
           expect(right_row[:ops]).to eq(1.0)
-          # result_counts は plate_result_id 昇順
-          expect(right_row[:result_counts]).to be_an(Array)
-          expect(right_row[:result_counts].first).to include(:plate_result_id, :plate_result_name, :count)
+
+          # result_counts は複数投手のバケット合算結果を投手単位の集計と一致させる必要がある。
+          # 右投の合算: 単打 3 (右オーバー 2 + 属性なし 1) + 三振 3 (右オーバー 2 + 属性なし 1)
+          expect(right_row[:result_counts]).to eq([
+                                                    { plate_result_id: single_result_id, plate_result_name: 'ヒット', count: 3 },
+                                                    { plate_result_id: strikeout_result_id, plate_result_name: '三振', count: 3 }
+                                                  ])
+          # 左投: 左サイドのみ → 二塁打 1 + 三振 2
+          expect(left_row[:result_counts]).to eq([
+                                                   { plate_result_id: double_result_id, plate_result_name: '二塁打', count: 1 },
+                                                   { plate_result_id: strikeout_result_id, plate_result_name: '三振', count: 2 }
+                                                 ])
         end
       end
 

--- a/spec/services/stats/pitcher_attribute_summary_aggregator_spec.rb
+++ b/spec/services/stats/pitcher_attribute_summary_aggregator_spec.rb
@@ -101,6 +101,26 @@ RSpec.describe Stats::PitcherAttributeSummaryAggregator, type: :service do
         end
       end
 
+      it 'exposes extended stats (TB / BB / HBP / SF / OBP / SLG / OPS / result_counts) per bucket' do
+        result = described_class.new(user_id: user.id).call
+        right_row = result[:by_throw_hand].find { |r| r[:key] == 'right' }
+
+        aggregate_failures do
+          # 右投: 右オーバー(at=4 hit=2 単打2/三振2 → TB=2) + 属性なし(at=2 hit=1 単打1/三振1 → TB=1)
+          #   合計: PA=6 AB=6 H=3 TB=3 BB=0 HBP=0 SF=0
+          expect(right_row).to include(
+            total_bases: 3, base_on_balls: 0, hit_by_pitch: 0, sacrifice_fly: 0
+          )
+          # OBP = (3+0+0)/(6+0+0+0) = .500, SLG = 3/6 = .500, OPS = 1.000
+          expect(right_row[:on_base_percentage]).to eq(0.5)
+          expect(right_row[:slugging_percentage]).to eq(0.5)
+          expect(right_row[:ops]).to eq(1.0)
+          # result_counts は plate_result_id 昇順
+          expect(right_row[:result_counts]).to be_an(Array)
+          expect(right_row[:result_counts].first).to include(:plate_result_id, :plate_result_name, :count)
+        end
+      end
+
       it 'buckets by pitcher_style using display_order' do
         result = described_class.new(user_id: user.id).call
 

--- a/spec/services/stats/pitcher_attribute_summary_aggregator_spec.rb
+++ b/spec/services/stats/pitcher_attribute_summary_aggregator_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Stats::PitcherAttributeSummaryAggregator, type: :service do
 
         aggregate_failures do
           # 右投: 右オーバー(4) + 属性なし(2) = 6 PA / 6 AB / 3 hits
-          expect(labels).to eq(%w[右投 左投])
+          expect(labels).to eq(%w[対右投 対左投])
           expect(right_row).to include(plate_appearances: 6, at_bats: 6, hits: 3, batting_average: 0.5)
           expect(left_row).to include(plate_appearances: 3, at_bats: 3, hits: 1, batting_average: (1.0 / 3).round(3))
         end

--- a/spec/services/stats/pitcher_attribute_summary_aggregator_spec.rb
+++ b/spec/services/stats/pitcher_attribute_summary_aggregator_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Stats::PitcherAttributeSummaryAggregator, type: :service do
+  let(:single_result_id) { Stats::BattingAverageRecalculator::HIT_RESULT_IDS.first } # 7 (単打)
+  let(:double_result_id) { 8 }
+  let(:strikeout_result_id) { 13 }
+
+  let(:user) { create(:user) }
+  let(:game_result) { create(:game_result, user:) }
+
+  def create_pitcher(name:, throw_hand: :right, arm_angle_id: nil, velocity_zone_id: nil, pitcher_style_id: nil)
+    Pitcher.create!(name:, throw_hand:, arm_angle_id:, velocity_zone_id:, pitcher_style_id:,
+                    created_by_user: user)
+  end
+
+  def create_pa(pitcher_id:, plate_result_id:, batter_box_number: nil, game: game_result)
+    attrs = { game_result: game, user:, pitcher_id:, plate_result_id:, is_new_format: true }
+    attrs[:batter_box_number] = batter_box_number if batter_box_number
+    create(:plate_appearance, **attrs)
+  end
+
+  describe '#call' do
+    context 'when no plate appearances' do
+      it 'returns 4 empty arrays' do
+        result = described_class.new(user_id: user.id).call
+
+        aggregate_failures do
+          expect(result[:by_throw_hand]).to eq([])
+          expect(result[:by_arm_angle]).to eq([])
+          expect(result[:by_velocity_zone]).to eq([])
+          expect(result[:by_pitcher_style]).to eq([])
+        end
+      end
+    end
+
+    context 'with mixed pitchers across attributes' do
+      let!(:right_over) do
+        create_pitcher(name: '右オーバー投手', throw_hand: :right, arm_angle_id: 1,
+                       velocity_zone_id: 3, pitcher_style_id: 1)
+      end
+      let!(:left_side) do
+        create_pitcher(name: '左サイド投手', throw_hand: :left, arm_angle_id: 3,
+                       velocity_zone_id: 2, pitcher_style_id: 2)
+      end
+      let!(:unset_pitcher) { create_pitcher(name: '属性なし投手', throw_hand: :right) }
+
+      before do
+        # 右オーバー: 4 PA = 単打 2 + 三振 2 → at=4, h=2
+        2.times { |i| create_pa(pitcher_id: right_over.id, plate_result_id: single_result_id, batter_box_number: i + 1) }
+        2.times { |i| create_pa(pitcher_id: right_over.id, plate_result_id: strikeout_result_id, batter_box_number: i + 3) }
+        # 左サイド: 3 PA = 二塁打 1 + 三振 2 → at=3, h=1
+        create_pa(pitcher_id: left_side.id, plate_result_id: double_result_id, batter_box_number: 10)
+        2.times { |i| create_pa(pitcher_id: left_side.id, plate_result_id: strikeout_result_id, batter_box_number: 11 + i) }
+        # 属性なし: 2 PA = 単打 1 + 三振 1 → at=2, h=1
+        create_pa(pitcher_id: unset_pitcher.id, plate_result_id: single_result_id, batter_box_number: 20)
+        create_pa(pitcher_id: unset_pitcher.id, plate_result_id: strikeout_result_id, batter_box_number: 21)
+      end
+
+      it 'buckets by throw_hand with right(0) before left(1)' do
+        result = described_class.new(user_id: user.id).call
+
+        labels = result[:by_throw_hand].pluck(:label)
+        right_row = result[:by_throw_hand].find { |r| r[:key] == 'right' }
+        left_row = result[:by_throw_hand].find { |r| r[:key] == 'left' }
+
+        aggregate_failures do
+          # 右投: 右オーバー(4) + 属性なし(2) = 6 PA / 6 AB / 3 hits
+          expect(labels).to eq(%w[右投 左投])
+          expect(right_row).to include(plate_appearances: 6, at_bats: 6, hits: 3, batting_average: 0.5)
+          expect(left_row).to include(plate_appearances: 3, at_bats: 3, hits: 1, batting_average: (1.0 / 3).round(3))
+        end
+      end
+
+      it 'buckets by arm_angle with display_order ascending, unset at tail' do
+        result = described_class.new(user_id: user.id).call
+
+        labels = result[:by_arm_angle].pluck(:label)
+        over_row = result[:by_arm_angle].find { |r| r[:key] == 1 }
+        side_row = result[:by_arm_angle].find { |r| r[:key] == 3 }
+        unset_row = result[:by_arm_angle].find { |r| r[:key].nil? }
+
+        aggregate_failures do
+          expect(labels).to eq(%w[オーバースロー サイドスロー 未設定])
+          expect(over_row).to include(plate_appearances: 4, at_bats: 4, hits: 2, batting_average: 0.5)
+          expect(side_row).to include(plate_appearances: 3, at_bats: 3, hits: 1, batting_average: (1.0 / 3).round(3))
+          expect(unset_row).to include(plate_appearances: 2, at_bats: 2, hits: 1, batting_average: 0.5)
+        end
+      end
+
+      it 'buckets by velocity_zone using display_order' do
+        result = described_class.new(user_id: user.id).call
+
+        rows = result[:by_velocity_zone]
+        aggregate_failures do
+          expect(rows.pluck(:label)).to eq(['120-130km/h', '130-140km/h', '未設定'])
+          expect(rows[0]).to include(key: 2, at_bats: 3, hits: 1)
+          expect(rows[1]).to include(key: 3, at_bats: 4, hits: 2)
+          expect(rows.last).to include(key: nil, label: '未設定', at_bats: 2)
+        end
+      end
+
+      it 'buckets by pitcher_style using display_order' do
+        result = described_class.new(user_id: user.id).call
+
+        rows = result[:by_pitcher_style]
+        aggregate_failures do
+          expect(rows.pluck(:label)).to eq(%w[本格派 技巧派 未設定])
+          expect(rows[0]).to include(key: 1, at_bats: 4, hits: 2)
+          expect(rows[1]).to include(key: 2, at_bats: 3, hits: 1)
+          expect(rows.last).to include(key: nil, at_bats: 2)
+        end
+      end
+    end
+
+    context 'with year filter' do
+      let!(:pitcher) { create_pitcher(name: '対象投手', throw_hand: :right) }
+
+      before do
+        old_game = create(:game_result, user:)
+        old_game.match_result.update!(date_and_time: Time.zone.parse('2025-09-30'))
+        create_pa(pitcher_id: pitcher.id, plate_result_id: single_result_id, batter_box_number: 1, game: old_game)
+
+        new_game = create(:game_result, user:)
+        new_game.match_result.update!(date_and_time: Time.zone.parse('2026-04-01'))
+        create_pa(pitcher_id: pitcher.id, plate_result_id: double_result_id, batter_box_number: 1, game: new_game)
+      end
+
+      it 'only counts plate_appearances within the year' do
+        result = described_class.new(user_id: user.id, year: 2026).call
+
+        right_row = result[:by_throw_hand].find { |r| r[:key] == 'right' }
+        expect(right_row).to include(plate_appearances: 1, at_bats: 1, hits: 1)
+      end
+    end
+
+    context 'with old-format PAs (is_new_format: false / pitcher_id: nil)' do
+      let!(:pitcher) { create_pitcher(name: '対象投手', throw_hand: :left, arm_angle_id: 1) }
+
+      before do
+        # 対象 (新仕様)
+        2.times { |i| create_pa(pitcher_id: pitcher.id, plate_result_id: single_result_id, batter_box_number: i + 1) }
+        # 旧仕様 (除外)
+        create(:plate_appearance, game_result:, user:, batter_box_number: 90,
+                                  pitcher_id: nil, plate_result_id: single_result_id, is_new_format: false)
+      end
+
+      it 'excludes old-format PAs from all buckets' do
+        result = described_class.new(user_id: user.id).call
+
+        aggregate_failures do
+          expect(result[:by_throw_hand].size).to eq(1)
+          expect(result[:by_throw_hand].first).to include(key: 'left', plate_appearances: 2, hits: 2)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/stats/pitcher_attribute_summary_aggregator_spec.rb
+++ b/spec/services/stats/pitcher_attribute_summary_aggregator_spec.rb
@@ -155,6 +155,38 @@ RSpec.describe Stats::PitcherAttributeSummaryAggregator, type: :service do
       end
     end
 
+    context 'when a pitcher record is missing (only orphan PA remains)' do
+      let!(:living_pitcher) { create_pitcher(name: '生存投手', throw_hand: :right, arm_angle_id: 1) }
+
+      before do
+        # 生存投手 (基準データ)
+        2.times { |i| create_pa(pitcher_id: living_pitcher.id, plate_result_id: single_result_id, batter_box_number: i + 1) }
+
+        # 削除済み投手の PA を疑似する: 通常は dependent: :nullify と FK で守られるが、
+        # 念のため referential_integrity を一時的に外して orphan PA を作り、
+        # Aggregator が「未設定」バケットに混入させないことを保護する。
+        pa = create(:plate_appearance, game_result:, user:, batter_box_number: 50,
+                                       pitcher_id: living_pitcher.id, plate_result_id: single_result_id,
+                                       is_new_format: true)
+        PlateAppearance.connection.disable_referential_integrity do
+          pa.update_column(:pitcher_id, 999_999) # rubocop:disable Rails/SkipsModelValidations
+        end
+      end
+
+      it 'excludes PAs whose pitcher record is missing' do
+        result = described_class.new(user_id: user.id).call
+
+        # 削除済み投手の PA は throw_hand=null（未設定）に紛れ込まない
+        right_row = result[:by_throw_hand].find { |r| r[:key] == 'right' }
+        unset_row = result[:by_throw_hand].find { |r| r[:key].nil? }
+
+        aggregate_failures do
+          expect(right_row).to include(plate_appearances: 2, at_bats: 2, hits: 2)
+          expect(unset_row).to be_nil
+        end
+      end
+    end
+
     context 'with old-format PAs (is_new_format: false / pitcher_id: nil)' do
       let!(:pitcher) { create_pitcher(name: '対象投手', throw_hand: :left, arm_angle_id: 1) }
 

--- a/spec/services/stats/pitcher_faceoff_aggregator_spec.rb
+++ b/spec/services/stats/pitcher_faceoff_aggregator_spec.rb
@@ -85,6 +85,25 @@ RSpec.describe Stats::PitcherFaceoffAggregator, type: :service do
           )
         end
       end
+
+      it 'exposes result_counts sorted by plate_result_id with name + count' do
+        result = described_class.new(user_id: user.id).call
+        ace_row = result[:rows].find { |r| r[:pitcher_name] == 'エース投手' }
+        rookie_row = result[:rows].find { |r| r[:pitcher_name] == '新人投手' }
+
+        aggregate_failures do
+          # エース: 単打 2 + 三振 1
+          expect(ace_row[:result_counts]).to eq([
+                                                  { plate_result_id: single_result_id, plate_result_name: 'ヒット', count: 2 },
+                                                  { plate_result_id: strikeout_result_id, plate_result_name: '三振', count: 1 }
+                                                ])
+          # 新人: 二塁打 1 + 三振 4
+          expect(rookie_row[:result_counts]).to eq([
+                                                     { plate_result_id: double_result_id, plate_result_name: '二塁打', count: 1 },
+                                                     { plate_result_id: strikeout_result_id, plate_result_name: '三振', count: 4 }
+                                                   ])
+        end
+      end
     end
 
     context 'when tied appearances, sorts by pitcher_name asc' do

--- a/spec/services/stats/pitcher_faceoff_aggregator_spec.rb
+++ b/spec/services/stats/pitcher_faceoff_aggregator_spec.rb
@@ -86,6 +86,29 @@ RSpec.describe Stats::PitcherFaceoffAggregator, type: :service do
         end
       end
 
+      it 'exposes total_bases / BB / HBP / SF / OBP / SLG / OPS per pitcher' do
+        result = described_class.new(user_id: user.id).call
+        rookie_row = result[:rows].find { |r| r[:pitcher_name] == '新人投手' }
+        ace_row = result[:rows].find { |r| r[:pitcher_name] == 'エース投手' }
+
+        aggregate_failures do
+          # エース: 単打 2 + 三振 1 → AB=3 H=2 TB=2 BB=0 HBP=0 SF=0
+          expect(ace_row).to include(
+            total_bases: 2,
+            base_on_balls: 0, hit_by_pitch: 0, sacrifice_fly: 0
+          )
+          # OBP = (2+0+0)/(3+0+0+0) = .667, SLG = 2/3 = .667, OPS = 1.333
+          expect(ace_row[:on_base_percentage]).to eq((2.0 / 3).round(3))
+          expect(ace_row[:slugging_percentage]).to eq((2.0 / 3).round(3))
+          expect(ace_row[:ops]).to eq(
+            ((2.0 / 3).round(3) + (2.0 / 3).round(3)).round(3)
+          )
+
+          # 新人: 二塁打 1 + 三振 4 → AB=5 H=1 TB=2
+          expect(rookie_row).to include(total_bases: 2, base_on_balls: 0)
+        end
+      end
+
       it 'exposes result_counts sorted by plate_result_id with name + count' do
         result = described_class.new(user_id: user.id).call
         ace_row = result[:rows].find { |r| r[:pitcher_name] == 'エース投手' }


### PR DESCRIPTION
## Summary

- ippei-shimizu/buzzbase#382 対応の back 側。stats 打撃の「対戦投手別」を細分化する 2 つの API 改修。
- `PitcherFaceoffAggregator` の各行に `result_counts`（plate_result_id → 件数の配列）を追加し、mobile 側で行タップ時に「ヒット / アウト / 四死球」の内訳を展開できるようにする
- `Stats::PitcherAttributeSummaryAggregator` を新規追加。投手属性 4 種（利き手 / 腕の角度 / 球速帯 / 投手タイプ）で打席を束ねた打率を返す

## 変更点

### `Add: PitcherFaceoffAggregator に result_counts を追加` (abe7cce)

- `aggregate_stats` は既に `result_counts` を内部構築していたので、`build_row` でシリアライズするだけ
- 形式: `[{ plate_result_id, plate_result_name, count }]` を `plate_result_id` 昇順で返す
- サーバー側でカテゴライズせず生の count 列を返すので、将来カテゴリを増やす（犠飛 / 失策など）時にサーバー → mobile 両方を触らずに済む

### `Add: Stats::PitcherAttributeSummaryAggregator + endpoint` (b3f417a)

- 新規 Aggregator: `Pitcher.throw_hand` enum + `arm_angle_id` / `velocity_zone_id` / `pitcher_style_id` の 4 軸で集計
- 各バケットで `{ key, label, plate_appearances, at_bats, hits, batting_average, display_order }` を返す
- マスタが nil の投手は `key: nil` の「未設定」バケットに集約（mobile で末尾表示）
- 並び順: throw_hand=enum 順 (right→left) / マスタ系=`display_order` 昇順 / 未設定=末尾
- per-pitcher の `MIN_PLATE_APPEARANCES` は適用しない（属性別は集約後の母数が大きくなる前提）
- 新 endpoint `GET /api/v2/stats/pitcher_attribute_summary`（既存の `authorize_target_user!` で非公開 403 を継承）

## スコープ外（本 PR では触らない）

- mobile 側の UI 実装（`PitcherFaceoffList` タップ展開 + `PitcherAttributeSummary` カード追加）→ 別 PR で対応
- `apply_*_filter` の FilterableConcern 適用（PR ippei-shimizu/buzzbase_back#269 マージ後に rebase 整理）

## Test plan

- [x] `docker compose exec back bundle exec rspec spec/services/stats/ spec/requests/api/v2/stats_spec.rb` → 136 examples PASS
- [x] `docker compose exec back bundle exec rubocop app/services/stats/ app/controllers/api/v2/stats_controller.rb config/routes.rb` → 0 offenses
- [ ] stg 反映後、`/api/v2/stats/pitcher_faceoffs` のレスポンスに各行 `result_counts` が含まれることを目視確認
- [ ] `/api/v2/stats/pitcher_attribute_summary` が 4 軸 (`by_throw_hand` / `by_arm_angle` / `by_velocity_zone` / `by_pitcher_style`) を返すことを目視確認
- [ ] 非公開ユーザーの `user_id` を指定して 403 が返ること
