### PR TITLE
Add: 三振の swing_type (空振り / 見逃し) を記録・集計可能にする

### DIFF
--- a/app/controllers/api/v2/plate_appearances_controller.rb
+++ b/app/controllers/api/v2/plate_appearances_controller.rb
@@ -84,7 +84,7 @@ module Api
           :game_result_id,
           :batter_box_number,
           :plate_result_id, :hit_direction_id, :batting_position_id,
-          :out_type, :hit_type,
+          :out_type, :hit_type, :swing_type,
           :hit_location_x, :hit_location_y,
           :rbi, :run_scored, :stolen_bases, :caught_stealing,
           :final_balls, :final_strikes, :final_outs,

--- a/app/models/plate_appearance.rb
+++ b/app/models/plate_appearance.rb
@@ -1,4 +1,8 @@
 class PlateAppearance < ApplicationRecord
+  # plate_results マスタの「三振」エントリの ID。swing_type は三振のときのみ
+  # 意味を持つので、validate でこの ID とセットで指定されているか確認する。
+  STRIKEOUT_RESULT_ID = 13
+
   belongs_to :game_result
   belongs_to :user
   belongs_to :plate_result, optional: true
@@ -13,6 +17,7 @@ class PlateAppearance < ApplicationRecord
   attribute :out_type, :integer
   attribute :hit_type, :integer
   attribute :runners_state, :integer
+  attribute :swing_type, :integer
 
   enum out_type: { ground_ball: 0, fly_ball: 1, line_drive: 2, double_play: 3, foul_fly: 4 }, _prefix: true
   enum hit_type: { single: 0, double: 1, triple: 2, home_run: 3 }, _prefix: true
@@ -26,6 +31,7 @@ class PlateAppearance < ApplicationRecord
     second_third: 6,
     bases_loaded: 7
   }, _prefix: true
+  enum swing_type: { swinging: 0, looking: 1 }, _prefix: true
 
   # 打球位置は正規化座標 (0.0〜1.0) で保存する。
   # DB の precision: 4, scale: 3 は範囲外値を許してしまうため、モデル側で防ぐ。
@@ -37,4 +43,15 @@ class PlateAppearance < ApplicationRecord
   validates :hit_direction_id,
             inclusion: { in: ::Stats::HitDirectionAggregator::DIRECTION_LABELS.keys },
             allow_nil: true
+
+  validate :swing_type_only_for_strikeout
+
+  private
+
+  def swing_type_only_for_strikeout
+    return if swing_type.blank?
+    return if plate_result_id == STRIKEOUT_RESULT_ID
+
+    errors.add(:swing_type, 'は三振 (plate_result_id=13) のときのみ指定可能です')
+  end
 end

--- a/app/serializers/v2/plate_appearance_serializer.rb
+++ b/app/serializers/v2/plate_appearance_serializer.rb
@@ -8,7 +8,7 @@ module V2
     attributes :id, :game_result_id, :user_id,
                :batter_box_number, :batting_result,
                :plate_result_id, :hit_direction_id, :batting_position_id,
-               :out_type, :hit_type,
+               :out_type, :hit_type, :swing_type,
                :hit_location_x, :hit_location_y,
                :rbi, :run_scored, :stolen_bases, :caught_stealing,
                :final_balls, :final_strikes, :final_outs,

--- a/app/serializers/v2/plate_appearance_serializer.rb
+++ b/app/serializers/v2/plate_appearance_serializer.rb
@@ -32,6 +32,9 @@ module V2
 
     private
 
