### PR TITLE
Refactor: PlateAppearance の callback で batting_average を自動再集計

### DIFF
--- a/app/controllers/api/v2/plate_appearances_controller.rb
+++ b/app/controllers/api/v2/plate_appearances_controller.rb
@@ -4,7 +4,9 @@ module Api
     #
     # - `is_new_format = true` を強制セットすることで「新仕様試合」とマークする
     # - `batting_result` 表示テキストをサーバー側で自動生成
-    # - `batting_average` を `Stats::BattingAverageRecalculator` で自動再集計
+    # - `batting_average` の再集計は PlateAppearance の after_commit /
+    #   after_destroy_commit に委ねる（controller 経由でも runner / 一括投入でも
+    #   同じ起動経路に統一する）
     # - v1 API は無修正、後方互換を保つ
     class PlateAppearancesController < Api::V2::ApplicationController
       before_action :authenticate_api_v1_user!
@@ -21,7 +23,6 @@ module Api
         plate_appearance.batting_result = ::Stats::BattingResultTextGenerator.generate(plate_appearance)
 
         if plate_appearance.save
-          recalculate_batting_average(plate_appearance.game_result_id, user_id: current_api_v1_user.id)
           render json: plate_appearance, serializer: ::V2::PlateAppearanceSerializer, status: :created
         else
           render json: { errors: plate_appearance.errors.full_messages }, status: :unprocessable_entity
@@ -37,7 +38,6 @@ module Api
         @plate_appearance.batting_result = ::Stats::BattingResultTextGenerator.generate(@plate_appearance)
 
         if @plate_appearance.save
-          recalculate_batting_average(@plate_appearance.game_result_id, user_id: current_api_v1_user.id)
           render json: @plate_appearance, serializer: ::V2::PlateAppearanceSerializer
         else
           render json: { errors: @plate_appearance.errors.full_messages }, status: :unprocessable_entity
@@ -45,12 +45,7 @@ module Api
       end
 
       def destroy
-        game_result_id = @plate_appearance.game_result_id
-        # 削除する打席が新仕様だった場合、最後の1件であれば対応する batting_average も
-        # 削除する必要がある（孤立レコード防止）。was_new_format を Recalculator に渡して判断させる。
-        was_new_format = @plate_appearance.is_new_format
         @plate_appearance.destroy!
-        recalculate_batting_average(game_result_id, user_id: current_api_v1_user.id, cleanup_orphan: was_new_format)
         render json: { message: '打席結果を削除しました' }
       end
 
@@ -104,10 +99,6 @@ module Api
 
         render json: { errors: ['指定された投手は存在しません'] }, status: :unprocessable_entity
         true
-      end
-
-      def recalculate_batting_average(game_result_id, user_id:, cleanup_orphan: false)
-        ::Stats::BattingAverageRecalculator.new(game_result_id:, user_id:, cleanup_orphan:).call
       end
     end
   end

--- a/app/models/plate_appearance.rb
+++ b/app/models/plate_appearance.rb
@@ -46,7 +46,30 @@ class PlateAppearance < ApplicationRecord
 
   validate :swing_type_only_for_strikeout
 
+  # batting_averages の集計は PA の追加・更新・削除に追従して更新する。
+  # controller 経由 (Api::V2::PlateAppearancesController) でも、rails runner /
+  # 一括投入スクリプト / 旧 v1 endpoint 経由でも、新仕様 PA を触ったら必ず
+  # recalculator が起動する。混在試合 / 旧仕様 PA は recalculator 内の
+  # new_format_game? で skip されるため副作用なし。
+  after_commit :recalculate_game_batting_average, on: %i[create update]
+  after_destroy_commit :recalculate_game_batting_average_after_destroy
+
   private
+
+  def recalculate_game_batting_average
+    Stats::BattingAverageRecalculator.new(
+      game_result_id:, user_id:, cleanup_orphan: false
+    ).call
+  end
+
+  # 新仕様 PA を destroy した場合のみ cleanup_orphan を true にする。
+  # 旧仕様 PA (is_new_format=false) の destroy で cleanup させると、
+  # 旧フロー直書きの batting_average を消してしまうため false 固定にする。
+  def recalculate_game_batting_average_after_destroy
+    Stats::BattingAverageRecalculator.new(
+      game_result_id:, user_id:, cleanup_orphan: is_new_format
+    ).call
+  end
 
   def swing_type_only_for_strikeout
     return if swing_type.blank?

