### PR TITLE
Refactor: 打撃集計式を Stats::BattingFormulas モジュールに集約

### DIFF
--- a/app/models/batting_average.rb
+++ b/app/models/batting_average.rb
@@ -47,7 +47,9 @@ class BattingAverage < ApplicationRecord
   # 画面に「安打 N」と出す値はこのメソッドを必ず通すこと（直接 `hit` を
   # 公開すると単打のみが表示され、二塁打 / 三塁打 / 本塁打が抜け落ちる）。
   def total_hits
-    hit.to_i + two_base_hit.to_i + three_base_hit.to_i + home_run.to_i
+    Stats::BattingFormulas.total_hits(
+      singles: hit, doubles: two_base_hit, triples: three_base_hit, home_runs: home_run
+    )
   end
 
   # per-game レスポンスで画面表示用に attributes を返す。`hit` を全安打に
@@ -76,10 +78,8 @@ class BattingAverage < ApplicationRecord
      'SUM(times_at_bat) AS times_at_bat',
      'SUM(at_bats) AS at_bats',
      # `hit` カラムは本番運用上「単打のみ」を保持するが、画面で「安打」として
-     # 表示する値は NPB 標準の全安打（単打 + 二塁打 + 三塁打 + 本塁打）。
-     # マイページ / ダッシュボード / ランキング / グループスタッツの安打表示を
-     # NPB 標準に揃え、stats タブの主要スタッツとも一致させる。
-     'SUM(hit + two_base_hit + three_base_hit + home_run) AS hit',
+     # 表示する値は NPB 標準の全安打 (Stats::BattingFormulas::TOTAL_HITS_SQL)。
+     "SUM#{Stats::BattingFormulas::TOTAL_HITS_SQL} AS hit",
      'SUM(two_base_hit) AS two_base_hit',
      'SUM(three_base_hit) AS three_base_hit',
      'SUM(home_run) AS home_run',
@@ -139,7 +139,7 @@ class BattingAverage < ApplicationRecord
   end
 
   def self.stats_columns
