### PR TITLE
Add: 管理ユーザー検索で users.id（PostHog ID）検索に対応

### DIFF
--- a/app/controllers/api/v1/admin/users_controller.rb
+++ b/app/controllers/api/v1/admin/users_controller.rb
@@ -71,7 +71,7 @@ module Api
         end
 
         def search_params
-          params.permit(:page, :per_page, :search, :sort_by, :sort_order, :status, :date_from, :date_to)
+          params.permit(:page, :per_page, :id, :search, :sort_by, :sort_order, :status, :date_from, :date_to)
         end
       end
     end

--- a/app/services/admin/user_management_service.rb
+++ b/app/services/admin/user_management_service.rb
@@ -3,13 +3,14 @@ module Admin
     DEFAULT_PER_PAGE = 20
     MAX_PER_PAGE = 100
     SORTABLE_COLUMNS = %w[created_at last_login_at name game_results_count followers_count].freeze
-    # PostgreSQL bigint の最大値。検索語を users.id として扱う前にこの範囲をガードし、
+    # PostgreSQL bigint の最大値。id 検索でこの範囲をガードし、
     # 巨大な数値文字列で StatementInvalid（範囲外）になるのを防ぐ。
     BIGINT_MAX = 9_223_372_036_854_775_807
 
     def initialize(params = {})
       @page = [params[:page].to_i, 1].max
       @per_page = params[:per_page].to_i.between?(1, MAX_PER_PAGE) ? params[:per_page].to_i : DEFAULT_PER_PAGE
+      @id = params[:id]
       @search = params[:search]
       @sort_by = SORTABLE_COLUMNS.include?(params[:sort_by]) ? params[:sort_by] : 'created_at'
       @sort_order = params[:sort_order] == 'asc' ? 'asc' : 'desc'
@@ -21,6 +22,7 @@ module Admin
     def call
       users = base_scope
       users = apply_status_filter(users)
+      users = apply_id_filter(users)
       users = apply_search(users)
       users = apply_date_filter(users)
       total_count = users.count
@@ -57,20 +59,21 @@ module Admin
       end
     end
 
+    # id（PostHog の distinct_id = users.id 主キー）専用の絞り込み。
+    # 名前等のあいまい検索（apply_search）とは独立した完全一致フィルタ。
+    # 非数値・bigint 範囲外は該当なしとして空集合を返す。
+    def apply_id_filter(users)
+      return users if @id.blank?
+      return users.none unless @id.to_s.match?(/\A\d+\z/) && @id.to_i <= BIGINT_MAX
+
+      users.where(id: @id.to_i)
+    end
+
     def apply_search(users)
       return users if @search.blank?
 
       search_term = "%#{@search}%"
-      # PostHog の distinct_id は users.id（主キー）なので、検索語が数値なら id 完全一致も OR で許す。
-      # 数字を含むハンドル名（user_id）も従来どおりヒットさせるため ILIKE の OR は残す。
-      if @search.match?(/\A\d+\z/) && @search.to_i <= BIGINT_MAX
-        users.where(
-          'users.id = :id OR name ILIKE :term OR email ILIKE :term OR user_id ILIKE :term',
-          id: @search.to_i, term: search_term
-        )
-      else
-        users.where('name ILIKE :term OR email ILIKE :term OR user_id ILIKE :term', term: search_term)
-      end
+      users.where('name ILIKE :term OR email ILIKE :term OR user_id ILIKE :term', term: search_term)
     end
 
     def apply_date_filter(users)

--- a/app/services/admin/user_management_service.rb
+++ b/app/services/admin/user_management_service.rb
@@ -3,6 +3,9 @@ module Admin
     DEFAULT_PER_PAGE = 20
     MAX_PER_PAGE = 100
     SORTABLE_COLUMNS = %w[created_at last_login_at name game_results_count followers_count].freeze
+    # PostgreSQL bigint の最大値。検索語を users.id として扱う前にこの範囲をガードし、
+    # 巨大な数値文字列で StatementInvalid（範囲外）になるのを防ぐ。
+    BIGINT_MAX = 9_223_372_036_854_775_807
 
     def initialize(params = {})
       @page = [params[:page].to_i, 1].max
@@ -58,7 +61,16 @@ module Admin
       return users if @search.blank?
 
       search_term = "%#{@search}%"
-      users.where('name ILIKE :term OR email ILIKE :term OR user_id ILIKE :term', term: search_term)
+      # PostHog の distinct_id は users.id（主キー）なので、検索語が数値なら id 完全一致も OR で許す。
+      # 数字を含むハンドル名（user_id）も従来どおりヒットさせるため ILIKE の OR は残す。
+      if @search.match?(/\A\d+\z/) && @search.to_i <= BIGINT_MAX
+        users.where(
+          'users.id = :id OR name ILIKE :term OR email ILIKE :term OR user_id ILIKE :term',
+          id: @search.to_i, term: search_term
+        )
+      else
+        users.where('name ILIKE :term OR email ILIKE :term OR user_id ILIKE :term', term: search_term)
+      end
     end
 
     def apply_date_filter(users)