--- a/app/services/stats/batting_average_recalculator.rb
+++ b/app/services/stats/batting_average_recalculator.rb
@@ -50,11 +50,23 @@ module Stats
     private
 
     def recalculate_and_save
+      stats = aggregate_stats
+      # plate_result_id が未入力の新仕様 PA だけが紐づいている過渡状態では、
+      # 集計値が plate_appearances 件数を除いて全て 0 になる。BattingAverage は
+      # must_have_any_stats バリデーションで全 0 行を許さないため、無理に save せず
+      # 既存 BA があれば触らないまま skip する（v2 controller では plate_result_id を
+      # 含む完全な params で create されるため、本パスは通常ヒットしない）。
+      return nil if empty_stats?(stats)
+
       batting_average = BattingAverage.find_or_initialize_by(game_result_id: @game_result_id)
       batting_average.user_id ||= resolve_user_id
-      batting_average.assign_attributes(aggregate_stats)
+      batting_average.assign_attributes(stats)
       batting_average.save!
       batting_average
+    end
+
+    def empty_stats?(stats)
+      stats.except(:plate_appearances).values.all? { |v| v.to_i.zero? }
     end
 
     def cleanup_orphaned_batting_average

--- a/lib/tasks/backfill_batting_averages.rake
+++ b/lib/tasks/backfill_batting_averages.rake
@@ -1,0 +1,42 @@
+namespace :data do
+  # PlateAppearance の callback 化（Issue #388）以前に runner / 一括投入スクリプト等で
+  # 直接作られた新仕様 PA に対して、対応する batting_averages が作られていない試合を
+  # 救済するためのバックフィル。recalculator を全試合に流し、混在試合・旧仕様試合は
+  # new_format_game? が false を返すため自動的に skip される。
+  #
+  # 実行例:
+  #   docker compose exec back bundle exec rails data:backfill_batting_averages DRY_RUN=1
+  #   docker compose exec back bundle exec rails data:backfill_batting_averages
+  #   heroku run bundle exec rails data:backfill_batting_averages
+  desc '全試合の batting_average を再集計する（新仕様試合のみ対象、混在/旧仕様は skip）'
+  task backfill_batting_averages: :environment do
+    dry_run = ENV['DRY_RUN'].present?
+    total = GameResult.count
+    puts "対象試合数: #{total}"
+
+    scanned = 0
+    recalculated = 0
+    skipped = 0
+
+    GameResult.find_each(batch_size: 200) do |game_result|
+      scanned += 1
+      if dry_run
+        has_new_pa = PlateAppearance.exists?(game_result_id: game_result.id, is_new_format: true)
+        has_old_pa = PlateAppearance.exists?(game_result_id: game_result.id, is_new_format: false)
+        if has_new_pa && !has_old_pa
+          recalculated += 1
+        else
+          skipped += 1
+        end
+      else
+        result = Stats::BattingAverageRecalculator.new(
+          game_result_id: game_result.id, user_id: game_result.user_id, cleanup_orphan: false
+        ).call
+        result ? recalculated += 1 : skipped += 1
+      end
+    end
+
+    suffix = dry_run ? '再集計可能と判定' : '再集計しました'
+    puts "対象 #{scanned}/#{total} 件中 #{recalculated} 件を#{suffix}（skip: #{skipped}）。"
+  end
+end

