### PR TITLE
Fix: per-game 表示の hit を NPB 標準の全安打に統一

### DIFF
--- a/app/controllers/api/v2/dashboards_controller.rb
+++ b/app/controllers/api/v2/dashboards_controller.rb
@@ -69,7 +69,11 @@ module Api
       end
 
       def serialize_batting(batting)
-        { hit: batting.hit, at_bats: batting.at_bats, home_run: batting.home_run,
+        # `hit` は NPB 標準の全安打（単打 + 2B + 3B + HR）を返す。raw column の
+        # `batting.hit` を直接公開すると単打のみとなり、ダッシュボードの集計表示
+        # （`batting_aggregate_hash`）と「最近の試合」per-game 表示で安打の意味が
+        # 割れてしまう。
+        { hit: batting.total_hits, at_bats: batting.at_bats, home_run: batting.home_run,
           runs_batted_in: batting.runs_batted_in }
       end
 

--- a/app/models/batting_average.rb
+++ b/app/models/batting_average.rb
@@ -42,6 +42,22 @@ class BattingAverage < ApplicationRecord
 
   ZERO = 0
 
+  # NPB / MLB スコアボードでいう「安打 (H)」相当の総安打数を返す。
+  # `hit` カラムは単打のみを保持する semantics のため、per-game 表示で
+  # 画面に「安打 N」と出す値はこのメソッドを必ず通すこと（直接 `hit` を
+  # 公開すると単打のみが表示され、二塁打 / 三塁打 / 本塁打が抜け落ちる）。
+  def total_hits
+    hit.to_i + two_base_hit.to_i + three_base_hit.to_i + home_run.to_i
+  end
+
+  # per-game レスポンスで画面表示用に attributes を返す。`hit` を全安打に
+  # 差し替えた状態の Hash で、ダッシュボードや試合一覧などレコードを直接
+  # JSON として返す controller / model helper で利用する（v1 batting_averages
+  # の編集系 API は raw カラムが必要なので、こちらは使わない）。
+  def display_attributes
+    attributes.merge('hit' => total_hits)
+  end
+
   def self.aggregate_for_user(user_id)
     aggregate_query.where(user_id:)
   end

--- a/app/models/game_result.rb
+++ b/app/models/game_result.rb
@@ -38,7 +38,6 @@ class GameResult < ApplicationRecord
       {
         game_result_id: game_result.id,
         match_result: game_result.match_result,
-        # `hit` を全安打で返すため display_attributes 経由でシリアライズ
         batting_average: game_result.batting_average&.display_attributes,
         pitching_result: game_result.pitching_result
       }

--- a/app/models/game_result.rb
+++ b/app/models/game_result.rb
@@ -38,7 +38,8 @@ class GameResult < ApplicationRecord
       {
         game_result_id: game_result.id,
         match_result: game_result.match_result,
-        batting_average: game_result.batting_average,
+        # `hit` を全安打で返すため display_attributes 経由でシリアライズ
+        batting_average: game_result.batting_average&.display_attributes,
         pitching_result: game_result.pitching_result
       }
     end
@@ -90,7 +91,7 @@ class GameResult < ApplicationRecord
       {
         game_result_id: game_result.id,
         match_result: game_result.match_result,
-        batting_average: game_result.batting_average,
+        batting_average: game_result.batting_average&.display_attributes,
         pitching_result: game_result.pitching_result
       }
     end

--- a/spec/requests/api/v1/game_results_spec.rb
+++ b/spec/requests/api/v1/game_results_spec.rb
@@ -56,6 +56,23 @@ RSpec.describe 'Api::V1::GameResults', type: :request do
 
         expect(response).to have_http_status(:ok)
       end
+
+      it 'returns per-game batting_average.hit as NPB 標準の全安打 for other user' do
+        gr = create(:game_result, user: other_user)
+        gr.match_result.update!(date_and_time: Time.zone.local(2026, 5, 1))
+        # 単打 1 + 2B 1 + HR 1 = 全安打 3
+        create(:batting_average, game_result: gr, user: other_user,
+                                 hit: 1, two_base_hit: 1, three_base_hit: 0, home_run: 1,
+                                 at_bats: 4, total_bases: 7, times_at_bat: 4)
+
+        get '/api/v1/game_results/game_associated_data_index_user_id',
+            params: { user_id: other_user.id },
+            headers: auth_headers_for(user)
+
+        json = response.parsed_body
+        ba = json.first['batting_average']
+        expect(ba['hit']).to eq(3)
+      end
     end
 
     context 'when not authenticated' do
@@ -253,6 +270,23 @@ RSpec.describe 'Api::V1::GameResults', type: :request do
             headers: auth_headers_for(user)
 
         expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns per-game batting_average.hit as NPB 標準の全安打 in filtered result' do
+        gr = create(:game_result, user:)
+        gr.match_result.update!(date_and_time: Time.zone.local(2026, 5, 1), match_type: 'regular')
+        # 単打 1 + 2B 1 + HR 1 = 全安打 3
+        create(:batting_average, game_result: gr, user:,
+                                 hit: 1, two_base_hit: 1, three_base_hit: 0, home_run: 1,
+                                 at_bats: 4, total_bases: 7, times_at_bat: 4)
+
+        get '/api/v1/game_results/filtered_game_associated_data',
+            params: { year: '2026', match_type: '全て' },
+            headers: auth_headers_for(user)
+
+        json = response.parsed_body
+        ba = json.first['batting_average']
+        expect(ba['hit']).to eq(3)
       end
     end
 

--- a/spec/requests/api/v1/game_results_spec.rb
+++ b/spec/requests/api/v1/game_results_spec.rb
@@ -19,6 +19,23 @@ RSpec.describe 'Api::V1::GameResults', type: :request do
 
         expect(response).to have_http_status(:ok)
       end
+
+      it 'returns per-game batting_average.hit as NPB 標準の全安打 (単打 + 2B + 3B + HR)' do
+        gr = create(:game_result, user:)
+        gr.match_result.update!(date_and_time: Time.zone.local(2026, 5, 1))
+        # 単打 1 + 2B 1 + HR 1 = 全安打 3
+        create(:batting_average, game_result: gr, user:,
+                                 hit: 1, two_base_hit: 1, three_base_hit: 0, home_run: 1,
+                                 at_bats: 4, total_bases: 7, times_at_bat: 4)
+
+        get '/api/v1/game_results/game_associated_data_index', headers: auth_headers_for(user)
+
+        json = response.parsed_body
+        ba = json.first['batting_average']
+        expect(ba['hit']).to eq(3)
+        expect(ba['two_base_hit']).to eq(1)
+        expect(ba['home_run']).to eq(1)
+      end
     end
 
     context 'when not authenticated' do

--- a/spec/requests/api/v2/dashboards_spec.rb
+++ b/spec/requests/api/v2/dashboards_spec.rb
@@ -36,14 +36,16 @@ RSpec.describe 'Api::V2::Dashboards', type: :request do
         gr
       end
 
-      it 'returns recent_game_results with batting data' do
+      it 'returns recent_game_results with batting data (hit = NPB 標準の全安打)' do
         get '/api/v2/dashboard', headers: auth_headers_for(user)
 
         json = response.parsed_body
         recent = json['recent_game_results']
         expect(recent.size).to eq(1)
         expect(recent.first['id']).to eq(game_result.id)
-        expect(recent.first['batting_average']).to include('hit' => 2, 'at_bats' => 4, 'home_run' => 1)
+        # 単打 2 + HR 1 = 全安打 3。`batting_averages.hit` は単打のみだが、
+        # per-game 表示でも aggregate 表示と同じく全安打を返す。
+        expect(recent.first['batting_average']).to include('hit' => 3, 'at_bats' => 4, 'home_run' => 1)
       end
 
       it 'returns batting_stats with aggregate and calculated values' do


### PR DESCRIPTION
## Summary

- ippei-shimizu/buzzbase#392 対応。ダッシュボードの「最近の試合」と v1 game_associated_data 系（試合一覧 / 試合詳細）で per-game 表示している「安打」が `batting_averages.hit` カラム（単打のみ）をそのまま返しており、aggregate 表示（ippei-shimizu/buzzbase_back#276 で NPB 標準の全安打表示に統一済み）と乖離していた。
- HR しか打っていない試合で「安打 0」と表示されるなどユーザーの違和感が大きい状態だったため、per-game JSON 表示で `hit` を NPB 標準の全安打（単打 + 2B + 3B + HR）に統一する。

## 変更内容

### `app/models/batting_average.rb`

- `BattingAverage#total_hits` 追加: NPB 標準の安打 (`hit + 2B + 3B + HR`) を返す
- `BattingAverage#display_attributes` 追加: `attributes` の `'hit'` を `total_hits` に差し替えた Hash を返す。per-game JSON 表示専用 helper

### `app/controllers/api/v2/dashboards_controller.rb`

- `serialize_batting` の `hit: batting.hit` → `hit: batting.total_hits`

### `app/models/game_result.rb`

- `game_associated_data_user` / `map_game_results` の `batting_average: game_result.batting_average` → `batting_average: game_result.batting_average&.display_attributes`

### spec

- `spec/requests/api/v1/game_results_spec.rb`: `game_associated_data_index` のレスポンスで `hit` が NPB 標準の全安打になることを assert
- `spec/requests/api/v2/dashboards_spec.rb`: `recent_game_results` の `hit` 期待値を total_hits 前提に更新（単打 2 + HR 1 = 全安打 3）

## スコープ外（本 PR では触らない）

- v1 batting_averages_controller の create / update / search 系: 編集フォームで `hit` カラム (単打のみ) を直接扱うため、raw column のままが正しい。`display_attributes` は使わない
- 集計式の SSoT 化 (#391): こちらは別 PR で対応中。SSoT 化が完了したら `total_hits` の実装も `Stats::BattingFormulas.total_hits` 経由に揃える

## ユーザーへの影響

修正前は per-game 表示で「安打 0、本塁打 1」のような違和感ある表示があったが、修正後は「安打 1、本塁打 1」（NPB 標準）に揃う。打率の数値は元から正しく変わらない。

## Test plan

- [x] `docker compose exec back bundle exec rspec spec/models/batting_average_spec.rb spec/models/game_result_spec.rb spec/requests/api/v1/game_results_spec.rb spec/requests/api/v2/dashboards_spec.rb` → 78 examples PASS
- [x] `docker compose exec back bundle exec rubocop app/models/batting_average.rb app/models/game_result.rb app/controllers/api/v2/dashboards_controller.rb` → 0 offenses
- [ ] stg 反映後、dev8 のダッシュボード「最近の試合」で `安打 = 単打 + 2B + 3B + HR` になることを目視確認
- [ ] 試合一覧画面 (`GameResultListItem`) の「N打数M安打」表示で M が全安打になることを確認
- [ ] v1 batting_averages のフォーム入力（試合記録ウィザード）が引き続き raw `hit` カラム前提で動作することを確認

## 関連

- 親 Issue: ippei-shimizu/buzzbase#336
- 本 Issue: ippei-shimizu/buzzbase#392
- 関連 Issue: ippei-shimizu/buzzbase#387 / ippei-shimizu/buzzbase#390 (同種の hit semantics 不整合バグ事例) / ippei-shimizu/buzzbase#391 (集計式 SSoT 化)
- 関連 PR: ippei-shimizu/buzzbase_back#276 (aggregate 表示を NPB 標準に統一、本 PR と対をなす)
