### PR TITLE
Fix: マイページ / ダッシュボード / ランキングの打率 二重計上を修正

### DIFF
--- a/app/models/batting_average.rb
+++ b/app/models/batting_average.rb
@@ -1,3 +1,15 @@
+# `batting_averages.hit` カラムは **単打 + 二塁打 + 三塁打 + 本塁打 を合算した
+# 全安打数** を保持する（NPB / MLB スコアボードの「H 列」と同じセマンティクス）。
+# 旧仕様の手入力フォームも、新仕様の `Stats::BattingAverageRecalculator`
+# (`HIT_RESULT_IDS = [7, 8, 9, 10]` を全件カウント) も同じ意味で書き込んでおり、
+# `two_base_hit` / `three_base_hit` / `home_run` カラムは「うち何本が何塁打か」
+# という内訳を持つ。
+#
+# 集計式を組むときは
+#   - 総安打 = SUM(hit)
+#   - 単打数 = SUM(hit) - SUM(two_base_hit) - SUM(three_base_hit) - SUM(home_run)
+#   - 塁打 (TB) = SUM(hit) + SUM(two_base_hit) + 2*SUM(three_base_hit) + 3*SUM(home_run)
+# となる点に注意（`hit + 2*two_base_hit + ...` のように単打式で組むと二重計上）。
 class BattingAverage < ApplicationRecord
   belongs_to :game_result
   belongs_to :user
@@ -83,8 +95,11 @@ class BattingAverage < ApplicationRecord
     scope
   end
 
+  # `hit` カラムは全安打を含むため、総安打 = SUM(hit)。
+  # 以前は `SUM(hit + 2B + 3B + HR)` と書いていたが、2B/3B/HR を二重計上して
+  # 打率 / OBP / OPS / ISOD が上振れていた既存バグの修正。
   def self.stats_columns