--- a/spec/lib/tasks/backfill_batting_averages_spec.rb
+++ b/spec/lib/tasks/backfill_batting_averages_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'data:backfill_batting_averages' do # rubocop:disable RSpec/DescribeClass
+  before(:all) do # rubocop:disable RSpec/BeforeAfterAll
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  let(:task) { Rake::Task['data:backfill_batting_averages'] }
+  let(:user) { create(:user) }
+
+  before { task.reenable }
+
+  context '新仕様 PA がある試合で batting_average が欠落しているとき' do
+    let!(:game_result) { create(:game_result, user:) }
+
+    before do
+      # callback での auto-create を抑止するため、PA を直接 SQL で挿入する
+      # （バックフィルが必要な「旧来の runner 経由で作られたデータ」の再現）。
+      PlateAppearance.skip_callback(:commit, :after, :recalculate_game_batting_average)
+      create(:plate_appearance, game_result:, user:, is_new_format: true,
+                                plate_result_id: Stats::BattingAverageRecalculator::SINGLE_HIT_ID)
+      PlateAppearance.set_callback(:commit, :after, :recalculate_game_batting_average)
+    end
+
+    it 'バックフィルで batting_average が新規作成される' do
+      expect do
+        task.invoke
+      end.to change { BattingAverage.where(game_result_id: game_result.id).count }.from(0).to(1)
+    end
+
+    context 'DRY_RUN=1 のとき' do
+      around do |example|
+        ENV['DRY_RUN'] = '1'
+        example.run
+      ensure
+        ENV.delete('DRY_RUN')
+      end
+
+      it 'batting_average は変更しない' do
+        expect do
+          task.invoke
+        end.not_to(change { BattingAverage.where(game_result_id: game_result.id).count })
+      end
+    end
+  end
+
+  context '混在試合（旧 PA を含む）のとき' do
+    let!(:game_result) { create(:game_result, user:) }
+    let!(:legacy_batting_average) { create(:batting_average, game_result:, user:, hit: 99, at_bats: 99) }
+
+    before do
+      PlateAppearance.skip_callback(:commit, :after, :recalculate_game_batting_average)
+      create(:plate_appearance, game_result:, user:, is_new_format: false,
+                                plate_result_id: Stats::BattingAverageRecalculator::SINGLE_HIT_ID)
+      create(:plate_appearance, game_result:, user:, is_new_format: true,
+                                plate_result_id: Stats::BattingAverageRecalculator::HOME_RUN_ID,
+                                batter_box_number: 2)
+      PlateAppearance.set_callback(:commit, :after, :recalculate_game_batting_average)
+    end
+
+    it '直書きされた batting_average を触らない（recalculator 内の new_format_game? で skip）' do
+      task.invoke
+      expect(legacy_batting_average.reload.hit).to eq(99)
+      expect(legacy_batting_average.at_bats).to eq(99)
+    end
+  end
+
+  context 'PA が 1 件もない試合のとき' do
+    let!(:game_result) { create(:game_result, user:) }
+
+    it 'batting_average は作成されない（skip）' do
+      expect do
+        task.invoke
+      end.not_to(change { BattingAverage.where(game_result_id: game_result.id).count })
+    end
+  end
+end

--- a/spec/models/plate_appearance_spec.rb
+++ b/spec/models/plate_appearance_spec.rb
@@ -169,7 +169,8 @@ RSpec.describe PlateAppearance, type: :model do
     end
 
     it 'true でセット可能' do
-      plate_appearance = create(:plate_appearance, is_new_format: true)
+      plate_appearance = create(:plate_appearance, is_new_format: true,
+                                                   plate_result_id: Stats::BattingAverageRecalculator::SINGLE_HIT_ID)
       expect(plate_appearance.is_new_format).to be(true)
     end
 
@@ -177,6 +178,82 @@ RSpec.describe PlateAppearance, type: :model do
       plate_appearance = create(:plate_appearance)
       plate_appearance.reload
       expect(plate_appearance.is_new_format).to be(false)
