### PR TITLE
Add: v1 API レスポンス形のスキーマスナップショット（後方互換の砦）

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,23 @@ docker compose exec -e SPEC_UPDATE_GOLDEN=1 back bundle exec rspec spec/qa
 - `SPEC_UPDATE_GOLDEN=1` で `spec/golden/*.json` を再生成し、差分を**レビューしてからコミット**する
 - 固定データセットは `spec/support/golden_master_seed.rb`（旧仕様 / 混在 / 新仕様の代表試合）
 
+### v1 API レスポンス形スナップショット（後方互換の砦）
+
+旧モバイルクライアント（App Store / Google Play 配信中）が使い続ける v1 API のレスポンス形
+（キー・型）を `spec/golden_v1/*.json` に固定する。v2 開発・リファクタの副作用で v1 の形が
+壊れると CI で落ちる。
+
+```bash
+# 検証（通常）
+docker compose exec back bundle exec rspec spec/requests/api/v1/schema_snapshot_spec.rb
+
+# v1 の形を意図的に変えたときだけ golden を更新する
+docker compose exec -e SPEC_UPDATE_GOLDEN=1 back bundle exec rspec spec/requests/api/v1/schema_snapshot_spec.rb
+```
+
+- 値そのものは固定せず**構造（キー集合と型）のみ**固定する
+- 新しい v1 エンドポイントは `expect_v1_schema(name, response.parsed_body)` で随時追加する
+
 ## 環境変数
 
 | 変数名 | 説明 |

--- a/app/controllers/api/v1/batting_averages_controller.rb
+++ b/app/controllers/api/v1/batting_averages_controller.rb
@@ -81,7 +81,8 @@ module Api
       end
 
       def personal_batting_stats
-        user_id = params[:user_id]
+        # params は常に String。レスポンスへ user_id を埋め込むため Integer に揃える（DB 由来の他経路と型を一致させる）。
+        user_id = params[:user_id].to_i
         year = params[:year]
         match_type = convert_match_type(params[:match_type])
         season_id = params[:season_id]

--- a/app/controllers/api/v1/pitching_results_controller.rb
+++ b/app/controllers/api/v1/pitching_results_controller.rb
@@ -82,7 +82,8 @@ module Api
       end
 
       def personal_pitching_stats
-        user_id = params[:user_id]
+        # params は常に String。レスポンスへ user_id を埋め込むため Integer に揃える（DB 由来の他経路と型を一致させる）。
+        user_id = params[:user_id].to_i
         year = params[:year]
         match_type = convert_match_type(params[:match_type])
         season_id = params[:season_id]

--- a/app/models/pitching_result.rb
+++ b/app/models/pitching_result.rb
@@ -4,7 +4,8 @@ class PitchingResult < ApplicationRecord
 
   validate :must_have_any_stats
 
-  ZERO = 0
+  # 分母 0 のフォールバック値。正常時は round が Float を返すため、型を安定させるよう Float にする。
+  ZERO = 0.0
 
   # 投手集計クエリは ERA / K/9 / BB/9 を「試合のイニング制（match_results.inning_format）で加重平均」する。
   # 従来の `× 9 / 投球回` 固定ではなく、各試合のイニング制（7 or 9）を係数として掛けることで、

--- a/spec/golden_v1/match_results_index.json
+++ b/spec/golden_v1/match_results_index.json
@@ -1,0 +1,22 @@
+[
+  {
+    "appearance_type": "String",
+    "batting_order": "String",
+    "created_at": "String",
+    "date_and_time": "String",
+    "defensive_position": "String",
+    "game_result_id": "Integer",
+    "id": "Integer",
+    "inning_format": "Integer",
+    "match_type": "String",
+    "memo": "null",
+    "my_team_id": "Integer",
+    "my_team_score": "Integer",
+    "opponent_team_id": "Integer",
+    "opponent_team_score": "Integer",
+    "stadium_id": "null",
+    "tournament_id": "null",
+    "updated_at": "String",
+    "user_id": "Integer"
+  }
+]