+    # swing_type は「打席結果 (plate_result_id) の不可分な一部」と捉えるため、
+    # 任意入力の「詳細データ」とは別扱いにする（has_detail_data に含めない）。
+    # 三振 PA で swing_type だけ入っていても「詳細未入力」バッジを出す意図。
     def detail_attributes
       %i[contact_quality_id timing_id pitch_type_id
          final_balls final_strikes final_outs first_pitch_swing

--- a/app/services/stats/additional_stats_aggregator.rb
+++ b/app/services/stats/additional_stats_aggregator.rb
@@ -25,13 +25,30 @@ module Stats
       @tournament_id = tournament_id
     end
 
-    # @return [Hash] 16 指標。母数 0 でも nil ではなく 0 / 0.0 を返す
+    # @return [Hash] 16 指標 + 三振内訳 (swinging / looking)。
+    #   母数 0 でも nil ではなく 0 / 0.0 を返す。
     def call
       stats = aggregate_stats
-      raw_counts(stats).merge(computed_rates(stats)).merge(games: count_games)
+      raw_counts(stats)
+        .merge(computed_rates(stats))
+        .merge(games: count_games)
+        .merge(aggregate_strike_out_breakdown)
     end
 
     private
+
+    # plate_appearances.swing_type の内訳を新仕様 PA から直接集計する。
+    # batting_averages 側にカラムを増やすと recalculator 連鎖の影響が広いため、
+    # 追加クエリ 2 本で済ませる。旧 PA (is_new_format=false) と
+    # 振り逃げ (plate_result_id=14) は対象外で、新仕様の純粋な三振 (id=13)
+    # のうち swing_type 別のカウントを返す。
+    def aggregate_strike_out_breakdown
+      strikeouts = filtered_pa_scope.where(plate_result_id: PlateAppearance::STRIKEOUT_RESULT_ID)
+      {
+        swinging_strike_out: strikeouts.swing_type_swinging.count,
+        looking_strike_out: strikeouts.swing_type_looking.count
+      }
+    end
 
     def raw_counts(stats)
       {
@@ -80,6 +97,19 @@ module Stats
     def filtered_scope
       @filtered_scope ||= begin
         scope = BattingAverage.joins(game_result: :match_result).where(user_id: @user_id)
+        scope = apply_year_filter(scope)
+        scope = apply_match_type_filter(scope)
+        scope = apply_season_filter(scope)
+        apply_tournament_filter(scope)
+      end
+    end
+
+    # swing_type 内訳は plate_appearances を直接集計する必要があるため、
+    # batting_averages 経由の filtered_scope とは別系統の同フィルタを用意する。
+    def filtered_pa_scope
+      @filtered_pa_scope ||= begin
+        scope = PlateAppearance.joins(game_result: :match_result)
+                               .where(user_id: @user_id, is_new_format: true)
         scope = apply_year_filter(scope)
         scope = apply_match_type_filter(scope)
         scope = apply_season_filter(scope)

--- a/app/services/stats/additional_stats_aggregator.rb
+++ b/app/services/stats/additional_stats_aggregator.rb
@@ -39,14 +39,20 @@ module Stats
 
     # plate_appearances.swing_type の内訳を新仕様 PA から直接集計する。
     # batting_averages 側にカラムを増やすと recalculator 連鎖の影響が広いため、
-    # 追加クエリ 2 本で済ませる。旧 PA (is_new_format=false) と
-    # 振り逃げ (plate_result_id=14) は対象外で、新仕様の純粋な三振 (id=13)
-    # のうち swing_type 別のカウントを返す。
+    # 追加クエリ 1 本（GROUP BY :swing_type）で済ませる。旧 PA
+    # (is_new_format=false) と振り逃げ (plate_result_id=14) は対象外で、
+    # 新仕様の純粋な三振 (id=13) のうち swing_type 別のカウントを返す。
+    #
+    # Rails 7.1 の enum + group + count は string key（enum label）の
+    # ハッシュを返すので、`counts.fetch('swinging', 0)` でアクセスする。
     def aggregate_strike_out_breakdown
-      strikeouts = filtered_pa_scope.where(plate_result_id: PlateAppearance::STRIKEOUT_RESULT_ID)
+      counts = filtered_pa_scope
+               .where(plate_result_id: PlateAppearance::STRIKEOUT_RESULT_ID)
+               .group(:swing_type)
+               .count
       {
-        swinging_strike_out: strikeouts.swing_type_swinging.count,
-        looking_strike_out: strikeouts.swing_type_looking.count
+        swinging_strike_out: counts.fetch('swinging', 0),
+        looking_strike_out: counts.fetch('looking', 0)
       }
     end
 

--- a/db/migrate/20260617000000_add_swing_type_to_plate_appearances.rb
+++ b/db/migrate/20260617000000_add_swing_type_to_plate_appearances.rb
@@ -1,6 +1,10 @@
 class AddSwingTypeToPlateAppearances < ActiveRecord::Migration[7.1]
   def change
     add_column :plate_appearances, :swing_type, :integer
-    add_index :plate_appearances, :swing_type
+    # swing_type は三振 (plate_result_id=13) のときだけ意味を持ち、それ以外は NULL。
+    # 三振以外は全件 NULL になるため単純インデックスでは選択性が極端に低い。
+    # WHERE 句で「swing_type IS NOT NULL」に絞った部分インデックスにして
+    # 三振の集計クエリでのみ実利を得るようにする。
+    add_index :plate_appearances, :swing_type, where: 'swing_type IS NOT NULL'
   end
 end

--- a/db/migrate/20260617000000_add_swing_type_to_plate_appearances.rb
+++ b/db/migrate/20260617000000_add_swing_type_to_plate_appearances.rb
@@ -1,0 +1,6 @@
+class AddSwingTypeToPlateAppearances < ActiveRecord::Migration[7.1]
+  def change
+    add_column :plate_appearances, :swing_type, :integer
+    add_index :plate_appearances, :swing_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -399,7 +399,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_17_000000) do
     t.index ["is_new_format"], name: "index_plate_appearances_on_is_new_format"
     t.index ["pitch_type_id"], name: "index_plate_appearances_on_pitch_type_id"
     t.index ["pitcher_id"], name: "index_plate_appearances_on_pitcher_id"
-    t.index ["swing_type"], name: "index_plate_appearances_on_swing_type"
+    t.index ["swing_type"], name: "index_plate_appearances_on_swing_type", where: "(swing_type IS NOT NULL)"
     t.index ["timing_id"], name: "index_plate_appearances_on_timing_id"
     t.index ["user_id"], name: "index_plate_appearances_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_12_130002) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_17_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -392,12 +392,14 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_12_130002) do
     t.boolean "is_new_format", default: false, null: false
     t.bigint "pitcher_id"
     t.bigint "appearance_situation_id"
+    t.integer "swing_type"
     t.index ["appearance_situation_id"], name: "index_plate_appearances_on_appearance_situation_id"
     t.index ["contact_quality_id"], name: "index_plate_appearances_on_contact_quality_id"
     t.index ["game_result_id"], name: "index_plate_appearances_on_game_result_id"
     t.index ["is_new_format"], name: "index_plate_appearances_on_is_new_format"
     t.index ["pitch_type_id"], name: "index_plate_appearances_on_pitch_type_id"
     t.index ["pitcher_id"], name: "index_plate_appearances_on_pitcher_id"
+    t.index ["swing_type"], name: "index_plate_appearances_on_swing_type"
     t.index ["timing_id"], name: "index_plate_appearances_on_timing_id"
     t.index ["user_id"], name: "index_plate_appearances_on_user_id"
   end

--- a/spec/models/plate_appearance_spec.rb
+++ b/spec/models/plate_appearance_spec.rb
@@ -42,6 +42,40 @@ RSpec.describe PlateAppearance, type: :model do
         'bases_loaded' => 7
       )
     end