+    end
+  end
+
+  describe 'callback: batting_average の自動再集計' do
+    let(:user) { create(:user) }
+    let(:game_result) { create(:game_result, user:) }
+
+    context '新仕様 PA を create したとき' do
+      it '同 game_result の batting_average を自動作成する' do
+        expect do
+          create(:plate_appearance, user:, game_result:, is_new_format: true,
+                                    plate_result_id: Stats::BattingAverageRecalculator::SINGLE_HIT_ID)
+        end.to change { BattingAverage.where(game_result_id: game_result.id).count }.from(0).to(1)
+
+        batting_average = BattingAverage.find_by(game_result_id: game_result.id)
+        expect(batting_average.hit).to eq(1)
+        expect(batting_average.at_bats).to eq(1)
+        expect(batting_average.user_id).to eq(user.id)
+      end
+    end
+
+    context '新仕様 PA を update したとき' do
+      it '再集計で batting_average が更新される' do
+        plate_appearance = create(:plate_appearance, user:, game_result:, is_new_format: true,
+                                                     plate_result_id: Stats::BattingAverageRecalculator::SINGLE_HIT_ID)
+        expect(BattingAverage.find_by(game_result_id: game_result.id).hit).to eq(1)
+
+        plate_appearance.update!(plate_result_id: Stats::BattingAverageRecalculator::HOME_RUN_ID)
+        batting_average = BattingAverage.find_by(game_result_id: game_result.id)
+        expect(batting_average.hit).to eq(0)
+        expect(batting_average.home_run).to eq(1)
+      end
+    end
+
+    context '新仕様 PA を最後の 1 件として destroy したとき' do
+      it '孤立した batting_average を削除する' do
+        plate_appearance = create(:plate_appearance, user:, game_result:, is_new_format: true,
+                                                     plate_result_id: Stats::BattingAverageRecalculator::SINGLE_HIT_ID)
+        expect(BattingAverage.where(game_result_id: game_result.id)).to exist
+
+        expect { plate_appearance.destroy! }
+          .to change { BattingAverage.where(game_result_id: game_result.id).count }.from(1).to(0)
+      end
+    end
+
+    context '旧仕様 PA (is_new_format=false) を create したとき' do
+      it 'batting_average は作成されない（混在試合保護）' do
+        expect do
+          create(:plate_appearance, user:, game_result:, is_new_format: false,
+                                    plate_result_id: Stats::BattingAverageRecalculator::SINGLE_HIT_ID)
+        end.not_to(change { BattingAverage.where(game_result_id: game_result.id).count })
+      end
+    end
+
+    context '旧仕様 PA を destroy したとき' do
+      it '直書きされた batting_average を触らない（cleanup_orphan=false）' do
+        create(:plate_appearance, user:, game_result:, is_new_format: false,
+                                  plate_result_id: Stats::BattingAverageRecalculator::SINGLE_HIT_ID)
+        legacy_batting_average = create(:batting_average, game_result:, user:, hit: 99, at_bats: 99)
+
+        game_result.plate_appearances.first.destroy!
+        expect(BattingAverage.find_by(id: legacy_batting_average.id)).to be_present
+      end
+    end
+
+    context '混在試合（旧 PA が 1 件でも残っているとき）' do
+      it '新仕様 PA を追加しても batting_average は触られない' do
+        create(:plate_appearance, user:, game_result:, is_new_format: false,
+                                  plate_result_id: Stats::BattingAverageRecalculator::SINGLE_HIT_ID)
+        legacy_batting_average = create(:batting_average, game_result:, user:, hit: 99, at_bats: 99)
+
+        create(:plate_appearance, user:, game_result:, is_new_format: true,
+                                  plate_result_id: Stats::BattingAverageRecalculator::HOME_RUN_ID)
+        expect(legacy_batting_average.reload.hit).to eq(99)
+        expect(legacy_batting_average.at_bats).to eq(99)
+      end
     end
   end
 end

--- a/spec/requests/api/v2/plate_appearances_spec.rb
+++ b/spec/requests/api/v2/plate_appearances_spec.rb
@@ -193,7 +193,8 @@ RSpec.describe 'Api::V2::PlateAppearances', type: :request do
       end
 
       it '新仕様試合の最後の打席を削除すると孤立する batting_average も削除される' do
-        create(:batting_average, game_result:, user:, at_bats: 1, hit: 1)
+        # PA を作った時点で callback により BattingAverage は既に存在する。
+        expect(BattingAverage.where(game_result_id: game_result.id)).to exist
         delete "/api/v2/plate_appearances/#{plate_appearance.id}", headers: auth_headers_for(user)
         expect(BattingAverage.where(game_result_id: game_result.id)).not_to exist
       end

--- a/spec/services/stats/batting_average_recalculator_spec.rb
+++ b/spec/services/stats/batting_average_recalculator_spec.rb
@@ -104,8 +104,12 @@ RSpec.describe Stats::BattingAverageRecalculator, type: :service do
 
     context '新仕様試合で batting_average レコードがまだ無い場合' do
       before do
+        # PlateAppearance の after_commit で BattingAverage が auto-create されるため、
+        # 「BA が無い」状態を再現するために auto-create された行を一度消す。
+        # ここでは「rake タスクや手動再集計から呼ばれて新規作成される」シナリオの retention。
         create(:plate_appearance, game_result:, user:, plate_result_id: 7, hit_direction_id: 10,
                                   is_new_format: true)
+        BattingAverage.where(game_result_id: game_result.id).destroy_all
       end
 
       it 'find_or_create_by で新規作成される' do


### PR DESCRIPTION
## Summary

`Stats::BattingAverageRecalculator` の起動を controller 一本化から **PlateAppearance の model コールバック**に移行しました。これで rails runner / 一括投入スクリプト / 旧 v1 endpoint 経由など controller を通らないパスでも、新仕様 PA の create / update / destroy に追従して `batting_averages` が自動で再集計されます。

実測ギャップ（dev8 で game_results=93 / batting_averages=76 → 17 件未集計）を救済するためのバックフィル用 rake タスクも追加しました。

関連 Issue: ippei-shimizu/buzzbase#388
関連 PR: #278 (Issue #391, 集計式 SSoT 化)

## 変更内容

2 コミットに分割。各コミットで関連 spec を 0 failure で確認しています。

