### PR TITLE
Fix: ISO を生値から直接計算し本番との丸め誤差を解消 (#416)

### DIFF
--- a/app/models/batting_average.rb
+++ b/app/models/batting_average.rb
@@ -162,15 +162,14 @@ class BattingAverage < ApplicationRecord
       hit_by_pitch: stats['hit_by_pitch'], at_bats:,
       sacrifice_fly: stats['sacrifice_fly']
     )
-    slg = Stats::BattingFormulas.slugging_percentage(
-      total_bases: calculate_total_bases(stats), at_bats:
-    )
+    total_bases = calculate_total_bases(stats)
+    slg = Stats::BattingFormulas.slugging_percentage(total_bases:, at_bats:)
     {
       user_id:,
       total_hits:,
       batting_average: avg,
       on_base_percentage: obp,
-      iso: Stats::BattingFormulas.iso(slg:, batting_average: avg),
+      iso: Stats::BattingFormulas.iso(total_bases:, total_hits:, at_bats:),
       ops: Stats::BattingFormulas.ops(obp:, slg:),
       bb_per_k: Stats::BattingFormulas.safe_divide(stats['base_on_balls'], stats['strike_outs']),
       isod: Stats::BattingFormulas.isod(obp:, batting_average: avg),

--- a/app/services/stats/additional_stats_aggregator.rb
+++ b/app/services/stats/additional_stats_aggregator.rb
@@ -87,9 +87,8 @@ module Stats
         hit_by_pitch: stats[:hit_by_pitch], at_bats:,
         sacrifice_fly: stats[:sacrifice_fly]
       )
-      slg = BattingFormulas.slugging_percentage(total_bases: stats[:total_bases], at_bats:)
       {
-        iso: BattingFormulas.iso(slg:, batting_average:),
+        iso: BattingFormulas.iso(total_bases: stats[:total_bases], total_hits:, at_bats:),
         isod: BattingFormulas.isod(obp:, batting_average:),
         bb_per_k: BattingFormulas.safe_divide(stats[:base_on_balls], stats[:strike_out])
       }

--- a/app/services/stats/batting_formulas.rb
+++ b/app/services/stats/batting_formulas.rb
@@ -47,9 +47,10 @@ module Stats
       (obp.to_f + slg.to_f).round(3)
     end
 
-    # ISO (純粋な長打力) = 長打率 - 打率
-    def self.iso(slg:, batting_average:)
-      (slg.to_f - batting_average.to_f).round(3)
+    # ISO (純粋な長打力) = (塁打 - 安打総数) / 打数
+    # 丸め済み SLG・打率の差ではなく生値から直接算出し、二重丸め誤差を避ける
+    def self.iso(total_bases:, total_hits:, at_bats:)
+      safe_divide(total_bases.to_i - total_hits.to_i, at_bats)
     end
 
     # ISOD (純粋な選球眼) = 出塁率 - 打率

--- a/app/services/stats/batting_stats_table_service.rb
+++ b/app/services/stats/batting_stats_table_service.rb
@@ -121,7 +121,7 @@ module Stats
 
       { hit:, total_bases:, batting_average: avg, slugging_percentage: slg,
         ops: BattingFormulas.ops(obp:, slg:),
-        iso: BattingFormulas.iso(slg:, batting_average: avg),
+        iso: BattingFormulas.iso(total_bases:, total_hits: hit, at_bats:),
         bb_per_k: BattingFormulas.safe_divide(vals['base_on_balls'], vals['strike_out']) }
         .merge(babip: calculate_babip(hit, vals))
     end

--- a/spec/services/stats/batting_formulas_spec.rb
+++ b/spec/services/stats/batting_formulas_spec.rb
@@ -121,17 +121,20 @@ RSpec.describe Stats::BattingFormulas do
   end
 
   describe '.iso' do
-    it 'ISO = SLG - AVG を 3 桁 round で返す' do
-      # SLG 0.7, AVG 0.3 → ISO 0.4
-      expect(described_class.iso(slg: 0.7, batting_average: 0.3)).to eq(0.4)
+    it 'ISO = (塁打 - 安打総数) / 打数 を 3 桁 round で返す' do
+      # total_bases 12, total_hits 5, at_bats 17 → (12-5)/17 = 0.41176... → 0.412
+      expect(described_class.iso(total_bases: 12, total_hits: 5, at_bats: 17)).to eq(0.412)
     end
 
-    it '負の値も返せる（実データでは普通起きないが式として）' do
-      expect(described_class.iso(slg: 0.2, batting_average: 0.5)).to eq(-0.3)
+    it '生値から直接計算するため丸め済み SLG・打率の差より正確' do
+      # total_bases 7, total_hits 5, at_bats 9 → (7-5)/9 = 0.2222... → 0.222
+      # round(SLG)=round(0.778)=0.778, round(AVG)=round(0.556)=0.556 の差 0.222 とは
+      # ケースにより ±0.001 ずれうるが、生値計算は常に正確
+      expect(described_class.iso(total_bases: 7, total_hits: 5, at_bats: 9)).to eq(0.222)
     end
 
-    it '両方 0 のとき 0 を返す' do
-      expect(described_class.iso(slg: 0.0, batting_average: 0.0)).to eq(0.0)
+    it '打数 0 のとき 0.0 を返す' do
+      expect(described_class.iso(total_bases: 0, total_hits: 0, at_bats: 0)).to eq(0.0)
     end
   end
 


### PR DESCRIPTION
## 概要

ippei-shimizu/buzzbase#416 の修正。game-stats-202605 リリースの集計リファクタ（`Stats::BattingFormulas` SSoT 化）で `iso`（純粋長打力）の計算方法が変わり、匿名化本番相当データ 770 ユーザー中 77 人（10%）で `iso` が ±0.001 ずれる丸め誤差が発生していた。

## 根本原因

| | 計算方法 | 性質 |
| ---- | ---- | ---- |
| 旧（本番） | `iso = (塁打 − 安打総数) / 打数` を生値から直接計算し丸め | 正確 |
| 新（release） | `iso = round(SLG, 3) − round(打率, 3)` | 丸め済み 2 値の差で ±0.001 の誤差混入 |

## 変更内容

- `BattingFormulas.iso` のシグネチャを `iso(total_bases:, total_hits:, at_bats:)` に変更し、`safe_divide`（3 桁 round 付き）で生値から一度だけ丸める。本番の旧計算と完全一致。
- 呼び出し 3 箇所（`BattingAverage#build_stats_hash` / `AdditionalStatsAggregator#computed_rates` / `BattingStatsTableService#calculate_batting_rates`）を生値を渡すよう更新。
- `batting_formulas_spec` の `.iso` を新シグネチャ用に書き換え。
- `isod` は旧コードも丸め済み差で計算しており既に一致しているため変更なし。
- `iso` は golden master（`spec/golden`・`spec/qa`）に含まれないため golden 再生成は不要。

## テスト

- 該当 spec + `spec/qa`（golden）+ consistency spec: 全て pass
- back 全体 rspec: 933 examples, 0 failures
- rubocop: no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
