### PR TITLE
Refactor: stats 集計式を本番の hit semantics に揃え + 安打表示を NPB 標準に統一

### DIFF
--- a/app/models/batting_average.rb
+++ b/app/models/batting_average.rb
@@ -1,3 +1,38 @@
+# `batting_averages.hit` カラムは **単打のみ** を保持する semantics で運用されている
+# （v1 フォーム手入力時代から一貫）。NPB / MLB スコアボードの「H（安打）」とは
+# 意味が異なる点に注意。
+#
+# == カラム定義（実データ）
+# - `hit`                : 単打数のみ（NPB 用語では「単打」「1B」相当）
+# - `two_base_hit`       : 二塁打の本数
+# - `three_base_hit`     : 三塁打の本数
+# - `home_run`           : 本塁打の本数
+# - `total_bases`        : 塁打 = `hit + 2*two_base_hit + 3*three_base_hit + 4*home_run`
+#
+# == 「安打」として画面に出す値（NPB 標準）
+#
+# 画面の「安打」ラベルが指す値は **全安打 = `hit + two_base_hit + three_base_hit + home_run`**。
+# 直接 `SUM(hit)` を画面表示すると単打数のみが表示され、ユーザーが手計算で
+# 「安打 / 打数 = 打率」と検算しても合わない問題が起きる（過去に起きた）。
+#
+# 集計時は以下の式で安打 / 打率 / OBP / SLG を算出する:
+#   total_hits = hit + two_base_hit + three_base_hit + home_run
+#   batting_average = total_hits / at_bats
+#   OBP = (total_hits + base_on_balls + hit_by_pitch) / (at_bats + base_on_balls + hit_by_pitch + sacrifice_fly)
+#   SLG = total_bases / at_bats
+#
+# == 各レイヤーの実装
+# - 本モデル `aggregate_columns` / `stats_columns`     : 内部で `SUM(hit + 2B + 3B + HR)` を返す
+# - `Stats::HeadlineStatsAggregator` (stats タブ主要)  : 同様に total_hits を導出
+# - `Stats::AdditionalStatsAggregator` (追加指標)      : 同様
+# - `Stats::BattingTrendAggregator` (打撃推移)         : 同様
+# - `Stats::BattingStatsTableService` (打撃成績表)     : 同様
+# - `Stats::BattingAverageRecalculator` (書き込み側)   : 新仕様 PA から hit カラムを
+#                                                         書き込むときは SINGLE_HIT_ID (= 7) のみ
+#                                                         をカウントし、旧データと同じ semantics を保つ
+#
+# == 単打のみの値が欲しい場合
+# 個別レコード列の `hit` を直接参照する（マイページ等の表示には出さない方針）。
 class BattingAverage < ApplicationRecord
   belongs_to :game_result
   belongs_to :user

--- a/app/models/batting_average.rb
+++ b/app/models/batting_average.rb
@@ -24,7 +24,11 @@ class BattingAverage < ApplicationRecord
      'COUNT(batting_averages.game_result_id) AS number_of_matches',
      'SUM(times_at_bat) AS times_at_bat',
      'SUM(at_bats) AS at_bats',
-     'SUM(hit) AS hit',
+     # `hit` カラムは本番運用上「単打のみ」を保持するが、画面で「安打」として
+     # 表示する値は NPB 標準の全安打（単打 + 二塁打 + 三塁打 + 本塁打）。
+     # マイページ / ダッシュボード / ランキング / グループスタッツの安打表示を
+     # NPB 標準に揃え、stats タブの主要スタッツとも一致させる。
+     'SUM(hit + two_base_hit + three_base_hit + home_run) AS hit',
      'SUM(two_base_hit) AS two_base_hit',
      'SUM(three_base_hit) AS three_base_hit',
      'SUM(home_run) AS home_run',

--- a/app/services/stats/additional_stats_aggregator.rb
+++ b/app/services/stats/additional_stats_aggregator.rb
@@ -14,7 +14,7 @@ module Stats
 
     SUM_COLUMNS = %i[
       plate_appearances at_bats hit total_bases
-      two_base_hit three_base_hit
+      two_base_hit three_base_hit home_run
       run strike_out base_on_balls hit_by_pitch
       sacrifice_hit sacrifice_fly stealing_base caught_stealing
     ].freeze
@@ -77,9 +77,12 @@ module Stats
 
     def computed_rates(stats)
       at_bats = stats[:at_bats]
-      batting_average = safe_divide(stats[:hit], at_bats)
+      # `batting_averages.hit` は本番運用上「単打のみ」を保持するため、総安打は
+      # 単打 + 2B + 3B + HR を加算して導出する。HeadlineStatsAggregator と同じパターン。
+      total_hits = stats[:hit] + stats[:two_base_hit] + stats[:three_base_hit] + stats[:home_run]
+      batting_average = safe_divide(total_hits, at_bats)
       obp_denom = at_bats + stats[:base_on_balls] + stats[:hit_by_pitch] + stats[:sacrifice_fly]