-    ['SUM(hit + two_base_hit + three_base_hit + home_run) AS total_hits',
+    ["SUM#{Stats::BattingFormulas::TOTAL_HITS_SQL} AS total_hits",
      'SUM(hit) AS hit',
      'SUM(two_base_hit) AS two_base_hit',
      'SUM(three_base_hit) AS three_base_hit',
@@ -154,50 +154,38 @@ class BattingAverage < ApplicationRecord
   end
 
   def self.build_stats_hash(user_id, stats)
+    total_hits = stats['total_hits'].to_i
+    at_bats = stats['at_bats'].to_i
+    avg = Stats::BattingFormulas.batting_average(total_hits:, at_bats:)
+    obp = Stats::BattingFormulas.on_base_percentage(
+      total_hits:, base_on_balls: stats['base_on_balls'],
+      hit_by_pitch: stats['hit_by_pitch'], at_bats:,
+      sacrifice_fly: stats['sacrifice_fly']
+    )
+    slg = Stats::BattingFormulas.slugging_percentage(
+      total_bases: calculate_total_bases(stats), at_bats:
+    )
     {
       user_id:,
-      total_hits: stats['total_hits'].to_i,
-      batting_average: safe_divide(stats['total_hits'].to_f, stats['at_bats'].to_i),
-      on_base_percentage: calculate_on_base_percentage(stats),
-      iso: safe_divide(
-        (stats['two_base_hit'].to_i + (stats['three_base_hit'].to_i * 2) + (stats['home_run'].to_i * 3)).to_f,
-        stats['at_bats'].to_i
-      ),
-      ops: calculate_ops(stats).round(3),
-      bb_per_k: safe_divide(stats['base_on_balls'].to_f, stats['strike_outs'].to_i),
-      isod: calculate_isod(stats).round(3),
-      slugging_percentage: calculate_slugging_percentage(stats).round(3)
+      total_hits:,
+      batting_average: avg,
+      on_base_percentage: obp,
+      iso: Stats::BattingFormulas.iso(slg:, batting_average: avg),
+      ops: Stats::BattingFormulas.ops(obp:, slg:),
+      bb_per_k: Stats::BattingFormulas.safe_divide(stats['base_on_balls'], stats['strike_outs']),
+      isod: Stats::BattingFormulas.isod(obp:, batting_average: avg),
+      slugging_percentage: slg
     }
   end
 
-  def self.safe_divide(numerator, denominator)
-    denominator.zero? ? ZERO : (numerator / denominator).round(3)
-  end
-
-  def self.calculate_on_base_percentage(stats)
-    denominator = stats['at_bats'].to_i + stats['base_on_balls'].to_i +
-                  stats['hit_by_pitch'].to_i + stats['sacrifice_fly'].to_i
-    numerator = stats['total_hits'].to_f + stats['base_on_balls'].to_i + stats['hit_by_pitch'].to_i
-    denominator.zero? ? ZERO : (numerator / denominator).round(3)
-  end
-
-  def self.calculate_ops(stats)
-    slg = calculate_slugging_percentage(stats)
-    obp = calculate_on_base_percentage(stats)
-    (obp + slg).round(3)
-  end
-
-  def self.calculate_isod(stats)
-    avg = safe_divide(stats['total_hits'].to_f, stats['at_bats'].to_i)
-    obp = calculate_on_base_percentage(stats)
-    (obp - avg).round(3)
-  end
-
-  def self.calculate_slugging_percentage(stats)
-    at_bats = stats['at_bats'].to_i
-    total_bases = stats['hit'].to_i + (stats['two_base_hit'].to_i * 2) +
-                  (stats['three_base_hit'].to_i * 3) + (stats['home_run'].to_i * 4)
-    at_bats.zero? ? ZERO : total_bases.to_f / at_bats
+  # SLG / ISO 計算で参照する塁打 (TB)。stats_columns の `hit` は単打のみを
+  # 保持する semantics なので、Stats::BattingFormulas.total_bases で
+  # 単打×1 + 2B×2 + 3B×3 + HR×4 を求める。
+  def self.calculate_total_bases(stats)
+    Stats::BattingFormulas.total_bases(
+      singles: stats['hit'], doubles: stats['two_base_hit'],
+      triples: stats['three_base_hit'], home_runs: stats['home_run']
+    )
   end
 
   private

--- a/app/services/stats/additional_stats_aggregator.rb
+++ b/app/services/stats/additional_stats_aggregator.rb
@@ -77,17 +77,21 @@ module Stats
 
     def computed_rates(stats)
       at_bats = stats[:at_bats]
-      # `batting_averages.hit` は本番運用上「単打のみ」を保持するため、総安打は
-      # 単打 + 2B + 3B + HR を加算して導出する。HeadlineStatsAggregator と同じパターン。
-      total_hits = stats[:hit] + stats[:two_base_hit] + stats[:three_base_hit] + stats[:home_run]
-      batting_average = safe_divide(total_hits, at_bats)
-      obp_denom = at_bats + stats[:base_on_balls] + stats[:hit_by_pitch] + stats[:sacrifice_fly]
-      obp = safe_divide(total_hits + stats[:base_on_balls] + stats[:hit_by_pitch], obp_denom)
-      slg = safe_divide(stats[:total_bases], at_bats)
+      total_hits = BattingFormulas.total_hits(
+        singles: stats[:hit], doubles: stats[:two_base_hit],
+        triples: stats[:three_base_hit], home_runs: stats[:home_run]
+      )
+      batting_average = BattingFormulas.batting_average(total_hits:, at_bats:)
+      obp = BattingFormulas.on_base_percentage(
+        total_hits:, base_on_balls: stats[:base_on_balls],
+        hit_by_pitch: stats[:hit_by_pitch], at_bats:,
+        sacrifice_fly: stats[:sacrifice_fly]
+      )
+      slg = BattingFormulas.slugging_percentage(total_bases: stats[:total_bases], at_bats:)
       {
-        iso: round3(slg - batting_average),
-        isod: round3(obp - batting_average),
-        bb_per_k: safe_divide(stats[:base_on_balls], stats[:strike_out])
+        iso: BattingFormulas.iso(slg:, batting_average:),
+        isod: BattingFormulas.isod(obp:, batting_average:),
+        bb_per_k: BattingFormulas.safe_divide(stats[:base_on_balls], stats[:strike_out])
       }
     end
 
@@ -126,16 +130,6 @@ module Stats
         scope = apply_season_filter(scope)
         apply_tournament_filter(scope)
       end
-    end
-
-    def safe_divide(numerator, denominator)
-      return 0.0 if denominator.to_i.zero?
-
-      round3(numerator.to_f / denominator)
-    end
-
-    def round3(value)
-      value.round(3)
     end
   end
 end

--- a/app/services/stats/batting_average_recalculator.rb
+++ b/app/services/stats/batting_average_recalculator.rb
@@ -110,7 +110,9 @@ module Stats
         home_run: homer,
         # 塁打 (TB) = 単打×1 + 2B×2 + 3B×3 + HR×4。既に取得済みのカウントを再利用して
         # 同じ COUNT クエリを 4 本余計に発行しないようにする。
-        total_bases: single + (double * 2) + (triple * 3) + (homer * 4),
+        total_bases: BattingFormulas.total_bases(
+          singles: single, doubles: double, triples: triple, home_runs: homer
+        ),
         runs_batted_in: scope.sum(:rbi).to_i,
         run: scope.sum(:run_scored).to_i,
         strike_out: scope.where(plate_result_id: STRIKE_OUT_IDS).count,

--- a/app/services/stats/batting_formulas.rb
+++ b/app/services/stats/batting_formulas.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Stats
+  # 打撃集計式の単一情報源 (SSoT)。
+  #
+  # `batting_averages.hit` カラムは「単打のみ」を保持する semantics のため、
+  # 画面に出す「安打 (NPB 標準 H)」と DB 列の `hit` は別物。本モジュールの
+  # `total_hits` を通すことで、Ruby 側でも SQL 側でも揃った計算ができる。
+  #
+  # 新規 Aggregator / Service / Controller は **必ず本モジュールの関数を経由** し、
+  # 独自に再計算しないこと。新しい指標を追加する場合も本モジュールに追加する。
+  module BattingFormulas
+    # SQL フラグメント。`SUM(...)` で囲って AS hit / AS total_hits に使う。
+    # NPB 標準の安打 = 単打 + 二塁打 + 三塁打 + 本塁打。
+    TOTAL_HITS_SQL = '(hit + two_base_hit + three_base_hit + home_run)'
+
+    # 全安打 = 単打 + 二塁打 + 三塁打 + 本塁打
+    def self.total_hits(singles:, doubles:, triples:, home_runs:)
+      singles.to_i + doubles.to_i + triples.to_i + home_runs.to_i
+    end
+
+    # 塁打 (TB) = 単打 + 2×二塁打 + 3×三塁打 + 4×本塁打
+    def self.total_bases(singles:, doubles:, triples:, home_runs:)
+      singles.to_i + (doubles.to_i * 2) + (triples.to_i * 3) + (home_runs.to_i * 4)
+    end
+
+    # 打率 = 総安打 / 打数
+    def self.batting_average(total_hits:, at_bats:)
+      safe_divide(total_hits, at_bats)
+    end
+
+    # 出塁率 = (総安打 + 四球 + 死球) / (打数 + 四球 + 死球 + 犠飛)
+    def self.on_base_percentage(total_hits:, base_on_balls:, hit_by_pitch:,
+                                at_bats:, sacrifice_fly:)
+      numer = total_hits.to_i + base_on_balls.to_i + hit_by_pitch.to_i
+      denom = at_bats.to_i + base_on_balls.to_i + hit_by_pitch.to_i + sacrifice_fly.to_i
+      safe_divide(numer, denom)
+    end
+
+    # 長打率 = 塁打 / 打数
+    def self.slugging_percentage(total_bases:, at_bats:)
+      safe_divide(total_bases, at_bats)
+    end
+
+    # OPS = 出塁率 + 長打率
+    def self.ops(obp:, slg:)
+      (obp.to_f + slg.to_f).round(3)
+    end
+
+    # ISO (純粋な長打力) = 長打率 - 打率
+    def self.iso(slg:, batting_average:)
+      (slg.to_f - batting_average.to_f).round(3)
+    end
+
+    # ISOD (純粋な選球眼) = 出塁率 - 打率
+    def self.isod(obp:, batting_average:)
+      (obp.to_f - batting_average.to_f).round(3)
+    end
+
+    # ゼロ除算を 0.0 に丸めて 3 桁 round。各レイヤーで自前実装していた
+    # safe_divide を本モジュールに集約する。
+    def self.safe_divide(numerator, denominator)
+      return 0.0 if denominator.to_i.zero?
+
+      (numerator.to_f / denominator).round(3)
+    end
+  end
+end

--- a/app/services/stats/batting_stats_table_service.rb
+++ b/app/services/stats/batting_stats_table_service.rb
@@ -97,30 +97,33 @@ module Stats
     end
 
     def calculate_rate_stats(vals)
-      hit = vals['hit'] + vals['two_base_hit'] + vals['three_base_hit'] + vals['home_run']
-      tb = vals['hit'] + (vals['two_base_hit'] * 2) + (vals['three_base_hit'] * 3) + (vals['home_run'] * 4)
+      hit = BattingFormulas.total_hits(
+        singles: vals['hit'], doubles: vals['two_base_hit'],
+        triples: vals['three_base_hit'], home_runs: vals['home_run']
+      )
+      tb = BattingFormulas.total_bases(
+        singles: vals['hit'], doubles: vals['two_base_hit'],
+        triples: vals['three_base_hit'], home_runs: vals['home_run']
+      )
 
       calculate_batting_rates(hit, tb, vals)
     end
 
     def calculate_batting_rates(hit, total_bases, vals)
-      ab = vals['at_bats']
-      bb = vals['base_on_balls']
-
-      avg = safe_divide(hit.to_f, ab)
-      slg = safe_divide(total_bases.to_f, ab)
-      obp = calculate_obp(hit, vals)
+      at_bats = vals['at_bats']
+      avg = BattingFormulas.batting_average(total_hits: hit, at_bats:)
+      slg = BattingFormulas.slugging_percentage(total_bases:, at_bats:)
+      obp = BattingFormulas.on_base_percentage(
+        total_hits: hit, base_on_balls: vals['base_on_balls'],
+        hit_by_pitch: vals['hit_by_pitch'], at_bats:,
+        sacrifice_fly: vals['sacrifice_fly']
+      )
 
       { hit:, total_bases:, batting_average: avg, slugging_percentage: slg,
-        ops: (obp + slg).round(3), iso: safe_divide((total_bases - hit).to_f, ab),
-        bb_per_k: safe_divide(bb.to_f, vals['strike_out']) }
+        ops: BattingFormulas.ops(obp:, slg:),
+        iso: BattingFormulas.iso(slg:, batting_average: avg),
+        bb_per_k: BattingFormulas.safe_divide(vals['base_on_balls'], vals['strike_out']) }
         .merge(babip: calculate_babip(hit, vals))
-    end
-
-    def calculate_obp(hit, vals)
-      on_base = hit + vals['base_on_balls'] + vals['hit_by_pitch']
-      denom = vals['at_bats'] + vals['base_on_balls'] + vals['hit_by_pitch'] + vals['sacrifice_fly']
-      safe_divide(on_base.to_f, denom)
     end
 
     def calculate_babip(hit, vals)

--- a/app/services/stats/batting_trend_aggregator.rb
+++ b/app/services/stats/batting_trend_aggregator.rb
@@ -174,23 +174,24 @@ module Stats
 
     def build_point(key:, label:, period_stats:, cumulative_stats:)
       at_bats = cumulative_stats[:at_bats]
-      # `batting_averages.hit` は本番運用上「単打のみ」を保持するため、総安打は
-      # 単打 + 2B + 3B + HR を加算して導出する。HeadlineStatsAggregator と同じパターン。
-      total_hits = cumulative_stats[:hit] + cumulative_stats[:two_base_hit] +
-                   cumulative_stats[:three_base_hit] + cumulative_stats[:home_run]
-      obp_denom = at_bats + cumulative_stats[:base_on_balls] +
-                  cumulative_stats[:hit_by_pitch] + cumulative_stats[:sacrifice_fly]
-      obp_num = total_hits + cumulative_stats[:base_on_balls] + cumulative_stats[:hit_by_pitch]
-      obp = safe_divide(obp_num, obp_denom)
-      slg = safe_divide(cumulative_stats[:total_bases], at_bats)
+      total_hits = BattingFormulas.total_hits(
+        singles: cumulative_stats[:hit], doubles: cumulative_stats[:two_base_hit],
+        triples: cumulative_stats[:three_base_hit], home_runs: cumulative_stats[:home_run]
+      )
+      obp = BattingFormulas.on_base_percentage(
+        total_hits:, base_on_balls: cumulative_stats[:base_on_balls],
+        hit_by_pitch: cumulative_stats[:hit_by_pitch], at_bats:,
+        sacrifice_fly: cumulative_stats[:sacrifice_fly]
+      )
+      slg = BattingFormulas.slugging_percentage(total_bases: cumulative_stats[:total_bases], at_bats:)
 
       {
         key:,
         label:,
-        batting_average: safe_divide(total_hits, at_bats),
+        batting_average: BattingFormulas.batting_average(total_hits:, at_bats:),
         on_base_percentage: obp,
         slugging_percentage: slg,
-        ops: round3(obp + slg),
+        ops: BattingFormulas.ops(obp:, slg:),
         at_bats_in_period: period_stats[:at_bats].to_i,
         cumulative_at_bats: at_bats
       }
@@ -204,16 +205,6 @@ module Stats
         scope = apply_season_filter(scope)
         apply_tournament_filter(scope)
       end
-    end
-
-    def safe_divide(numerator, denominator)
-      return 0.0 if denominator.to_i.zero?
-
-      round3(numerator.to_f / denominator)
-    end
-
-    def round3(value)
-      value.round(3)
     end
   end
 end

--- a/app/services/stats/headline_stats_aggregator.rb
+++ b/app/services/stats/headline_stats_aggregator.rb
@@ -24,22 +24,25 @@ module Stats
     def call
       stats = aggregate_stats
       at_bats = stats[:at_bats]
-      # `batting_averages.hit` は本番運用上「単打のみ」を保持するため、総安打は
-      # 単打 + 2B + 3B + HR を加算して導出する。マイページ系
-      # (`BattingAverage.stats_for_user`) と同じ semantics に揃える。
-      total_hits = stats[:hit] + stats[:two_base_hit] + stats[:three_base_hit] + stats[:home_run]
-      obp_denominator = at_bats + stats[:base_on_balls] + stats[:hit_by_pitch] + stats[:sacrifice_fly]
-      obp = safe_divide(total_hits + stats[:base_on_balls] + stats[:hit_by_pitch], obp_denominator)
-      slg = safe_divide(stats[:total_bases], at_bats)
+      total_hits = BattingFormulas.total_hits(
+        singles: stats[:hit], doubles: stats[:two_base_hit],
+        triples: stats[:three_base_hit], home_runs: stats[:home_run]
+      )
+      obp = BattingFormulas.on_base_percentage(
+        total_hits:, base_on_balls: stats[:base_on_balls],
+        hit_by_pitch: stats[:hit_by_pitch], at_bats:,
+        sacrifice_fly: stats[:sacrifice_fly]
+      )
+      slg = BattingFormulas.slugging_percentage(total_bases: stats[:total_bases], at_bats:)
 
       {
-        batting_average: safe_divide(total_hits, at_bats),
+        batting_average: BattingFormulas.batting_average(total_hits:, at_bats:),
         hit: total_hits,
         home_run: stats[:home_run],
         runs_batted_in: stats[:runs_batted_in],
         on_base_percentage: obp,
         slugging_percentage: slg,
-        ops: round3(obp + slg),
+        ops: BattingFormulas.ops(obp:, slg:),
         at_bats:
       }
     end
@@ -67,17 +70,6 @@ module Stats
       scope = apply_match_type_filter(scope)
       scope = apply_season_filter(scope)
       apply_tournament_filter(scope)
-    end
-
-    # 0 除算を 0.0 に丸めて、率指標は小数 3 桁に揃える。
-    def safe_divide(numerator, denominator)
-      return 0.0 if denominator.to_i.zero?
-
-      round3(numerator.to_f / denominator)
-    end
-
-    def round3(value)
-      value.round(3)
     end
   end
 end

--- a/spec/services/stats/batting_formulas_spec.rb
+++ b/spec/services/stats/batting_formulas_spec.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Stats::BattingFormulas do
+  describe '.total_hits' do
+    it '単打 + 2B + 3B + HR の合計を返す' do
+      expect(described_class.total_hits(singles: 5, doubles: 2, triples: 1, home_runs: 1)).to eq(9)
+    end
+
+    it 'すべて 0 のとき 0 を返す' do
+      expect(described_class.total_hits(singles: 0, doubles: 0, triples: 0, home_runs: 0)).to eq(0)
+    end
+
+    it 'nil を 0 として扱う（nil-safe）' do
+      expect(described_class.total_hits(singles: nil, doubles: 2, triples: nil, home_runs: 1)).to eq(3)
+    end
+  end
+
+  describe '.total_bases' do
+    it '単打×1 + 2B×2 + 3B×3 + HR×4 を返す' do
+      # 単打 1 + 2B 2 + 3B 1 + HR 1 = 1 + 4 + 3 + 4 = 12
+      expect(described_class.total_bases(singles: 1, doubles: 2, triples: 1, home_runs: 1)).to eq(12)
+    end
+
+    it 'すべて 0 のとき 0 を返す' do
+      expect(described_class.total_bases(singles: 0, doubles: 0, triples: 0, home_runs: 0)).to eq(0)
+    end
+
+    it '単打のみのときその数を返す' do
+      expect(described_class.total_bases(singles: 5, doubles: 0, triples: 0, home_runs: 0)).to eq(5)
+    end
+
+    it '本塁打のみのとき 4 倍を返す' do
+      expect(described_class.total_bases(singles: 0, doubles: 0, triples: 0, home_runs: 3)).to eq(12)
+    end
+
+    it 'nil を 0 として扱う' do
+      expect(described_class.total_bases(singles: nil, doubles: 1, triples: nil, home_runs: nil)).to eq(2)
+    end
+  end
+
+  describe '.batting_average' do
+    it '打率 = 総安打 / 打数 を 3 桁 round で返す' do
+      expect(described_class.batting_average(total_hits: 3, at_bats: 10)).to eq(0.3)
+    end
+
+    it '打数 0 のとき 0.0 を返す（ゼロ除算ガード）' do
+      expect(described_class.batting_average(total_hits: 5, at_bats: 0)).to eq(0.0)
+    end
+
+    it '丸めが効く（3/7 = 0.428... → 0.429）' do
+      expect(described_class.batting_average(total_hits: 3, at_bats: 7)).to eq((3.0 / 7).round(3))
+    end
+
+    it '1.0 を超えるケース（実データはあり得ないが式の挙動として）' do
+      expect(described_class.batting_average(total_hits: 11, at_bats: 10)).to eq(1.1)
+    end
+  end
+
+  describe '.on_base_percentage' do
+    it 'OBP = (H + BB + HBP) / (AB + BB + HBP + SF) を返す' do
+      # (3 + 2 + 1) / (10 + 2 + 1 + 1) = 6/14 = 0.4285... → 0.429
+      result = described_class.on_base_percentage(
+        total_hits: 3, base_on_balls: 2, hit_by_pitch: 1, at_bats: 10, sacrifice_fly: 1
+      )
+      expect(result).to eq((6.0 / 14).round(3))
+    end
+
+    it '分母が 0 のとき 0.0 を返す' do
+      expect(
+        described_class.on_base_percentage(
+          total_hits: 0, base_on_balls: 0, hit_by_pitch: 0, at_bats: 0, sacrifice_fly: 0
+        )
+      ).to eq(0.0)
+    end
+
+    it '四球のみのケース（AB=0, BB=2）でも 1.0 を返す' do
+      expect(
+        described_class.on_base_percentage(
+          total_hits: 0, base_on_balls: 2, hit_by_pitch: 0, at_bats: 0, sacrifice_fly: 0
+        )
+      ).to eq(1.0)
+    end
+
+    it 'nil を 0 として扱う' do
+      expect(
+        described_class.on_base_percentage(
+          total_hits: 1, base_on_balls: nil, hit_by_pitch: nil, at_bats: 3, sacrifice_fly: nil
+        )
+      ).to eq((1.0 / 3).round(3))
+    end
+  end
+
+  describe '.slugging_percentage' do
+    it 'SLG = TB / AB を 3 桁 round で返す' do
+      expect(described_class.slugging_percentage(total_bases: 7, at_bats: 10)).to eq(0.7)
+    end
+
+    it '打数 0 のとき 0.0 を返す' do
+      expect(described_class.slugging_percentage(total_bases: 5, at_bats: 0)).to eq(0.0)
+    end
+
+    it 'TB > AB（実データにはあるパターン: 本塁打多め）も正しく返す' do
+      expect(described_class.slugging_percentage(total_bases: 15, at_bats: 10)).to eq(1.5)
+    end
+  end
+
+  describe '.ops' do
+    it 'OPS = OBP + SLG を 3 桁 round で返す' do
+      expect(described_class.ops(obp: 0.4, slg: 0.7)).to eq(1.1)
+    end
+
+    it '両方 0 のとき 0 を返す' do
+      expect(described_class.ops(obp: 0.0, slg: 0.0)).to eq(0.0)
+    end
+
+    it '丸め誤差の累積を 3 桁で抑える' do
+      expect(described_class.ops(obp: 0.4285, slg: 0.7142)).to eq(1.143)
+    end
+  end
+
+  describe '.iso' do
+    it 'ISO = SLG - AVG を 3 桁 round で返す' do
+      # SLG 0.7, AVG 0.3 → ISO 0.4
+      expect(described_class.iso(slg: 0.7, batting_average: 0.3)).to eq(0.4)
+    end
+
+    it '負の値も返せる（実データでは普通起きないが式として）' do
+      expect(described_class.iso(slg: 0.2, batting_average: 0.5)).to eq(-0.3)
+    end
+
+    it '両方 0 のとき 0 を返す' do
+      expect(described_class.iso(slg: 0.0, batting_average: 0.0)).to eq(0.0)
+    end
+  end
+
+  describe '.isod' do
+    it 'ISOD = OBP - AVG を 3 桁 round で返す' do
+      expect(described_class.isod(obp: 0.4, batting_average: 0.3)).to eq(0.1)
+    end
+
+    it '同じ値のとき 0 を返す' do
+      expect(described_class.isod(obp: 0.3, batting_average: 0.3)).to eq(0.0)
+    end
+  end
+
+  describe '.safe_divide' do
+    it '通常の割り算結果を 3 桁 round で返す' do
+      expect(described_class.safe_divide(3, 10)).to eq(0.3)
+    end
+
+    it '分母 0 のとき 0.0 を返す' do
+      expect(described_class.safe_divide(5, 0)).to eq(0.0)
+    end
+
+    it '分母 nil のとき 0.0 を返す' do
+      expect(described_class.safe_divide(5, nil)).to eq(0.0)
+    end
+
+    it '分子 0 のとき 0.0 を返す' do
+      expect(described_class.safe_divide(0, 5)).to eq(0.0)
+    end
+
+    it '整数演算で誤差が出ない（5.0/3 = 1.666...）' do
+      expect(described_class.safe_divide(5, 3)).to eq(1.667)
+    end
+  end
+
+  describe 'TOTAL_HITS_SQL' do
+    let(:user) { create(:user) }
+
+    it '実 DB の SUM 式として Ruby 版 total_hits と同じ値を返す' do
+      gr1 = create(:game_result, user:)
+      gr1.match_result.update!(date_and_time: Time.zone.local(2026, 5, 1))
+      create(:batting_average, game_result: gr1, user:,
+                               hit: 2, two_base_hit: 1, three_base_hit: 0, home_run: 1,
+                               at_bats: 5, total_bases: 7, times_at_bat: 5)
+      gr2 = create(:game_result, user:)
+      gr2.match_result.update!(date_and_time: Time.zone.local(2026, 5, 2))
+      create(:batting_average, game_result: gr2, user:,
+                               hit: 1, two_base_hit: 0, three_base_hit: 1, home_run: 0,
+                               at_bats: 3, total_bases: 4, times_at_bat: 3)
+
+      # SQL 版: SUM(hit + 2B + 3B + HR) = (2+1+0+1) + (1+0+1+0) = 4 + 2 = 6
+      sql_sum = BattingAverage.where(user_id: user.id)
+                              .pick(Arel.sql("SUM(#{Stats::BattingFormulas::TOTAL_HITS_SQL})"))
+                              .to_i
+
+      # Ruby 版（モデル経由）
+      ruby_sum = BattingAverage.where(user_id: user.id).sum(&:total_hits)
+
+      expect(sql_sum).to eq(6)
+      expect(sql_sum).to eq(ruby_sum)
+    end
+  end
+end

--- a/spec/services/stats/batting_stats_consistency_spec.rb
+++ b/spec/services/stats/batting_stats_consistency_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Batting stats SSoT consistency across aggregators', type: :servi
     # 通算: AB=12, hit=3, 2B=1, 3B=0, HR=1, total_hits=5, TB=3+2+0+4=9, BB=1, HBP=0, SF=0
     # 打率 = 5/12 = .417, OBP = 6/13 = .462, SLG = 9/12 = .750, OPS = 1.212
 
-    it '全集計レイヤーで打率 / OBP / SLG / OPS が完全一致する' do
+    it '全集計レイヤーで打率 / OBP / SLG / OPS が完全一致する' do # rubocop:disable RSpec/ExampleLength
       mypage     = BattingAverage.stats_for_user(user.id)
       headline   = Stats::HeadlineStatsAggregator.new(user_id: user.id).call
       additional = Stats::AdditionalStatsAggregator.new(user_id: user.id).call

--- a/spec/services/stats/batting_stats_consistency_spec.rb
+++ b/spec/services/stats/batting_stats_consistency_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Stats::BattingFormulas SSoT 化後、マイページ / stats タブ headline /
+# additional / trend / table の打率・出塁率・長打率・OPS が完全に
+# 一致することを保証する retention test。
+#
+# 過去に式が散らばっていた状態では「stats タブだけ過少表示」や
+# 「stats タブだけ通算 OPS が違う」といった乖離が発生していた。本 spec は
+# その再発を構造的に防ぐ（どこか 1 つでも独自再計算に戻ったら ROUND-TRIP で
+# 必ず差分が出る）。
+RSpec.describe 'Batting stats SSoT consistency across aggregators', type: :service do # rubocop:disable RSpec/DescribeClass
+  let(:user) { create(:user) }
+
+  def create_game_with_batting(date:, hit:, at_bats:, two_base_hit: 0, three_base_hit: 0, # rubocop:disable Metrics/ParameterLists
+                               home_run: 0, base_on_balls: 0, hit_by_pitch: 0,
+                               sacrifice_fly: 0, strike_out: 0)
+    game = create(:game_result, user:)
+    game.match_result.update!(date_and_time: Time.zone.parse("#{date} 12:00:00"), match_type: 'regular')
+    total_bases = hit + (two_base_hit * 2) + (three_base_hit * 3) + (home_run * 4)
+    create(:batting_average, game_result: game, user:,
+                             hit:, at_bats:, total_bases:,
+                             two_base_hit:, three_base_hit:, home_run:,
+                             base_on_balls:, hit_by_pitch:, sacrifice_fly:,
+                             times_at_bat: at_bats + base_on_balls + hit_by_pitch + sacrifice_fly,
+                             strike_out:, sacrifice_hit: 0)
+  end
+
+  context 'with mixed singles / doubles / triples / home runs in a single year' do
+    before do
+      create_game_with_batting(date: '2026-04-01', hit: 1, at_bats: 4, two_base_hit: 1, base_on_balls: 1, strike_out: 1)
+      create_game_with_batting(date: '2026-04-15', hit: 1, at_bats: 3, home_run: 1, strike_out: 1)
+      create_game_with_batting(date: '2026-04-30', hit: 1, at_bats: 5)
+    end
+
+    # 通算: AB=12, hit=3, 2B=1, 3B=0, HR=1, total_hits=5, TB=3+2+0+4=9, BB=1, HBP=0, SF=0
+    # 打率 = 5/12 = .417, OBP = 6/13 = .462, SLG = 9/12 = .750, OPS = 1.212
+
+    it '全集計レイヤーで打率 / OBP / SLG / OPS が完全一致する' do
+      mypage     = BattingAverage.stats_for_user(user.id)
+      headline   = Stats::HeadlineStatsAggregator.new(user_id: user.id).call
+      additional = Stats::AdditionalStatsAggregator.new(user_id: user.id).call
+      trend_last = Stats::BattingTrendAggregator.new(user_id: user.id, granularity: 'game').call[:points].last
+      table_row  = Stats::BattingStatsTableService.new(user_id: user.id, mode: :yearly).call.first
+
+      aggregate_failures do
+        expect(headline[:batting_average]).to eq(mypage[:batting_average])
+        expect(trend_last[:batting_average]).to eq(mypage[:batting_average])
+        expect(table_row[:batting_average]).to eq(mypage[:batting_average])
+        expect(headline[:on_base_percentage]).to eq(mypage[:on_base_percentage])
+        expect(trend_last[:on_base_percentage]).to eq(mypage[:on_base_percentage])
+        expect(headline[:slugging_percentage]).to eq(mypage[:slugging_percentage])
+        expect(trend_last[:slugging_percentage]).to eq(mypage[:slugging_percentage])
+        expect(table_row[:slugging_percentage]).to eq(mypage[:slugging_percentage])
+        expect(headline[:ops]).to eq(mypage[:ops])
+        expect(trend_last[:ops]).to eq(mypage[:ops])
+        expect(table_row[:ops]).to eq(mypage[:ops])
+        expect(additional[:iso]).to eq(mypage[:iso])
+        expect(additional[:isod]).to eq(mypage[:isod])
+      end
+    end
+
+    it 'NPB 公式式が要求する具体値と一致する（既存挙動の固定）' do
+      mypage = BattingAverage.stats_for_user(user.id)
+      expected_avg = (5.0 / 12).round(3)
+      expected_obp = (6.0 / 13).round(3)
+      expected_slg = (9.0 / 12).round(3)
+      expected_ops = (expected_obp + expected_slg).round(3)
+
+      aggregate_failures do
+        expect(mypage[:batting_average]).to eq(expected_avg)
+        expect(mypage[:on_base_percentage]).to eq(expected_obp)
+        expect(mypage[:slugging_percentage]).to eq(expected_slg)
+        expect(mypage[:ops]).to eq(expected_ops)
+      end
+    end
+  end
+
+  context 'with zero at-bats (only walks / hit-by-pitch)' do
+    before do
+      create_game_with_batting(date: '2026-05-01', hit: 0, at_bats: 0, base_on_balls: 2, hit_by_pitch: 1)
+    end
+
+    it 'ゼロ除算ガードで全レイヤーが NaN / Infinity を返さない' do
+      mypage = BattingAverage.stats_for_user(user.id)
+      headline = Stats::HeadlineStatsAggregator.new(user_id: user.id).call
+
+      aggregate_failures do
+        expect(mypage[:batting_average]).to eq(0.0)
+        expect(headline[:batting_average]).to eq(0.0)
+        expect(mypage[:slugging_percentage]).to eq(0.0)
+        expect(headline[:slugging_percentage]).to eq(0.0)
+        # OBP は AB=0 でも BB / HBP があれば 1.0 になる仕様
+        expect(headline[:on_base_percentage]).to eq(1.0)
+      end
+    end
+  end
+end

--- a/spec/services/stats/batting_stats_consistency_spec.rb
+++ b/spec/services/stats/batting_stats_consistency_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe 'Batting stats SSoT consistency across aggregators', type: :servi
         expect(trend_last[:ops]).to eq(mypage[:ops])
         expect(table_row[:ops]).to eq(mypage[:ops])
         expect(additional[:iso]).to eq(mypage[:iso])
+        expect(table_row[:iso]).to eq(mypage[:iso])
         expect(additional[:isod]).to eq(mypage[:isod])
       end
     end


### PR DESCRIPTION
## Summary

打撃集計式（総安打 / 塁打 / 打率 / OBP / SLG / OPS / ISO / ISOD / safe_divide）が 5 - 6 ファイルに重複定義されていたのを `Stats::BattingFormulas` モジュール (SSoT) に集約しました。
`#387` / `#390` / ippei-shimizu/buzzbase#392 はいずれも「式の散らばり」が根本原因のバグで、本 PR は将来の同種バグを構造的に防ぐリファクタです。

関連 Issue: ippei-shimizu/buzzbase#391
関連 PR: #276 (aggregate 表示の NPB 標準化) / #277 (per-game 表示の NPB 標準化)

## 挙動変更（マイページ ISO の丸め順序統一）

`BattingAverage.build_stats_hash` の ISO 計算式を以下のように変更しました。

- 旧: `(2B + 2×3B + 3×HR) / AB → round(3)`（中間丸めなし）
- 新: `SLG.round(3) - AVG.round(3) → round(3)`（中間丸めあり / `Stats::BattingFormulas.iso(slg:, batting_average:)` 経由）

数学的には等価ですが、丸め順序の違いにより **第 3 位 ±0.001 のズレが発生するケース** があります（例: AB=3 / 単打=1 / 三塁打=1 のときに旧 0.667 → 新 0.666）。

これは本リファクタ前から **stats タブの `AdditionalStatsAggregator` が `round3(slg - batting_average)` を採用** しており、マイページ ISO だけが別式で計算されていた既存の不整合を、SSoT 化のタイミングで stats タブ側の式に揃えた結果です。マイページ ISO と stats タブ ISO が常に同じ値を返すようになります。

## 変更内容

9 コミットに分割。各コミットは「既存 spec を 1 件も壊さない」を満たした状態で積んでいます。

1. `Add: Stats::BattingFormulas モジュール + 単体 spec` — SSoT 本体 (8 関数 + SQL フラグメント定数 + safe_divide) と 33 例の境界値 spec を追加。
2. `Refactor: BattingAverage を Stats::BattingFormulas に委譲` — `aggregate_columns` / `stats_columns` の `SUM(hit + ...)` を `TOTAL_HITS_SQL` 経由に置換、Ruby 側の `calculate_*` / `safe_divide` を BattingFormulas に委譲。
3. `Refactor: HeadlineStatsAggregator を Stats::BattingFormulas に委譲`
4. `Refactor: AdditionalStatsAggregator を Stats::BattingFormulas に委譲`
5. `Refactor: BattingTrendAggregator を Stats::BattingFormulas に委譲`
6. `Refactor: BattingStatsTableService を Stats::BattingFormulas に委譲` — BABIP は本 Issue スコープ外で無変更。
7. `Refactor: BattingAverageRecalculator を Stats::BattingFormulas.total_bases に委譲`
8. `Test: 全集計レイヤーの consistency retention spec を追加` — マイページ / headline / additional / trend / table が打率 / OBP / SLG / OPS / ISO / ISOD で完全一致することを保証。
9. `Test: consistency spec に table_row[:iso] のアサートを追加` — レビュー指摘対応。

## 設計の要点

- **キーワード引数で統一**: `hit` と `total_hits` を取り違える事故を構造的に防ぐ。
- **`.to_i` で nil-safe**: DB に NULL が入っているレコードでも壊れない。
- **SQL フラグメント定数 (`TOTAL_HITS_SQL`)**: Ruby と SQL の両方で同じ式を使う。
- **`safe_divide` も公開メソッド化**: 各レイヤーで再実装していた 5 箇所を統一。

## スコープ外（後続 Issue / PR）

- `BattingStatsTableService#calculate_babip` の BABIP 計算式
- pitching 系の同種統合
- `Stats::BattingAverageRecalculator::HIT_RESULT_IDS` 等の定数移動
- v2 シリアライザ移行 (`display_attributes` 廃止)

## Test plan

- [x] 単体 spec: `spec/services/stats/batting_formulas_spec.rb` 33 例 PASS（TOTAL_HITS_SQL の SQL 版 vs Ruby 版の一致 assert を含む）
- [x] 横断 consistency spec: `spec/services/stats/batting_stats_consistency_spec.rb` 3 例 PASS（全 5 集計レイヤー一致 + ゼロ AB エッジ、`table_row[:iso]` assert 追加済み）
- [x] 関連回帰 spec フルパス（247 examples / 0 failures）
  - `spec/services/stats/`
  - `spec/models/batting_average_spec.rb`
  - `spec/requests/api/v1/batting_averages_spec.rb`
  - `spec/requests/api/v1/game_results_spec.rb`
  - `spec/requests/api/v2/dashboards_spec.rb`
  - `spec/services/group_ranking_snapshot_service_spec.rb`
  - `spec/requests/api/v1/groups_spec.rb`
- [x] バックエンド全 spec: 918 examples / 0 failures
- [x] `bundle exec rubocop` 該当ディレクトリ全て 0 offenses
- [ ] dev DB で適当な複数試合データを投入し、Rails console で `BattingAverage.stats_for_user` / `HeadlineStatsAggregator` / `AdditionalStatsAggregator` / `BattingTrendAggregator` / `BattingStatsTableService` が打率 / OBP / SLG / OPS / ISO で目視一致すること
- [ ] 新仕様 PA を 1 件 create → recalculator 経由で batting_averages 行が更新されること（Phase 7 の挙動確認）