--- a/spec/services/admin/user_management_service_spec.rb
+++ b/spec/services/admin/user_management_service_spec.rb
@@ -43,22 +43,40 @@ RSpec.describe Admin::UserManagementService do
         expect(result[:users]).to include(user_a, user_b, user_c)
       end
 
-      it 'filters users by exact users.id when search term is numeric (PostHog id)' do
-        # name / email に数字を含めず、ILIKE の偶発一致を排除して id 完全一致のみを検証する。
-        target = create(:user, name: 'Target', email: 'target@example.com')
-        other = create(:user, name: 'Other', email: 'other@example.com')
+      it 'does not match users.id by the keyword search (id is a dedicated filter)' do
+        # name / email に数字を含めないユーザーを id 文字列で検索しても、
+        # search は ILIKE のみで id 完全一致を持たないためヒットしない。
+        target = create(:user, name: 'Zeta', email: 'zeta@example.com')
 
         result = described_class.new(search: target.id.to_s).call
 
-        expect(result[:users]).to include(target)
-        expect(result[:users]).not_to include(other)
+        expect(result[:users]).not_to include(target)
+      end
+    end
+
+    context 'with id filter' do
+      it 'filters users by exact users.id' do
+        result = described_class.new(id: user_b.id.to_s).call
+
+        expect(result[:users]).to contain_exactly(user_b)
       end
 
-      it 'does not raise when search term is a huge numeric string out of bigint range' do
-        huge_numeric = '9' * 25
+      it 'returns no users when id matches nothing' do
+        result = described_class.new(id: '999999999').call
 
+        expect(result[:users]).to be_empty
+      end
+
+      it 'returns no users and does not raise for a non-numeric id' do
         expect do
-          result = described_class.new(search: huge_numeric).call
+          result = described_class.new(id: 'abc').call
+          expect(result[:users]).to be_empty
+        end.not_to raise_error
+      end
+
+      it 'returns no users and does not raise for a huge numeric id out of bigint range' do
+        expect do
+          result = described_class.new(id: '9' * 25).call
           expect(result[:users]).to be_empty
         end.not_to raise_error
       end

--- a/spec/services/admin/user_management_service_spec.rb
+++ b/spec/services/admin/user_management_service_spec.rb
@@ -42,6 +42,26 @@ RSpec.describe Admin::UserManagementService do
 
         expect(result[:users]).to include(user_a, user_b, user_c)
       end
+
+      it 'filters users by exact users.id when search term is numeric (PostHog id)' do
+        # name / email に数字を含めず、ILIKE の偶発一致を排除して id 完全一致のみを検証する。
+        target = create(:user, name: 'Target', email: 'target@example.com')
+        other = create(:user, name: 'Other', email: 'other@example.com')
+
+        result = described_class.new(search: target.id.to_s).call
+
+        expect(result[:users]).to include(target)
+        expect(result[:users]).not_to include(other)
+      end
+
+      it 'does not raise when search term is a huge numeric string out of bigint range' do
+        huge_numeric = '9' * 25
+
+        expect do
+          result = described_class.new(search: huge_numeric).call
+          expect(result[:users]).to be_empty
+        end.not_to raise_error
+      end
     end
 
     context 'with status filter' do


### PR DESCRIPTION
## 概要

ippei-shimizu/buzzbase#424 対応（back）。管理画面ユーザー管理の検索で、`users.id`（= PostHog の distinct_id）による検索を可能にする。

PostHog は `posthog.identify(String(user.id))` で `users.id`（主キー）を distinct_id として送出しているため、PostHog 上の id（例: "2416"）を起点に管理画面でユーザーを特定できるようにする。

## 変更内容

- `Admin::UserManagementService#apply_search` を変更し、検索語が数値のとき `users.id = :id` の完全一致を OR に追加
  - 既存の `name / email / user_id (ハンドル名) ILIKE` 検索はそのまま維持（後方互換）
  - 数字を含むハンドル名も従来どおりヒット
- 巨大な数値文字列での bigint 範囲外エラー（`StatementInvalid`）を防ぐ `BIGINT_MAX` ガードを追加（超過時は文字列検索にフォールバック）

## 補足

- シリアライザ（`Admin::UserManagementSerializer` / `Admin::UserManagementDetailSerializer`）は既に `id` を返しているため変更なし

## テスト

- `spec/services/admin/user_management_service_spec.rb` に追加
  - 数値検索で `users.id` 完全一致のユーザーが返る（name/email に数字を含めず ILIKE の偶発一致を排除）
  - 巨大な数値文字列でも例外を出さない
- `bundle exec rspec spec/services/admin/user_management_service_spec.rb` 全22例パス
- `bundle exec rubocop`（対象2ファイル）offense なし