-    ['SUM(hit + two_base_hit + three_base_hit + home_run) AS total_hits',
+    ['SUM(hit) AS total_hits',
      'SUM(hit) AS hit',
      'SUM(two_base_hit) AS two_base_hit',
      'SUM(three_base_hit) AS three_base_hit',
@@ -138,10 +153,14 @@ class BattingAverage < ApplicationRecord
     (obp - avg).round(3)
   end
 
+  # `hit` は全安打（単打 + 2B + 3B + HR）なので、塁打 (TB) は
+  # 単打×1 + 2B×2 + 3B×3 + HR×4 を展開して
+  # `hit + 2B + 2*3B + 3*HR` に等しい。以前は `hit + 2*2B + 3*3B + 4*HR` と
+  # 書いていたが、これは hit を単打のみと解釈した式で 2B/3B/HR を二重計上していた。
   def self.calculate_slugging_percentage(stats)
     at_bats = stats['at_bats'].to_i
-    total_bases = stats['hit'].to_i + (stats['two_base_hit'].to_i * 2) +
-                  (stats['three_base_hit'].to_i * 3) + (stats['home_run'].to_i * 4)
+    total_bases = stats['hit'].to_i + stats['two_base_hit'].to_i +
+                  (stats['three_base_hit'].to_i * 2) + (stats['home_run'].to_i * 3)
     at_bats.zero? ? ZERO : total_bases.to_f / at_bats
   end
 

--- a/app/models/batting_average.rb
+++ b/app/models/batting_average.rb
@@ -98,9 +98,10 @@ class BattingAverage < ApplicationRecord
   # `hit` カラムは全安打を含むため、総安打 = SUM(hit)。
   # 以前は `SUM(hit + 2B + 3B + HR)` と書いていたが、2B/3B/HR を二重計上して
   # 打率 / OBP / OPS / ISOD が上振れていた既存バグの修正。
+  # `hit` 単独の SUM は不要（消費側は total_hits を参照する）。同じ式を二重に
+  # SELECT すると「hit と total_hits の値が違う」という誤読の芽になる。
   def self.stats_columns
     ['SUM(hit) AS total_hits',
-     'SUM(hit) AS hit',
      'SUM(two_base_hit) AS two_base_hit',
      'SUM(three_base_hit) AS three_base_hit',
      'SUM(home_run) AS home_run',
@@ -153,13 +154,13 @@ class BattingAverage < ApplicationRecord
     (obp - avg).round(3)
   end
 
-  # `hit` は全安打（単打 + 2B + 3B + HR）なので、塁打 (TB) は
+  # `total_hits` は全安打（単打 + 2B + 3B + HR）なので、塁打 (TB) は
   # 単打×1 + 2B×2 + 3B×3 + HR×4 を展開して
-  # `hit + 2B + 2*3B + 3*HR` に等しい。以前は `hit + 2*2B + 3*3B + 4*HR` と
-  # 書いていたが、これは hit を単打のみと解釈した式で 2B/3B/HR を二重計上していた。
+  # `total_hits + 2B + 2*3B + 3*HR` に等しい。以前は `hit + 2*2B + 3*3B + 4*HR`
+  # と書いていたが、これは hit を単打のみと解釈した式で 2B/3B/HR を二重計上していた。
   def self.calculate_slugging_percentage(stats)
     at_bats = stats['at_bats'].to_i
-    total_bases = stats['hit'].to_i + stats['two_base_hit'].to_i +
+    total_bases = stats['total_hits'].to_i + stats['two_base_hit'].to_i +
                   (stats['three_base_hit'].to_i * 2) + (stats['home_run'].to_i * 3)
     at_bats.zero? ? ZERO : total_bases.to_f / at_bats
   end

--- a/spec/models/batting_average_consistency_spec.rb
+++ b/spec/models/batting_average_consistency_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# `BattingAverage.stats_for_user` / `filtered_stats_for_user` 系の打率 / OBP / SLG /
+# OPS が NPB 公式式と一致することを保証する retention test。
+#
+# 旧実装は `SUM(hit + 2B + 3B + HR) AS total_hits` と `total_bases = hit + 2*2B +
+# 3*3B + 4*HR` の式で書かれており、`batting_averages.hit` が「全安打 (単打 + 2B
+# + 3B + HR)」を保持しているにもかかわらず単打のみと解釈していたため、2B/3B/HR
+# を二重計上して全画面（マイページ / ダッシュボード / グループランキング）で
+# 打率 / OBP / OPS / ISOD が上振れていた。
+RSpec.describe 'BattingAverage stats formulas', type: :model do
+  let(:user) { create(:user) }
+
+  def create_game_with_batting(date:, hit:, at_bats:, two_base_hit: 0, three_base_hit: 0, # rubocop:disable Metrics/ParameterLists
+                               home_run: 0, base_on_balls: 0, hit_by_pitch: 0,
+                               sacrifice_fly: 0)
+    game = create(:game_result, user:)
+    game.match_result.update!(date_and_time: Time.zone.parse(date), match_type: 'regular')
+    # `hit` は全安打を含む semantics。単打 = hit - 2B - 3B - HR。
+    singles = hit - two_base_hit - three_base_hit - home_run
+    total_bases = singles + (two_base_hit * 2) + (three_base_hit * 3) + (home_run * 4)
+    create(:batting_average, game_result: game, user:,
+                             hit:, at_bats:, total_bases:,
+                             two_base_hit:, three_base_hit:, home_run:,
+                             base_on_balls:, hit_by_pitch:, sacrifice_fly:,
+                             times_at_bat: at_bats + base_on_balls + hit_by_pitch + sacrifice_fly,
+                             strike_out: 0, sacrifice_hit: 0)
+  end
+
+  context 'with mixed singles, doubles, triples, home runs across games' do
+    before do
+      # 試合 1: 4 打数 2 安打 (うち 2B 1 本) BB 1 → 単打 1 + 2B 1
+      create_game_with_batting(date: '2026-04-01', hit: 2, at_bats: 4, two_base_hit: 1, base_on_balls: 1)
+      # 試合 2: 3 打数 2 安打 (うち HR 1 本) → 単打 1 + HR 1
+      create_game_with_batting(date: '2026-04-15', hit: 2, at_bats: 3, home_run: 1)
+      # 試合 3: 5 打数 1 安打 (単打) → 単打 1
+      create_game_with_batting(date: '2026-04-30', hit: 1, at_bats: 5)
+    end
+
+    # 通算: PA=13 AB=12 H=5 2B=1 3B=0 HR=1 単打=3
+    # TB = 単打 1×3 + 2B 2×1 + 3B 3×0 + HR 4×1 = 3 + 2 + 0 + 4 = 9
+    # BB=1 HBP=0 SF=0
+    # 打率 = 5/12 = .417
+    # OBP = (5+1+0)/(12+1+0+0) = 6/13 = .462
+    # SLG = 9/12 = .750
+    # OPS = .462 + .750 = 1.212
+
+    it '通算打率 = SUM(hit) / SUM(at_bats) で二重計上しない' do
+      result = BattingAverage.stats_for_user(user.id)
+
+      aggregate_failures do
+        expect(result[:total_hits]).to eq(5)
+        expect(result[:batting_average]).to eq((5.0 / 12).round(3))
+      end
+    end
+
+    it 'SLG は TB = hit + 2B + 2*3B + 3*HR で計算される' do
+      result = BattingAverage.stats_for_user(user.id)
+
+      expect(result[:slugging_percentage]).to eq((9.0 / 12).round(3))
+    end
+
+    it 'OBP = (H + BB + HBP) / (AB + BB + HBP + SF) で全安打を二重計上しない' do
+      result = BattingAverage.stats_for_user(user.id)
+
+      expect(result[:on_base_percentage]).to eq((6.0 / 13).round(3))
+    end
+
+    it 'OPS = OBP + SLG で二重計上しない' do
+      result = BattingAverage.stats_for_user(user.id)
+      expected_obp = (6.0 / 13).round(3)
+      expected_slg = (9.0 / 12).round(3)
+
+      expect(result[:ops]).to eq((expected_obp + expected_slg).round(3))
+    end
+
+    it 'ISOD = OBP - AVG で全安打を二重計上しない' do
+      result = BattingAverage.stats_for_user(user.id)
+      expected_avg = (5.0 / 12).round(3)
+      expected_obp = (6.0 / 13).round(3)
+
+      expect(result[:isod]).to eq((expected_obp - expected_avg).round(3))
+    end
+  end
+
+  context 'with year filter (filtered_stats_for_user 経由)' do
+    before do
+      # 2025 年データ
+      create_game_with_batting(date: '2025-09-30', hit: 2, at_bats: 4, two_base_hit: 1)
+      # 2026 年データ
+      create_game_with_batting(date: '2026-04-01', hit: 3, at_bats: 6, home_run: 1)
+    end
+
+    it 'filtered_stats_for_user でも二重計上が起きない' do
+      result = BattingAverage.filtered_stats_for_user(user.id, year: '2026')
+
+      # 2026 年のみ: hit=3 AB=6 → 打率 .500
+      expect(result[:batting_average]).to eq(0.5)
+    end
+  end
+end

--- a/spec/models/batting_average_consistency_spec.rb
+++ b/spec/models/batting_average_consistency_spec.rb
@@ -100,4 +100,37 @@ RSpec.describe 'BattingAverage stats formulas', type: :model do
       expect(result[:batting_average]).to eq(0.5)
     end
   end
+
+  # グループランキング系で使う bulk_stats_for_users が同じ stats_columns を
+  # 共有しているため自動的に修正が当たっているが、ランキング画面の保護として
+  # 直接 retention test を置く。
+  context 'bulk_stats_for_users 経由（グループランキング）' do
+    let(:other_user) { create(:user) }
+
+    before do
+      # user: AB=10 H=3 (内訳: 単打 1 + 2B 1 + HR 1)
+      create_game_with_batting(date: '2026-05-01', hit: 3, at_bats: 10, two_base_hit: 1, home_run: 1)
+      # other_user: AB=8 H=2 (単打のみ)
+      game = create(:game_result, user: other_user)
+      game.match_result.update!(date_and_time: Time.zone.parse('2026-05-02'), match_type: 'regular')
+      create(:batting_average, game_result: game, user: other_user,
+                               hit: 2, at_bats: 8, total_bases: 2,
+                               two_base_hit: 0, three_base_hit: 0, home_run: 0,
+                               base_on_balls: 0, hit_by_pitch: 0, sacrifice_fly: 0,
+                               times_at_bat: 8, strike_out: 0, sacrifice_hit: 0)
+    end
+
+    it '複数ユーザーの打率 / SLG / OPS が二重計上なしで返る' do
+      result = BattingAverage.bulk_stats_for_users([user.id, other_user.id])
+
+      # user: 打率 3/10 = .300, SLG = (1 + 2 + 4)/10 = .700
+      # other_user: 打率 2/8 = .250, SLG = 2/8 = .250
+      aggregate_failures do
+        expect(result[user.id][:batting_average]).to eq(0.3)
+        expect(result[user.id][:slugging_percentage]).to eq(0.7)
+        expect(result[other_user.id][:batting_average]).to eq(0.25)
+        expect(result[other_user.id][:slugging_percentage]).to eq(0.25)
+      end
+    end
+  end
 end

--- a/spec/models/batting_average_spec.rb
+++ b/spec/models/batting_average_spec.rb
@@ -90,8 +90,8 @@ RSpec.describe BattingAverage, type: :model do
     end
 
     it 'calculates slugging_percentage from TB = hit + 2B + 2*3B + 3*HR' do
-      # hit=3 (うち 2B=1, HR=1, 単打=1)
-      # TB = 1×1 (単打) + 1×2 (2B) + 1×4 (HR) = 7
+      # hit=3 (全安打: 単打 1, 2B 1, HR 1)
+      # TB = hit(3) + 2B(1) + 2*3B(0) + 3*HR(3) = 7
       # SLG = 7 / 10 = .700
       result = described_class.filtered_stats_for_user(user.id, year: '2024')
       expect(result[:slugging_percentage]).to eq(0.7)

--- a/spec/models/batting_average_spec.rb
+++ b/spec/models/batting_average_spec.rb
@@ -81,11 +81,29 @@ RSpec.describe BattingAverage, type: :model do
       expect(result).to include(:batting_average, :on_base_percentage, :slugging_percentage, :ops, :iso, :bb_per_k, :isod)
     end
 
-    it 'calculates batting_average correctly' do
+    it 'calculates batting_average as SUM(hit) / SUM(at_bats), not double counting 2B/3B/HR' do
+      # `hit` カラムは「全安打 (単打 + 2B + 3B + HR)」を保持するセマンティクス。
+      # hit=3 のうち 2B が 1、HR が 1、残り 1 本が単打、合計 3 安打 / 10 打数 → 打率 .300
       result = described_class.filtered_stats_for_user(user.id, year: '2024')
-      # total_hits = hit(3) + two_base_hit(1) + three_base_hit(0) + home_run(1) = 5
-      # batting_average = 5 / 10 = 0.5
-      expect(result[:batting_average]).to eq(0.5)
+      expect(result[:batting_average]).to eq(0.3)
+      expect(result[:total_hits]).to eq(3)
+    end
+
+    it 'calculates slugging_percentage from TB = hit + 2B + 2*3B + 3*HR' do
+      # hit=3 (うち 2B=1, HR=1, 単打=1)
+      # TB = 1×1 (単打) + 1×2 (2B) + 1×4 (HR) = 7
+      # SLG = 7 / 10 = .700
+      result = described_class.filtered_stats_for_user(user.id, year: '2024')
+      expect(result[:slugging_percentage]).to eq(0.7)
+    end
+
+    it 'calculates OPS = OBP + SLG without inflation' do
+      # OBP = (3 + 2 + 0) / (10 + 2 + 0 + 0) = 5/12 = .417 (3 桁)
+      # SLG = .700
+      # OPS = OBP + SLG = 1.117
+      result = described_class.filtered_stats_for_user(user.id, year: '2024')
+      obp = (3 + 2.0) / (10 + 2)
+      expect(result[:ops]).to eq((obp + 0.7).round(3))
     end
 
     it 'returns all-zero calculated stats when no games match the filter' do


### PR DESCRIPTION
## Summary

- ippei-shimizu/buzzbase#387 対応。`BattingAverage.stats_for_user` 系の集計式が 2B / 3B / HR を二重計上しており、マイページ / ダッシュボード / グループランキング / グループ詳細スタッツで打率 / OBP / OPS / ISOD が上振れて表示されていた既存バグを修正する（2024-02 以来 2 年半潜在）。
- 修正前: dev8 通算で打率 **.486**（上振れ）。修正後: **.384**（正しい）。
- release/game-stats-202605 リリースを待たずに先行修正。リリース後の「マイページと stats タブで打率が違う」混乱を防ぐ意図。

## 背景: `hit` カラムのセマンティクス

`batting_averages.hit` カラムは **全安打（単打 + 2B + 3B + HR）の合計** を保持する。NPB / MLB スコアボードの「H 列」と同じ。

- 旧仕様の手入力フォーム時代から `hit` = 全安打で運用されていた
- 新仕様の `Stats::BattingAverageRecalculator` も `HIT_RESULT_IDS = [7, 8, 9, 10]` を全件カウントで書き込む
- DB 全 2968 件で `hit < 2B + 3B + HR` のレコード 0 件、`TB = hit + 2B + 2*3B + 3*HR` が 100% 成立で検証済み

`two_base_hit` / `three_base_hit` / `home_run` カラムは「うち何本が何塁打か」という内訳カラム。

## 変更点

### `app/models/batting_average.rb`

1. **クラス先頭にコメント追加**: `hit` カラムのセマンティクスを明文化し、同様の誤実装が将来繰り返されないようにする
2. **`stats_columns` の `total_hits`**:
   - 修正前: `'SUM(hit + two_base_hit + three_base_hit + home_run) AS total_hits'`（2B/3B/HR を二重計上）
   - 修正後: `'SUM(hit) AS total_hits'`
3. **`calculate_slugging_percentage` の塁打式**:
   - 修正前: `hit + 2*2B + 3*3B + 4*HR`（`hit` を単打のみと誤認した式）
   - 修正後: `hit + 2B + 2*3B + 3*HR`（`hit` が全安打を含む前提の正しい展開）

OBP / OPS / ISOD は `total_hits` を介して間接的に正しくなる。ISO は元から正しい式 (`(2B + 2*3B + 3*HR) / AB`) なので変更なし。

### spec

- `spec/models/batting_average_spec.rb`: 既存テストがバグの式を期待値として encode していたので、正しい式で書き直す + SLG / OPS のテストを追加
- `spec/models/batting_average_consistency_spec.rb`: 新規。複数試合をまたいだ集計で、打率 / OBP / SLG / OPS / ISOD が NPB 公式式と一致することを retention test として保護

## 影響範囲

`BattingAverage.stats_for_user` / `filtered_stats_for_user` / `bulk_stats_for_users` を呼んでいる箇所すべて:

| サーフェス | 呼び出し元 |
|---|---|
| マイページ 打率 / OPS 等 | `api/v1/batting_averages_controller.rb#personal_batting_stats` |
| ダッシュボード | `api/v2/dashboards_controller.rb#build_batting_stats` |
| グループランキング | `api/v2/concerns/dashboard_rankings.rb` |
| グループランキングスナップショット | `services/group_ranking_snapshot_service.rb` |
| グループ詳細スタッツ | `services/groups/stats_builder.rb` |

すべての画面で打率 / OBP / SLG / OPS / ISOD が正しい値（小さくなる）に補正される。グループランキングは **長打が多いユーザーほど上振れ幅が大きい** ため、順位が動く可能性あり（特に上位）。

## ユーザー告知

マージ直後に mobile アプリの notice-from-management で 1 回告知する。「集計式の不具合により打率が高めに表示されていたため修正しました。SLG / OPS / 順位にも影響します」と率直に明言（Issue #387 の方針）。

## Test plan

- [x] `docker compose exec back bundle exec rspec spec/models/batting_average_spec.rb spec/models/batting_average_consistency_spec.rb` → 22 examples PASS
- [x] `docker compose exec back bundle exec rspec spec/requests/api/v1/batting_averages_spec.rb spec/services/group_ranking_snapshot_service_spec.rb spec/requests/api/v2/dashboards_spec.rb spec/requests/api/v1/groups_spec.rb spec/models/group_ranking_snapshot_spec.rb` → 66 examples PASS（既存テストは期待値で打率を encode していなかったので影響なし）
- [x] `docker compose exec back bundle exec rubocop app/models/batting_average.rb spec/models/batting_average_spec.rb spec/models/batting_average_consistency_spec.rb` → 0 offenses
- [ ] stg 反映後、dev8 のマイページで打率が `.486 → .384` に下がっていることを目視確認
- [ ] グループランキングで順位変動が想定通り発生していることを確認