+
+    it 'swing_type は swinging / looking の 2 種' do
+      expect(described_class.swing_types).to eq('swinging' => 0, 'looking' => 1)
+    end
+  end
+
+  describe 'swing_type の整合バリデーション' do
+    let(:pa) { build(:plate_appearance) }
+
+    it '三振 (plate_result_id=13) で swinging は valid' do
+      pa.assign_attributes(plate_result_id: 13, swing_type: :swinging)
+      expect(pa).to be_valid
+    end
+
+    it '三振で looking は valid' do
+      pa.assign_attributes(plate_result_id: 13, swing_type: :looking)
+      expect(pa).to be_valid
+    end
+
+    it '三振で swing_type 未指定は valid' do
+      pa.assign_attributes(plate_result_id: 13, swing_type: nil)
+      expect(pa).to be_valid
+    end
+
+    it '三振以外 (例: 単打 id=7) に swing_type を入れると invalid' do
+      pa.assign_attributes(plate_result_id: 7, swing_type: :swinging)
+      expect(pa).not_to be_valid
+      expect(pa.errors[:swing_type]).to be_present
+    end
+
+    it '振り逃げ (id=14) に swing_type を入れても invalid' do
+      pa.assign_attributes(plate_result_id: 14, swing_type: :looking)
+      expect(pa).not_to be_valid
+    end
   end
 
   describe '新カラムの保存と取得' do

--- a/spec/requests/api/v2/plate_appearances_spec.rb
+++ b/spec/requests/api/v2/plate_appearances_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'Api::V2::PlateAppearances', type: :request do
 
         expect(response).to have_http_status(:created)
         expect(response.parsed_body['swing_type']).to eq('swinging')