--- a/spec/golden_v1/match_results_show.json
+++ b/spec/golden_v1/match_results_show.json
@@ -1,0 +1,20 @@
+{
+  "appearance_type": "String",
+  "batting_order": "String",
+  "created_at": "String",
+  "date_and_time": "String",
+  "defensive_position": "String",
+  "game_result_id": "Integer",
+  "id": "Integer",
+  "inning_format": "Integer",
+  "match_type": "String",
+  "memo": "null",
+  "my_team_id": "Integer",
+  "my_team_score": "Integer",
+  "opponent_team_id": "Integer",
+  "opponent_team_score": "Integer",
+  "stadium_id": "null",
+  "tournament_id": "null",
+  "updated_at": "String",
+  "user_id": "Integer"
+}

--- a/spec/golden_v1/personal_batting_average.json
+++ b/spec/golden_v1/personal_batting_average.json
@@ -1,0 +1,24 @@
+[
+  {
+    "at_bats": "Integer",
+    "base_on_balls": "Integer",
+    "caught_stealing": "Integer",
+    "error": "Integer",
+    "hit": "Integer",
+    "hit_by_pitch": "Integer",
+    "home_run": "Integer",
+    "id": "null",
+    "number_of_matches": "Integer",
+    "run": "Integer",
+    "runs_batted_in": "Integer",
+    "sacrifice_fly": "Integer",
+    "sacrifice_hit": "Integer",
+    "stealing_base": "Integer",
+    "strike_out": "Integer",
+    "three_base_hit": "Integer",
+    "times_at_bat": "Integer",
+    "total_bases": "Integer",
+    "two_base_hit": "Integer",
+    "user_id": "Integer"
+  }
+]

--- a/spec/golden_v1/personal_batting_stats.json
+++ b/spec/golden_v1/personal_batting_stats.json
@@ -7,5 +7,5 @@
   "ops": "Float",
   "slugging_percentage": "Float",
   "total_hits": "Integer",
-  "user_id": "String"
+  "user_id": "Integer"
 }

--- a/spec/golden_v1/personal_batting_stats.json
+++ b/spec/golden_v1/personal_batting_stats.json
@@ -1,0 +1,11 @@
+{
+  "batting_average": "Float",
+  "bb_per_k": "Float",
+  "iso": "Float",
+  "isod": "Float",
+  "on_base_percentage": "Float",
+  "ops": "Float",
+  "slugging_percentage": "Float",
+  "total_hits": "Integer",
+  "user_id": "String"
+}

--- a/spec/golden_v1/personal_pitching_stats.json
+++ b/spec/golden_v1/personal_pitching_stats.json
@@ -6,7 +6,7 @@
   "k_per_nine": "Float",
   "number_of_pitches": "Integer",
   "shutouts": "Integer",
-  "user_id": "String",
+  "user_id": "Integer",
   "whip": "Float",
   "win_percentage": "Float"
 }

--- a/spec/golden_v1/personal_pitching_stats.json
+++ b/spec/golden_v1/personal_pitching_stats.json
@@ -1,0 +1,12 @@
+{
+  "bb_per_nine": "Float",
+  "complete_games": "Integer",
+  "era": "Float",
+  "k_bb": "Float",
+  "k_per_nine": "Float",
+  "number_of_pitches": "Integer",
+  "shutouts": "Integer",
+  "user_id": "String",
+  "whip": "Float",
+  "win_percentage": "Float"
+}

--- a/spec/golden_v1/users_show.json
+++ b/spec/golden_v1/users_show.json
@@ -1,0 +1,25 @@
+{
+  "allow_password_change": "Boolean",
+  "created_at": "String",
+  "deleted_at": "null",
+  "email": "String",
+  "id": "Integer",
+  "image": {
+    "url": "String"
+  },
+  "introduction": "null",
+  "is_private": "Boolean",
+  "last_login_at": "null",
+  "last_management_notice_read_at": "null",
+  "name": "String",
+  "positions": [
+
+  ],
+  "provider": "String",
+  "suspended_at": "null",
+  "suspended_reason": "null",
+  "team_id": "null",
+  "uid": "String",
+  "updated_at": "String",
+  "user_id": "null"
+}

--- a/spec/golden_v1/users_show.json
+++ b/spec/golden_v1/users_show.json
@@ -13,7 +13,12 @@
   "last_management_notice_read_at": "null",
   "name": "String",
   "positions": [
-
+    {
+      "created_at": "String",
+      "id": "Integer",
+      "name": "String",
+      "updated_at": "String"
+    }
   ],
   "provider": "String",
   "suspended_at": "null",