### 1. `Refactor: PlateAppearance に recalculator 起動 callback を追加し、controller の呼び出しを削除`

- `app/models/plate_appearance.rb` に `after_commit :recalculate_game_batting_average, on: %i[create update]` と `after_destroy_commit :recalculate_game_batting_average_after_destroy` を追加。
  - `user_id` を `self.user_id` で渡して recalculator 内の `GameResult.find` フォールバックを回避。
  - destroy 時の `cleanup_orphan` は `self.is_new_format` で判定（現 controller の `was_new_format` と同じセマンティクス）。
- `app/controllers/api/v2/plate_appearances_controller.rb` の create / update / destroy 内の recalculator 呼び出しと private helper を削除して一本化（二重発火回避）。
- `app/services/stats/batting_average_recalculator.rb` に `empty_stats?` ガードを追加。`plate_result_id` が未入力の新仕様 PA だけが紐づいている過渡状態（spec での aggregator テストや、入力途中の PA）では集計値が全 0 になり、`BattingAverage#must_have_any_stats` バリデーションに失敗していたため、recalculator 側で「全 0 のときは save しない」セーフガードを入れました。
- 既存 spec の修正:
  - `spec/services/stats/batting_average_recalculator_spec.rb`: callback で auto-create された BA を `destroy_all` してから recalculator の単体挙動を検証する形に修正。
  - `spec/requests/api/v2/plate_appearances_spec.rb`: callback で既に BA が作られている前提に setup を変更。
  - `spec/models/plate_appearance_spec.rb` の `is_new_format=true でセット可能` テスト: `plate_result_id` を明示してバリデーション通過を担保。
- 追加 spec: `spec/models/plate_appearance_spec.rb` に callback 動作の retention test 6 件を追加。
  - 新仕様 PA の create で BA が auto-create される
  - 新仕様 PA の update で BA が再集計される
  - 新仕様 PA の destroy（最後の 1 件）で BA が削除される
  - 旧仕様 PA の create では BA が作られない（混在試合保護）
  - 旧仕様 PA の destroy で直書きされた BA を触らない
  - 混在試合に新仕様 PA を追加しても直書き BA を触らない

### 2. `Add: data:backfill_batting_averages rake タスクを追加（既存ギャップ向け）`

- `lib/tasks/backfill_batting_averages.rake` を追加。既存の `data:normalize_match_type` / `data:repair_double_encoded_tokens` と同じ `namespace :data` で揃え、DRY_RUN サポート + `find_each(batch_size: 200)` + 進捗 puts。
- `spec/lib/tasks/backfill_batting_averages_spec.rb` を追加（4 例）:
  - 新仕様 PA がある試合の BA 欠落をバックフィル
  - DRY_RUN=1 で BA を変更しない
  - 混在試合の直書き BA を触らない
  - PA が 1 件もない試合では何もしない

## ユーザー表示への影響

- 既存ユーザーで「PA はあるが BA がない」試合があれば、本番でバックフィル後に stats タブ / マイページ / ランキングに反映される（**ポジティブな効果**）。
- 既存 BA が正しい試合では DB 値が変わらない（recalculator は同じ値で再 save するだけ）。
- 混在試合・旧仕様試合は `new_format_game?` で skip されるため触らない。

## Test plan

- [x] バックエンド全 spec: 928 examples / 0 failures
- [x] `bundle exec rubocop` 変更ファイル全て 0 offenses
- [x] callback 動作 retention spec（model）: 6 件 PASS
- [x] rake タスク spec: 4 件 PASS
- [ ] dev DB で `data:backfill_batting_averages DRY_RUN=1` → 該当件数を目視確認
- [ ] dev DB で `data:backfill_batting_averages` → 17 件のギャップが解消されること（中村優斗ユーザーで game_results 数 = batting_averages 数）
- [ ] dev での v2 PA create / update / destroy の体感確認（callback 化後も同じ最終状態が得られる）

## 本番運用

PR マージ後、本番で 1 回手動実行:

```bash
heroku run bundle exec rails data:backfill_batting_averages DRY_RUN=1
heroku run bundle exec rails data:backfill_batting_averages
```

Procfile の release フェーズには含めない（失敗時の rollback が複雑になるため別オペレーション）。

## スコープ外

- v1 PA endpoint (`Api::V1::PlateAppearancesController`) のフロー整理（旧仕様 PA は直書きで保護されているため本 Issue では触らない）
- `dev_data_creator.rb` で PA を生成しない明示的な省略の見直し
- model コールバック最小限原則との整合性に関する将来的なリファクタ
