### PR TITLE
Fix: masters:reseed の対象テーブルに appearance_situations を追加

### DIFF
--- a/lib/tasks/masters.rake
+++ b/lib/tasks/masters.rake
@@ -12,6 +12,7 @@ GAME_RECORD_MASTER_TABLES = %w[
   arm_angles
   velocity_zones
   pitcher_styles
+  appearance_situations
 ].freeze
 
 namespace :masters do


### PR DESCRIPTION
## Summary

`lib/tasks/masters.rake` の `GAME_RECORD_MASTER_TABLES` 配列に `appearance_situations` が抜けており、`masters:reseed` でこのテーブルだけ再投入できない状態でした。同テーブルは migration `20260611120003_create_appearance_situations.rb` 内で `MasterData::Seeder.from_yaml` を呼んで投入される設計ですが、何らかの理由で dev 環境では 0 件のままだったため、`AppearanceSituation` を参照する PA 入力 UI が選択肢を取得できない懸念がありました。

実測:
- dev DB で `AppearanceSituation.count == 0`（先発 / 中継ぎ / 抑え の 3 件入るべき）
- 他マスタは正常: PlateResult=19 / ContactQuality=5 / Timing=3 / PitchType=10 / 等

## 変更内容

`GAME_RECORD_MASTER_TABLES` 配列に `appearance_situations` を追加。これで `docker compose exec back bundle exec rails masters:reseed` を実行すると `db/data/master_seeds/appearance_situations.yml` から 3 件が upsert されます。

## ユーザー影響

- dev / 検証環境: 投手登板状況の選択肢が表示されるようになる（先発 / 中継ぎ / 抑え）
- 本番: マスタが既に正常に入っていれば挙動変化なし。万一 0 件であれば `heroku run bundle exec rails masters:reseed` で救済可能

## Test plan

- [x] 修正後 `bundle exec rails masters:reseed` で `AppearanceSituation` が 3 件投入されることを確認（dev DB で実施済み）
- [x] rubocop 0 offenses
- [ ] 本番 DB でマスタが既に正しく入っていることを Heroku 上で `AppearanceSituation.count` で確認