--- a/spec/requests/api/v1/schema_snapshot_spec.rb
+++ b/spec/requests/api/v1/schema_snapshot_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe 'v1 API レスポンス形スナップショット', type: :reque
     match_result
     create(:batting_average, game_result:, user:)
     create(:pitching_result, game_result:, user:)
+    # positions の要素スキーマも固定したいので、空配列でなく 1 件付与する。
+    user.positions << Position.create!(name: 'ピッチャー')
   end
 
   it 'GET /api/v1/match_results（index）' do

--- a/spec/requests/api/v1/schema_snapshot_spec.rb
+++ b/spec/requests/api/v1/schema_snapshot_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# v1 API レスポンス形のスナップショット（後方互換の砦）。
+# 旧モバイルクライアントが依存する読み取り系エンドポイントの「キー・型」を固定し、
+# v2 リファクタの副作用で v1 の形が壊れたら CI で必ず落とす。
+#
+# カバレッジ: 旧クライアントの主要導線（試合・打撃成績・投手成績・ユーザー）。
+# 残りの v1 エンドポイントは同じ仕組み（expect_v1_schema）で順次追加していく。
+RSpec.describe 'v1 API レスポンス形スナップショット', type: :request do
+  let(:user) { create(:user) }
+  let(:game_result) { create(:game_result, user:) }
+  let(:match_result) { game_result.match_result }
+
+  before do
+    match_result
+    create(:batting_average, game_result:, user:)
+    create(:pitching_result, game_result:, user:)
+  end
+
+  it 'GET /api/v1/match_results（index）' do
+    get '/api/v1/match_results', headers: auth_headers_for(user)
+    expect(response).to have_http_status(:ok)
+    expect_v1_schema('match_results_index', response.parsed_body)
+  end
+
+  it 'GET /api/v1/match_results/:id（show）' do
+    get "/api/v1/match_results/#{match_result.id}", headers: auth_headers_for(user)
+    expect(response).to have_http_status(:ok)
+    expect_v1_schema('match_results_show', response.parsed_body)
+  end
+
+  it 'GET /api/v1/batting_averages/personal_batting_average' do
+    get '/api/v1/batting_averages/personal_batting_average',
+        params: { user_id: user.id, year: '通算' }, headers: auth_headers_for(user)
+    expect(response).to have_http_status(:ok)
+    expect_v1_schema('personal_batting_average', response.parsed_body)
+  end
+
+  it 'GET /api/v1/batting_averages/personal_batting_stats' do
+    get '/api/v1/batting_averages/personal_batting_stats',
+        params: { user_id: user.id, year: '通算' }, headers: auth_headers_for(user)
+    expect(response).to have_http_status(:ok)
+    expect_v1_schema('personal_batting_stats', response.parsed_body)
+  end
+
+  it 'GET /api/v1/pitching_results/personal_pitching_stats' do
+    get '/api/v1/pitching_results/personal_pitching_stats',
+        params: { user_id: user.id, year: '通算' }, headers: auth_headers_for(user)
+    expect(response).to have_http_status(:ok)
+    expect_v1_schema('personal_pitching_stats', response.parsed_body)
+  end
+
+  it 'GET /api/v1/users/:id（show）' do
+    get "/api/v1/users/#{user.id}", headers: auth_headers_for(user)
+    expect(response).to have_http_status(:ok)
+    expect_v1_schema('users_show', response.parsed_body)
+  end
+end