-        expect(PlateAppearance.find(response.parsed_body['id']).swing_type_looking?).to be(false)
+        expect(PlateAppearance.find(response.parsed_body['id']).swing_type_swinging?).to be(true)
       end
 
       it '三振以外 (例: 単打 id=7) に swing_type を指定すると 422' do

--- a/spec/requests/api/v2/plate_appearances_spec.rb
+++ b/spec/requests/api/v2/plate_appearances_spec.rb
@@ -145,6 +145,29 @@ RSpec.describe 'Api::V2::PlateAppearances', type: :request do
         expect(response.parsed_body['errors']).to include('指定された投手は存在しません')
         expect(plate_appearance.reload.pitcher_id).to be_nil
       end
+
+      it '三振 PA の swing_type を swinging → looking に更新できる' do
+        strikeout = create(:plate_appearance, game_result:, user:, batter_box_number: 5,
+                                              plate_result_id: 13, swing_type: :swinging,
+                                              is_new_format: true)
+
+        patch "/api/v2/plate_appearances/#{strikeout.id}",
+              params: { plate_appearance: { swing_type: 'looking' } },
+              headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(strikeout.reload.swing_type_looking?).to be(true)
+      end
+
+      it '三振以外の PA に swing_type を更新で付与しようとすると 422' do
+        patch "/api/v2/plate_appearances/#{plate_appearance.id}",
+              params: { plate_appearance: { swing_type: 'swinging' } },
+              headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['errors'].join).to include('三振')
+        expect(plate_appearance.reload.swing_type).to be_nil
+      end
     end
 
     context 'when not authenticated' do

--- a/spec/requests/api/v2/plate_appearances_spec.rb
+++ b/spec/requests/api/v2/plate_appearances_spec.rb
@@ -74,6 +74,31 @@ RSpec.describe 'Api::V2::PlateAppearances', type: :request do
         expect(response).to have_http_status(:created)
         expect(PlateAppearance.find(response.parsed_body['id']).pitcher_id).to eq(own_pitcher.id)
       end
+
+      it '三振 (plate_result_id=13) + swing_type=swinging で 201 と swing_type 保存' do
+        strikeout_params = {
+          plate_appearance: {
+            game_result_id: game_result.id,
+            batter_box_number: 2,
+            plate_result_id: 13,
+            swing_type: 'swinging'
+          }
+        }
+        post '/api/v2/plate_appearances', params: strikeout_params, headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body['swing_type']).to eq('swinging')
+        expect(PlateAppearance.find(response.parsed_body['id']).swing_type_looking?).to be(false)
+      end
+
+      it '三振以外 (例: 単打 id=7) に swing_type を指定すると 422' do
+        bad_params = base_params.deep_merge(plate_appearance: { swing_type: 'swinging' })
+
+        post '/api/v2/plate_appearances', params: bad_params, headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['errors'].join).to include('三振')
+      end
     end
 
     context 'when not authenticated' do

--- a/spec/services/stats/additional_stats_aggregator_spec.rb
+++ b/spec/services/stats/additional_stats_aggregator_spec.rb
@@ -103,5 +103,41 @@ RSpec.describe Stats::AdditionalStatsAggregator, type: :service do
         end
       end
     end
+
+    context 'with strike_out swing_type breakdown' do
+      let!(:game_result) do
+        gr = create(:game_result, user:)
+        gr.match_result.update!(date_and_time: Time.zone.parse('2026-04-01 12:00:00'))
+        gr
+      end
+
+      before do
+        # 新仕様 PA: 空振り三振 ×2、見逃し三振 ×1、swing_type 未指定の三振 ×1、振り逃げ ×1、ヒット ×1
+        create(:plate_appearance, game_result:, user:, batter_box_number: 1,
+                                  plate_result_id: 13, swing_type: :swinging, is_new_format: true)
+        create(:plate_appearance, game_result:, user:, batter_box_number: 2,
+                                  plate_result_id: 13, swing_type: :swinging, is_new_format: true)
+        create(:plate_appearance, game_result:, user:, batter_box_number: 3,
+                                  plate_result_id: 13, swing_type: :looking, is_new_format: true)
+        create(:plate_appearance, game_result:, user:, batter_box_number: 4,
+                                  plate_result_id: 13, is_new_format: true)
+        create(:plate_appearance, game_result:, user:, batter_box_number: 5,
+                                  plate_result_id: 14, is_new_format: true)
+        create(:plate_appearance, game_result:, user:, batter_box_number: 6,
+                                  plate_result_id: 7, is_new_format: true)
+        # 旧 PA も投入 → 内訳には含めない
+        create(:plate_appearance, game_result:, user:, batter_box_number: 7,
+                                  plate_result_id: 13, is_new_format: false)
+      end
+
+      it 'returns swinging / looking breakdown from new-format PAs only' do
+        result = described_class.new(user_id: user.id).call
+
+        aggregate_failures do
+          expect(result[:swinging_strike_out]).to eq(2)
+          expect(result[:looking_strike_out]).to eq(1)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- ippei-shimizu/buzzbase#383 対応の back 側。mobile の新仕様打席記録画面に存在する「空振り三振 / 見逃し三振」のボタンが両方とも `plate_result_id=13` で保存されていた不整合を解消する。
- `plate_appearances.swing_type` enum (`swinging` / `looking`, nullable) を追加し、(1) PA 保存時に区別、(2) `AdditionalStatsAggregator` で `swinging_strike_out` / `looking_strike_out` の内訳を返す。