-      obp = safe_divide(stats[:hit] + stats[:base_on_balls] + stats[:hit_by_pitch], obp_denom)
+      obp = safe_divide(total_hits + stats[:base_on_balls] + stats[:hit_by_pitch], obp_denom)
       slg = safe_divide(stats[:total_bases], at_bats)
       {
         iso: round3(slg - batting_average),

--- a/app/services/stats/batting_average_recalculator.rb
+++ b/app/services/stats/batting_average_recalculator.rb
@@ -91,19 +91,26 @@ module Stats
       # 本アプリでは既存集計テーブルに揃えて同一値で運用している（旧仕様 batting_average も同様）。
       counted = with_plate_result.where(plate_results: { counted_in_at_bats: true }).count
 
+      # `batting_averages.hit` は本番運用上「単打のみ」を保持する semantics で揃える。
+      # 2B/3B/HR は別カラムで内訳として持つため、ここで全安打を入れると
+      # マイページ系 (`BattingAverage.stats_for_user` の `SUM(hit + 2B + 3B + HR)`)
+      # で二重計上になる。集計の真は SUM(hit) + SUM(2B) + SUM(3B) + SUM(HR)。
+      single = scope.where(plate_result_id: SINGLE_HIT_ID).count
+      double = scope.where(plate_result_id: DOUBLE_HIT_ID).count
+      triple = scope.where(plate_result_id: TRIPLE_HIT_ID).count
+      homer  = scope.where(plate_result_id: HOME_RUN_ID).count
+
       {
         plate_appearances: scope.count,
         times_at_bat: counted,
         at_bats: counted,
-        # `batting_averages.hit` は本番運用上「単打のみ」を保持する semantics で揃える。
-        # 2B/3B/HR は別カラムで内訳として持つため、ここで全安打を入れると
-        # マイページ系 (`BattingAverage.stats_for_user` の `SUM(hit + 2B + 3B + HR)`)
-        # で二重計上になる。集計の真は SUM(hit) + SUM(2B) + SUM(3B) + SUM(HR)。
-        hit: scope.where(plate_result_id: SINGLE_HIT_ID).count,
-        two_base_hit: scope.where(plate_result_id: DOUBLE_HIT_ID).count,
-        three_base_hit: scope.where(plate_result_id: TRIPLE_HIT_ID).count,
-        home_run: scope.where(plate_result_id: HOME_RUN_ID).count,
-        total_bases: compute_total_bases(scope),
+        hit: single,
+        two_base_hit: double,
+        three_base_hit: triple,
+        home_run: homer,
+        # 塁打 (TB) = 単打×1 + 2B×2 + 3B×3 + HR×4。既に取得済みのカウントを再利用して
+        # 同じ COUNT クエリを 4 本余計に発行しないようにする。
+        total_bases: single + (double * 2) + (triple * 3) + (homer * 4),
         runs_batted_in: scope.sum(:rbi).to_i,
         run: scope.sum(:run_scored).to_i,
         strike_out: scope.where(plate_result_id: STRIKE_OUT_IDS).count,
@@ -115,13 +122,6 @@ module Stats
         caught_stealing: scope.sum(:caught_stealing).to_i,
         error: scope.where(plate_result_id: ERROR_ID).count
       }
-    end
-
-    def compute_total_bases(scope)
-      scope.where(plate_result_id: SINGLE_HIT_ID).count +
-        (scope.where(plate_result_id: DOUBLE_HIT_ID).count * 2) +
-        (scope.where(plate_result_id: TRIPLE_HIT_ID).count * 3) +
-        (scope.where(plate_result_id: HOME_RUN_ID).count * 4)
     end
   end
 end

--- a/app/services/stats/batting_average_recalculator.rb
+++ b/app/services/stats/batting_average_recalculator.rb
@@ -95,7 +95,11 @@ module Stats
         plate_appearances: scope.count,
         times_at_bat: counted,
         at_bats: counted,
-        hit: scope.where(plate_result_id: HIT_RESULT_IDS).count,
+        # `batting_averages.hit` は本番運用上「単打のみ」を保持する semantics で揃える。
+        # 2B/3B/HR は別カラムで内訳として持つため、ここで全安打を入れると
+        # マイページ系 (`BattingAverage.stats_for_user` の `SUM(hit + 2B + 3B + HR)`)
+        # で二重計上になる。集計の真は SUM(hit) + SUM(2B) + SUM(3B) + SUM(HR)。
+        hit: scope.where(plate_result_id: SINGLE_HIT_ID).count,
         two_base_hit: scope.where(plate_result_id: DOUBLE_HIT_ID).count,
         three_base_hit: scope.where(plate_result_id: TRIPLE_HIT_ID).count,
         home_run: scope.where(plate_result_id: HOME_RUN_ID).count,

--- a/app/services/stats/batting_trend_aggregator.rb
+++ b/app/services/stats/batting_trend_aggregator.rb
@@ -13,7 +13,10 @@ module Stats
   class BattingTrendAggregator # rubocop:disable Metrics/ClassLength
     include Concerns::FilterableConcern
 
-    SUM_COLUMNS = %i[at_bats hit total_bases base_on_balls hit_by_pitch sacrifice_fly].freeze
+    SUM_COLUMNS = %i[
+      at_bats hit two_base_hit three_base_hit home_run
+      total_bases base_on_balls hit_by_pitch sacrifice_fly
+    ].freeze
 
     # 受け付ける granularity:
     # - `game`: 開幕から各試合時点までの **累積**（シーズン通算の推移）
@@ -171,17 +174,20 @@ module Stats
 
     def build_point(key:, label:, period_stats:, cumulative_stats:)
       at_bats = cumulative_stats[:at_bats]
+      # `batting_averages.hit` は本番運用上「単打のみ」を保持するため、総安打は
+      # 単打 + 2B + 3B + HR を加算して導出する。HeadlineStatsAggregator と同じパターン。
+      total_hits = cumulative_stats[:hit] + cumulative_stats[:two_base_hit] +
+                   cumulative_stats[:three_base_hit] + cumulative_stats[:home_run]
       obp_denom = at_bats + cumulative_stats[:base_on_balls] +
                   cumulative_stats[:hit_by_pitch] + cumulative_stats[:sacrifice_fly]
-      obp_num = cumulative_stats[:hit] + cumulative_stats[:base_on_balls] +
-                cumulative_stats[:hit_by_pitch]
+      obp_num = total_hits + cumulative_stats[:base_on_balls] + cumulative_stats[:hit_by_pitch]
       obp = safe_divide(obp_num, obp_denom)
       slg = safe_divide(cumulative_stats[:total_bases], at_bats)
 
       {
         key:,
         label:,
-        batting_average: safe_divide(cumulative_stats[:hit], at_bats),
+        batting_average: safe_divide(total_hits, at_bats),
         on_base_percentage: obp,
         slugging_percentage: slg,
         ops: round3(obp + slg),

--- a/app/services/stats/headline_stats_aggregator.rb
+++ b/app/services/stats/headline_stats_aggregator.rb
@@ -24,13 +24,17 @@ module Stats
     def call
       stats = aggregate_stats
       at_bats = stats[:at_bats]
+      # `batting_averages.hit` は本番運用上「単打のみ」を保持するため、総安打は
+      # 単打 + 2B + 3B + HR を加算して導出する。マイページ系
+      # (`BattingAverage.stats_for_user`) と同じ semantics に揃える。
+      total_hits = stats[:hit] + stats[:two_base_hit] + stats[:three_base_hit] + stats[:home_run]
       obp_denominator = at_bats + stats[:base_on_balls] + stats[:hit_by_pitch] + stats[:sacrifice_fly]
-      obp = safe_divide(stats[:hit] + stats[:base_on_balls] + stats[:hit_by_pitch], obp_denominator)
+      obp = safe_divide(total_hits + stats[:base_on_balls] + stats[:hit_by_pitch], obp_denominator)
       slg = safe_divide(stats[:total_bases], at_bats)
 
       {
-        batting_average: safe_divide(stats[:hit], at_bats),
-        hit: stats[:hit],
+        batting_average: safe_divide(total_hits, at_bats),
+        hit: total_hits,
         home_run: stats[:home_run],
         runs_batted_in: stats[:runs_batted_in],
         on_base_percentage: obp,
@@ -42,7 +46,10 @@ module Stats
 
     private
 
-    SUM_COLUMNS = %i[at_bats hit home_run runs_batted_in base_on_balls hit_by_pitch sacrifice_fly total_bases].freeze
+    SUM_COLUMNS = %i[
+      at_bats hit two_base_hit three_base_hit home_run
+      runs_batted_in base_on_balls hit_by_pitch sacrifice_fly total_bases
+    ].freeze
 
     # 8 カラムの SUM を 1 クエリで取得する。scope.sum を都度呼ぶと SELECT が
     # SUM 1 個ずつ 8 本走るため、pick + SUM で 1 本にまとめる。

--- a/spec/models/batting_average_spec.rb
+++ b/spec/models/batting_average_spec.rb
@@ -25,39 +25,43 @@ RSpec.describe BattingAverage, type: :model do
       gr
     end
 
+    # `hit` カラムは「単打のみ」を保持するが、aggregate_for_user では NPB 標準の
+    # 全安打 (単打 + 2B + 3B + HR) を返すよう SQL 側で集計済みのため、
+    # game_2024_regular: 単打3 + HR1 = 全安打 4 / game_2024_open: 単打1 = 全安打 1 /
+    # game_2023_regular: 単打2 = 全安打 2 が期待値となる。
     it 'returns aggregated stats for all games when no filter is given' do
       result = described_class.filtered_aggregate_for_user(user.id).take
-      expect(result.hit.to_i).to eq(6) # 3+1+2
+      expect(result.hit.to_i).to eq(7) # (3+1) + 1 + 2
       expect(result.at_bats.to_i).to eq(12) # 4+3+5
       expect(result.home_run.to_i).to eq(1)
     end
 
     it 'filters by year' do
       result = described_class.filtered_aggregate_for_user(user.id, year: '2024').take
-      expect(result.hit.to_i).to eq(4) # 3+1
+      expect(result.hit.to_i).to eq(5) # (3+1) + 1 = 全安打 4 + 1
       expect(result.at_bats.to_i).to eq(7) # 4+3
     end
 
     it 'filters by match_type' do
       result = described_class.filtered_aggregate_for_user(user.id, match_type: 'regular').take
-      expect(result.hit.to_i).to eq(5) # 3+2
+      expect(result.hit.to_i).to eq(6) # (3+1) + 2 = 全安打 4 + 2
       expect(result.at_bats.to_i).to eq(9) # 4+5
     end
 
     it 'filters by both year and match_type' do
       result = described_class.filtered_aggregate_for_user(user.id, year: '2024', match_type: 'regular').take
-      expect(result.hit.to_i).to eq(3)
+      expect(result.hit.to_i).to eq(4) # 単打3 + HR1
       expect(result.at_bats.to_i).to eq(4)
     end
 
     it 'skips year filter when year is "通算"' do
       result = described_class.filtered_aggregate_for_user(user.id, year: '通算').take
-      expect(result.hit.to_i).to eq(6)
+      expect(result.hit.to_i).to eq(7)
     end
 
     it 'skips match_type filter when match_type is "全て"' do
       result = described_class.filtered_aggregate_for_user(user.id, match_type: '全て').take
-      expect(result.hit.to_i).to eq(6)
+      expect(result.hit.to_i).to eq(7)
     end
 
     it 'returns nil when no games match the filter' do

--- a/spec/requests/api/v2/dashboards_spec.rb
+++ b/spec/requests/api/v2/dashboards_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe 'Api::V2::Dashboards', type: :request do
 
         json = response.parsed_body
         batting = json['batting_stats']
-        expect(batting['aggregate']).to include('hit' => 2, 'at_bats' => 4, 'home_run' => 1)
+        # 単打 2 + HR 1 = 全安打 3 (aggregate_columns で NPB 標準の安打を返す)
+        expect(batting['aggregate']).to include('hit' => 3, 'at_bats' => 4, 'home_run' => 1)
         expect(batting['calculated']).to include('batting_average', 'on_base_percentage', 'slugging_percentage', 'ops')
         expect(batting['calculated']['batting_average']).to be_a(Numeric)
       end

--- a/spec/services/stats/additional_stats_aggregator_spec.rb
+++ b/spec/services/stats/additional_stats_aggregator_spec.rb
@@ -47,16 +47,18 @@ RSpec.describe Stats::AdditionalStatsAggregator, type: :service do
 
     context 'when summing multiple games' do
       before do
-        # 1試合目: 4打数 2安打 (うち1本塁打) 2打点 1四球 1得点 1三振
+        # 1試合目: 4打数 2安打 (単打1 + 本塁打1) 2打点 1四球 1得点 1三振
+        # `hit` カラムは単打のみを保持する semantics なので hit=1 (HR は home_run に別計上)
         build_game(date: '2026-04-01 12:00:00', batting_attrs: {
-                     plate_appearances: 5, at_bats: 4, hit: 2,
+                     plate_appearances: 5, at_bats: 4, hit: 1,
                      home_run: 1, total_bases: 5,
                      runs_batted_in: 2, run: 1, strike_out: 1,
                      base_on_balls: 1
                    })
-        # 2試合目: 3打数 1安打 (二塁打) 1打点 1犠飛 2三振 1四球 1盗塁
+        # 2試合目: 3打数 1安打 (二塁打1) 1打点 1犠飛 2三振 1四球 1盗塁
+        # 単打 0、二塁打 1 → hit=0, two_base_hit=1
         build_game(date: '2026-04-08 12:00:00', batting_attrs: {
-                     plate_appearances: 5, at_bats: 3, hit: 1, two_base_hit: 1,
+                     plate_appearances: 5, at_bats: 3, hit: 0, two_base_hit: 1,
                      total_bases: 2, runs_batted_in: 1, strike_out: 2,
                      base_on_balls: 1, sacrifice_fly: 1, stealing_base: 1
                    })

--- a/spec/services/stats/batting_average_recalculator_spec.rb
+++ b/spec/services/stats/batting_average_recalculator_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Stats::BattingAverageRecalculator, type: :service do
           expect(batting_average.plate_appearances).to eq(4)
           expect(batting_average.at_bats).to eq(3)              # 7,8,13 が counted_in_at_bats: true（15=四球は false）
           expect(batting_average.times_at_bat).to eq(3)
-          expect(batting_average.hit).to eq(2)                  # 7 (単打) + 8 (二塁打)
+          expect(batting_average.hit).to eq(1)                  # 単打 (id=7) のみ。2B は two_base_hit カラムに別計上
           expect(batting_average.two_base_hit).to eq(1)
           expect(batting_average.three_base_hit).to eq(0)
           expect(batting_average.home_run).to eq(0)

--- a/spec/services/stats/headline_stats_aggregator_consistency_spec.rb
+++ b/spec/services/stats/headline_stats_aggregator_consistency_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# stats タブの主要スタッツ (Stats::HeadlineStatsAggregator) と
+# マイページ / ダッシュボード / ランキングで使う BattingAverage.stats_for_user の
+# 打率 / OBP / SLG / OPS が一致することを保証する retention test。
+#
+# 以前は HeadlineStats が SUM(hit) を「総安打」と解釈する一方、本番の
+# batting_averages.hit は「単打のみ」を保持する semantics になっており、
+# stats タブだけ過少表示される乖離が発生していた (#387 revert で判明)。
+# 集計式を Approach C で揃え直した後、両系統が常に同じ値を返すことを
+# 保護する。
+RSpec.describe 'HeadlineStatsAggregator consistency with BattingAverage.stats_for_user', type: :service do # rubocop:disable RSpec/DescribeClass
+  let(:user) { create(:user) }
+
+  def create_game_with_batting(date:, hit:, at_bats:, two_base_hit: 0, three_base_hit: 0, # rubocop:disable Metrics/ParameterLists
+                               home_run: 0, base_on_balls: 0, hit_by_pitch: 0,
+                               sacrifice_fly: 0)
+    game = create(:game_result, user:)
+    game.match_result.update!(date_and_time: Time.zone.parse(date), match_type: 'regular')
+    # `hit` は単打のみを保持する semantics。塁打 (TB) は単打×1 + 2B×2 + 3B×3 + HR×4。
+    total_bases = hit + (two_base_hit * 2) + (three_base_hit * 3) + (home_run * 4)
+    create(:batting_average, game_result: game, user:,
+                             hit:, at_bats:, total_bases:,
+                             two_base_hit:, three_base_hit:, home_run:,
+                             base_on_balls:, hit_by_pitch:, sacrifice_fly:,
+                             times_at_bat: at_bats + base_on_balls + hit_by_pitch + sacrifice_fly,
+                             strike_out: 0, sacrifice_hit: 0)
+  end
+
+  context 'with mixed singles, doubles, triples, home runs across games' do
+    before do
+      # 試合 1: 単打 1 + 2B 1 + 三振 1 + ゴロ 1 + BB 1 → AB=4 hit=1 2B=1
+      create_game_with_batting(date: '2026-04-01', hit: 1, at_bats: 4, two_base_hit: 1, base_on_balls: 1)
+      # 試合 2: 単打 1 + HR 1 + 三振 1 → AB=3 hit=1 HR=1
+      create_game_with_batting(date: '2026-04-15', hit: 1, at_bats: 3, home_run: 1)
+      # 試合 3: 単打 1 + アウト 4 → AB=5 hit=1
+      create_game_with_batting(date: '2026-04-30', hit: 1, at_bats: 5)
+    end
+
+    # 通算: AB=12, hit=3, 2B=1, 3B=0, HR=1, total_hits=5, TB=3+2+0+4=9, BB=1, HBP=0, SF=0
+    # 打率 = 5/12 = .417
+    # OBP = (5+1+0)/(12+1+0+0) = 6/13 = .462
+    # SLG = 9/12 = .750
+    # OPS = .462 + .750 = 1.212
+
+    it 'マイページ stats_for_user と stats タブ HeadlineStatsAggregator が同じ打率を返す' do
+      mypage = BattingAverage.stats_for_user(user.id)
+      headline = Stats::HeadlineStatsAggregator.new(user_id: user.id).call
+
+      aggregate_failures do
+        expect(mypage[:batting_average]).to eq(headline[:batting_average])
+        expect(mypage[:on_base_percentage]).to eq(headline[:on_base_percentage])
+        expect(mypage[:slugging_percentage]).to eq(headline[:slugging_percentage])
+        expect(mypage[:ops]).to eq(headline[:ops])
+      end
+    end
+
+    it '両系統が NPB 公式式と一致する具体値を返す' do
+      mypage = BattingAverage.stats_for_user(user.id)
+      headline = Stats::HeadlineStatsAggregator.new(user_id: user.id).call
+      expected_avg = (5.0 / 12).round(3)
+      expected_obp = (6.0 / 13).round(3)
+      expected_slg = (9.0 / 12).round(3)
+
+      aggregate_failures do
+        expect(mypage[:batting_average]).to eq(expected_avg)
+        expect(headline[:batting_average]).to eq(expected_avg)
+        expect(mypage[:on_base_percentage]).to eq(expected_obp)
+        expect(headline[:on_base_percentage]).to eq(expected_obp)
+        expect(mypage[:slugging_percentage]).to eq(expected_slg)
+        expect(headline[:slugging_percentage]).to eq(expected_slg)
+        expect(mypage[:ops]).to eq((expected_obp + expected_slg).round(3))
+        expect(headline[:ops]).to eq((expected_obp + expected_slg).round(3))
+      end
+    end
+  end
+
+  context 'with year filter' do
+    before do
+      create_game_with_batting(date: '2025-09-30', hit: 1, at_bats: 4, two_base_hit: 1)
+      create_game_with_batting(date: '2026-04-01', hit: 2, at_bats: 6, home_run: 1)
+    end
+
+    it 'year フィルタを通しても両系統で同じ打率になる' do
+      mypage = BattingAverage.stats_for_user(user.id, year: '2026')
+      headline = Stats::HeadlineStatsAggregator.new(user_id: user.id, year: '2026').call
+
+      expect(mypage[:batting_average]).to eq(headline[:batting_average])
+      expect(mypage[:ops]).to eq(headline[:ops])
+    end
+  end
+end

--- a/spec/services/stats/headline_stats_aggregator_consistency_spec.rb
+++ b/spec/services/stats/headline_stats_aggregator_consistency_spec.rb
@@ -54,7 +54,16 @@ RSpec.describe 'HeadlineStatsAggregator consistency with BattingAverage.stats_fo
         expect(mypage[:on_base_percentage]).to eq(headline[:on_base_percentage])
         expect(mypage[:slugging_percentage]).to eq(headline[:slugging_percentage])
         expect(mypage[:ops]).to eq(headline[:ops])
+        # マイページの total_hits と stats タブの hit が NPB 標準で一致する（= 全安打）
+        expect(mypage[:total_hits]).to eq(headline[:hit])
       end
+    end
+
+    it 'aggregate_for_user が返す hit も全安打で一致する（ダッシュボード / ランキング表示の整合性）' do
+      aggregate = BattingAverage.aggregate_for_user(user.id).take
+      headline = Stats::HeadlineStatsAggregator.new(user_id: user.id).call
+
+      expect(aggregate.hit.to_i).to eq(headline[:hit])
     end
 
     it '両系統が NPB 公式式と一致する具体値を返す' do

--- a/spec/services/stats/headline_stats_aggregator_spec.rb
+++ b/spec/services/stats/headline_stats_aggregator_spec.rb
@@ -38,17 +38,19 @@ RSpec.describe Stats::HeadlineStatsAggregator, type: :service do
 
     context 'when summing multiple games' do
       before do
-        # 1試合目: 4打数 2安打 (うち1本塁打) 2打点 1四球
+        # 1試合目: 4打数 2安打 (単打1 + 本塁打1) 2打点 1四球
+        # `hit` カラムは単打のみを保持する semantics なので hit=1 (HR は home_run に別計上)
         build_game(
           batting_attrs: {
-            at_bats: 4, hit: 2, two_base_hit: 0, three_base_hit: 0, home_run: 1,
+            at_bats: 4, hit: 1, two_base_hit: 0, three_base_hit: 0, home_run: 1,
             total_bases: 5, runs_batted_in: 2, base_on_balls: 1
           }
         )
-        # 2試合目: 3打数 1安打 (二塁打) 1打点 0四球 1犠飛
+        # 2試合目: 3打数 1安打 (二塁打1) 1打点 0四球 1犠飛
+        # 単打 0、二塁打 1 → hit=0, two_base_hit=1
         build_game(
           batting_attrs: {
-            at_bats: 3, hit: 1, two_base_hit: 1, three_base_hit: 0, home_run: 0,
+            at_bats: 3, hit: 0, two_base_hit: 1, three_base_hit: 0, home_run: 0,
             total_bases: 2, runs_batted_in: 1, base_on_balls: 0, sacrifice_fly: 1
           }
         )


### PR DESCRIPTION
## Summary

- ippei-shimizu/buzzbase#390 対応。release/game-stats-202605 をこのまま本番デプロイすると stats タブの主要スタッツが過少表示 + 新仕様 PA を記録するたびに `batting_averages.hit` カラムに 2 種類の semantics が混在する破壊的な状態になるため、コード側を本番 semantics に合わせて事前に解消する。
- 同 PR でマイページ / ダッシュボード / グループランキング / グループスタッツの「安打」表示も NPB 標準（単打 + 二塁打 + 三塁打 + 本塁打）に統一する。
- ippei-shimizu/buzzbase_back#272 (#387 対応) と #274 (revert) で判明した「`batting_averages.hit` は本番運用上『単打のみ』を保持する」事実を、コード全体で正しく扱うようにする。

## 背景

`batting_averages.hit` カラムは v1 フォーム手入力時代から **単打のみ** を保持する semantics で運用されている。マイページ系 `BattingAverage.stats_for_user` は `SUM(hit + 2B + 3B + HR) AS total_hits` でこれを正しく扱っていた一方、

- release/game-stats-202605 で追加した `Stats::BattingAverageRecalculator` は `HIT_RESULT_IDS = [7, 8, 9, 10]` を全件カウントして `hit` に **全安打** を書き込んでいた
- `HeadlineStatsAggregator` / `AdditionalStatsAggregator` / `BattingTrendAggregator` は `SUM(hit)` を「総安打」として読んでいた
- マイページ / ダッシュボード / ランキングは `SUM(hit) AS hit` をそのまま「安打 N」と表示し、内部の打率計算（`SUM(hit + 2B + 3B + HR) / SUM(at_bats)`）とユーザーが手計算した時の数値が合わない問題があった

このまま本番に出すと:

1. 既存データを読む stats タブの集計が単打数のみで打率を計算し過少表示
2. 新仕様 PA を記録するたびに `hit` カラム内に 2 種類の semantics が混入

## 変更点

### `Fix: BattingAverageRecalculator を単打のみカウントに変更` (24df49d)

`hit:` の集計を `HIT_RESULT_IDS` 全件から `SINGLE_HIT_ID = 7` のみに変更。新仕様 PA を記録しても旧データと同じ「単打のみ」semantics で書き込まれるようにする。`total_bases` は元から正しく `単打×1 + 2B×2 + 3B×3 + HR×4` で計算されているため無修正。

### `Fix: HeadlineStatsAggregator の集計式を本番 hit semantics に揃える` (14f802e)

- `SUM_COLUMNS` に `two_base_hit` / `three_base_hit` を追加（`home_run` は既に含まれていた）
- `call` メソッド内で `total_hits = stats[:hit] + stats[:two_base_hit] + stats[:three_base_hit] + stats[:home_run]` を導出して `batting_average` と OBP の分子に使う
- API レスポンスの `:hit` キーは「総安打」を返す（NPB 標準、mobile 互換）

### `Fix: AdditionalStatsAggregator の集計式を本番 hit semantics に揃える` (71e0204)

同じパターンで `SUM_COLUMNS` に `home_run` を追加し、`computed_rates` 内で `total_hits` を使う。

### `Fix: BattingTrendAggregator の集計式を本番 hit semantics に揃える` (d2f4fd0)

同じパターンで `SUM_COLUMNS` に `two_base_hit` / `three_base_hit` / `home_run` を追加し、`build_point` 内で `cumulative_total_hits` を導出。game / month / year / recent_games の全 granularity が同じパターンで動く。

### `Test: HeadlineStatsAggregator と BattingAverage.stats_for_user の数値一致を保護する retention spec` (b540898)

複数試合データで `Stats::HeadlineStatsAggregator.new(...).call` と `BattingAverage.stats_for_user(user.id)` が `batting_average` / `on_base_percentage` / `slugging_percentage` / `ops` ですべて一致することを assert。retention test として乖離の再発を防ぐ。

### `Fix: aggregate_for_user の hit を NPB 標準の全安打に変更` (98825e5)

`BattingAverage.aggregate_columns` の SQL を `SUM(hit) AS hit` → `SUM(hit + 2B + 3B + HR) AS hit` に変更。

これにより:
- マイページの打撃成績
- ダッシュボードの打撃サマリー
- グループランキングの打撃指標
- グループ詳細スタッツ

全てで「安打」表示が NPB 標準（全安打）に統一される。stats タブの主要スタッツ表示と一致し、ユーザーが画面で手計算しても打率と整合する。

consistency spec に `mypage[:total_hits] == headline[:hit]` と `aggregate.hit == headline[:hit]` の 2 つの assert を追加。

### `Docs: BattingAverage モデルに hit カラムの semantics と表示変換ルールを明記` (9ead4d6)

クラス先頭に hit カラムの意味と、各 Aggregator / Service / Recalculator がこれをどう扱うかを文書化。将来の同種バグを防ぐ。

## スコープ外（本 PR では触らない）

- `Stats::BattingStatsTableService`: 元から `calculate_rate_stats` で `hit = vals['hit'] + 2B + 3B + HR` と計算しており、本番 semantics 前提で正しく動作する → 無修正
- `Stats::PitcherFaceoffAggregator` / `PitchTypeAggregator` / `PitcherAttributeSummaryAggregator` / `RunnersSituationAggregator` / `ContactQualityAggregator` / `TimingBreakdownAggregator` 等: `plate_appearances.plate_result_id` を per-PA で見て安打判定しているため `batting_averages.hit` の semantics に依存しない → 無修正
- マイページ系 (`BattingAverage.stats_for_user`): revert PR ippei-shimizu/buzzbase_back#274 で戻した状態が正しい → 無修正

## ユーザーへの影響

### 数値計算
- 打率 / OBP / SLG / OPS / ISO / ISOD: 元から正しく計算されており **変わらない**

### 表示の変化
- マイページ / ダッシュボード / グループランキング / グループスタッツの **「安打」表示値が増える**
  - 例: これまで「安打 106 / 二塁打 16 / 三塁打 3 / 本塁打 9」と表示していたユーザーは「安打 134 / 二塁打 16 / 三塁打 3 / 本塁打 9」になる
  - 106 は単打数のみだったため、二塁打 / 三塁打 / 本塁打を含めた NPB 標準の安打数 134 に統一される
- これにより画面の打率と「安打 / 打数」の手計算が一致するようになる

リリース時に「集計式統一」のお知らせが必要。

## Test plan

- [x] `docker compose exec back bundle exec rspec spec/services/stats/ spec/models/batting_average_spec.rb spec/requests/api/v1/batting_averages_spec.rb spec/requests/api/v2/dashboards_spec.rb spec/services/group_ranking_snapshot_service_spec.rb spec/requests/api/v1/groups_spec.rb` → 全パス
- [x] `docker compose exec back bundle exec rubocop app/models/batting_average.rb app/services/stats/` → 0 offenses
- [ ] stg 反映後、dev8 (中村優斗) のマイページと stats タブで「安打」「打率」「OPS」が一致することを目視確認
- [ ] 新仕様 PA を v2 controller 経由で記録した後、`batting_averages.hit` が単打のみで書かれていることを SQL で確認
- [ ] グループランキングで「安打」の順位が NPB 標準に揃っていることを確認

## 関連

- 親 Issue: ippei-shimizu/buzzbase#336
- 本 Issue: ippei-shimizu/buzzbase#390
- 関連 Issue: ippei-shimizu/buzzbase#387（同 issue を Approach A で誤対応した経緯、本 PR で Approach C により正しく対応）
- 関連 PR: ippei-shimizu/buzzbase_back#272（誤対応）, ippei-shimizu/buzzbase_back#274（revert）


## マージ前のデータ整合性チェック（レビュー指摘対応）

旧 batting_averages レコードの `total_bases` が破損しているケースが無いか、本番 / stg で以下 SQL を実行して確認:

```sql
-- TB が hit + 2*2B + 3*3B + 4*HR と一致しない行 (もしあれば手動修復対象)
SELECT
  COUNT(*) FILTER (WHERE total_bases <> hit + 2*two_base_hit + 3*three_base_hit + 4*home_run) AS broken_records,
  COUNT(*) AS total_records
FROM batting_averages;

-- ユーザー別に通算値で乖離があるか
SELECT
  user_id,
  SUM(total_bases) AS sum_tb,
  SUM(hit + 2*two_base_hit + 3*three_base_hit + 4*home_run) AS sum_tb_recomputed,
  SUM(total_bases) - SUM(hit + 2*two_base_hit + 3*three_base_hit + 4*home_run) AS diff
FROM batting_averages
GROUP BY user_id
HAVING SUM(total_bases) <> SUM(hit + 2*two_base_hit + 3*three_base_hit + 4*home_run);
```

→ `broken_records = 0` なら HeadlineStats (DB の `SUM(total_bases)` を使う SLG) と マイページ (Ruby 側で `hit + 2*2B + 3*3B + 4*HR` を再計算する SLG) で SLG が常に一致する。