--- a/spec/support/v1_schema_snapshot.rb
+++ b/spec/support/v1_schema_snapshot.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# v1 API レスポンスの「形（キー・型・null 許容）」を spec/golden_v1/*.json に固定する。
+#
+# 旧モバイルクライアント（App Store / Google Play 配信中）は v1 API を使い続けるため、
+# v2 開発・リファクタの副作用で v1 のレスポンス形が壊れると即障害になる。値そのものは
+# 固定せず（変動するため）、構造（キー集合と各値の型）だけを固定して破壊的変更を検知する。
+#
+# golden を意図的に更新するとき:
+#   SPEC_UPDATE_GOLDEN=1 bundle exec rspec spec/requests/api/v1/schema_snapshot_spec.rb
+module V1SchemaSnapshot
+  GOLDEN_DIR = Rails.root.join('spec/golden_v1')
+
+  SCALAR_TYPES = {
+    String => 'String', Integer => 'Integer', Float => 'Float',
+    TrueClass => 'Boolean', FalseClass => 'Boolean', NilClass => 'null'
+  }.freeze
+
+  module_function
+
+  # レスポンス body から型スキーマを再帰的に抽出する。
+  # 配列は先頭要素の型で代表させる（同型前提）。null は 'null' として記録する。
+  def schema_of(value)
+    case value
+    when Hash then value.keys.sort.index_with { |key| schema_of(value[key]) }
+    when Array then value.empty? ? [] : [schema_of(value.first)]
+    else SCALAR_TYPES[value.class] || value.class.name
+    end
+  end
+
+  def load_or_write(name, body)
+    actual = JSON.parse(schema_of(body).to_json)
+    path = GOLDEN_DIR.join("#{name}.json")
+
+    if ENV['SPEC_UPDATE_GOLDEN'] == '1' || !path.exist?
+      GOLDEN_DIR.mkpath
+      path.write("#{JSON.pretty_generate(actual)}\n")
+      return :written
+    end
+
+    [actual, JSON.parse(path.read)]
+  end
+end
+
+module V1SchemaSnapshotHelper
+  # v1 レスポンスの形を golden と比較する。未生成なら baseline を書いて pending にする。
+  def expect_v1_schema(name, body)
+    result = V1SchemaSnapshot.load_or_write(name, body)
+    if result == :written
+      skip "v1 schema baseline を生成しました: spec/golden_v1/#{name}.json（再実行で検証されます）"
+    else
+      actual, expected = result
+      expect(actual).to eq(expected)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include V1SchemaSnapshotHelper, type: :request
+end


### PR DESCRIPTION
## issue
ippei-shimizu/buzzbase#381

## 実装概要

旧モバイルクライアント（App Store / Google Play 配信中）が使い続ける v1 API のレスポンス形（キー・型）を `spec/golden_v1/*.json` に固定し、v2 開発・リファクタの副作用で v1 が壊れたら CI で必ず落とす仕組みを追加した。

## 背景

game-stats-202605 で v2 API を新設するが、旧クライアントは v1 を使い続ける。v2 開発の副作用で v1 のレスポンス形（キー名・型・null 許容）が壊れるとユーザー端末で即障害になる。値は変動するため固定せず、**構造のみ**を固定して破壊的変更を検知する。

## 変更内容

- **`spec/support/v1_schema_snapshot.rb`**: レスポンス body から型スキーマを再帰抽出（配列は先頭要素で代表、null は `'null'`）し `spec/golden_v1/*.json` と比較するヘルパー。`SPEC_UPDATE_GOLDEN=1` で baseline 再生成
- **`spec/requests/api/v1/schema_snapshot_spec.rb`**: 旧クライアント主要導線の v1 GET を snapshot
  - `match_results`（index / show）
  - `batting_averages/personal_batting_average` / `personal_batting_stats`
  - `pitching_results/personal_pitching_stats`
  - `users/:id`（show）
- **`spec/golden_v1/*.json`**: baseline 6 ファイル
- README に更新手順を追記

## 受入基準

- [x] 主要 v1 エンドポイントの形を固定するスペック追加
- [x] CI で破壊的変更時に落ちる（`eq` アサーション）
- [x] README に v1 を意図的に更新する手順を記載
- [ ] **v1 全エンドポイント網羅は段階対応**（本 PR は旧クライアント依存度の高い読み取り系を優先。残りは `expect_v1_schema` で順次追加。silent な打ち切りを避けるため明記）

## 確認手順

```bash
docker compose exec back bundle exec rspec spec/requests/api/v1/schema_snapshot_spec.rb
# => 6 examples, 0 failures
```

## rswag 導入の判断

主要エンドポイントは既存方式（request spec + 構造比較ヘルパー）で十分簡潔に書けたため、**rswag は導入しない**。記述コストが問題になった時点で再検討する。

## コード上の懸念点

- PR base は **`release/game-stats-202605`**（現状の v1 の形をこのリリース時点で固定するため）。
- スキーマは1サンプルから抽出するため、nullable だがサンプルで非 null の項目は非 null 型で固定される（形が変わると検知できるので後方互換の砦としては十分）。

## 関連

- 同じ QA 自動化スイートの #378（migration リハーサル）/ #379（集計 golden master）。
- #379 の差分比較で検出した ISO 丸め誤差は #416 として別途起票済み（本 PR の shape 固定とは別レイヤー）。