## 変更点

### `Add: plate_appearances.swing_type マイグレーション + model enum + validate` (1ba6ecb)

- マイグレーション: `add_column :plate_appearances, :swing_type, :integer` + index
- `PlateAppearance` モデル: `enum swing_type: { swinging: 0, looking: 1 }, _prefix: true`、`attribute :swing_type, :integer` で migration 前後どちらでもロード可能
- validate: 三振以外 (`plate_result_id != 13`) に swing_type が来た場合は invalid
- `STRIKEOUT_RESULT_ID = 13` 定数を model に置いてマジックナンバー排除

### `Add: v2 plate_appearances controller / serializer で swing_type を受け渡し` (d4b5d2e)

- `Api::V2::PlateAppearancesController#plate_appearance_params` の permit に `:swing_type` を追加
- `V2::PlateAppearanceSerializer` の attributes に `:swing_type` を追加
- request spec で「三振 + swinging で 201」「三振以外 + swing_type で 422」を保護
- v1 controller は permit が最小構成で mobile 運用も v2 のみのため触らない（regression なし）

### `Add: AdditionalStatsAggregator に swinging_strike_out / looking_strike_out を追加` (23a91f7)

- 新仕様 PA の三振 (id=13) を swing_type 別に集計（enum scope 経由で 2 クエリ）
- `batting_averages` 側にカラムを増やさない方針: recalculator 連鎖の影響を避ける
- 旧 PA (`is_new_format=false`) と振り逃げ (id=14) は対象外
- 既存 `strike_out` 総数 (id=13 + 14) は変えない。新フィールドは純然たる内訳で、合計が `strike_out` と一致しないケース (swing_type 未設定 / 振り逃げ / 旧 PA) があるのは仕様

## スコープ外（本 PR では触らない）

- mobile 側の UI 実装（`plateResults.ts` の TODO 解除 + store + AdditionalStatsCard 表示）→ 別 PR
- `batting_averages` 集約への取り込み（パフォーマンス要求が出るまで PA 直接集計で対応）
- 過去 PA への swing_type バックフィル（区別情報がそもそも無い）

## Test plan

- [x] `docker compose exec back bundle exec rspec spec/models/plate_appearance_spec.rb spec/requests/api/v2/plate_appearances_spec.rb spec/services/stats/additional_stats_aggregator_spec.rb` → 全 PASS
- [x] `docker compose exec back bundle exec rubocop app/models/plate_appearance.rb app/controllers/api/v2/plate_appearances_controller.rb app/serializers/v2/plate_appearance_serializer.rb app/services/stats/additional_stats_aggregator.rb db/migrate/20260617000000_add_swing_type_to_plate_appearances.rb` → 0 offenses
- [ ] stg 反映後、`POST /api/v2/plate_appearances` に `swing_type: "swinging"` を含めて三振を保存 → `swing_type` が DB に保存される
- [ ] `GET` で取り出した PA に `swing_type` が含まれている
- [ ] 三振以外 (例: id=7) で `swing_type` を含めると 422
- [ ] stats タブの `/api/v2/stats/additional_stats` レスポンスに `swinging_strike_out` / `looking_strike_out` が含まれる
- [ ] 旧データのみのユーザー: 両フィールドとも 0
