### PR TITLE
Add: 対戦投手別レスポンスに投手属性（チーム名・左右・タイプ・球速帯）を追加

### DIFF
--- a/app/services/stats/pitcher_faceoff_aggregator.rb
+++ b/app/services/stats/pitcher_faceoff_aggregator.rb
@@ -33,14 +33,18 @@ module Stats
       @tournament_id = tournament_id
     end
 
-    # @return [Hash] rows: [{ pitcher_id, pitcher_name, plate_appearances,
+    # @return [Hash] rows: [{ pitcher_id, pitcher_name, team_name, throw_hand,
+    #   pitcher_style, velocity_zone, plate_appearances,
     #   at_bats, hits, batting_average, top_result }],
     #   total_target_pa: pitcher_id 付き打席の総数,
     #   min_plate_appearances: しきい値
     def call
       stats = aggregate_stats
       total_target_pa = stats.values.sum { |s| s[:plate_appearances] }
-      pitchers_by_id = Pitcher.where(id: stats.keys).index_by(&:id)
+      # 所属チーム名・投手タイプ・球速帯を行ごとに引くため関連を preload して N+1 を回避する。
+      pitchers_by_id = Pitcher.where(id: stats.keys)
+                              .includes(:team, :pitcher_style, :velocity_zone)
+                              .index_by(&:id)
       # AR オブジェクトを介さず id → name の Hash だけ作る。マスタ件数は少なくても
       # 集計対象投手ごとに 1 名引くだけなので余計なオブジェクト生成を避ける。
       plate_result_names_by_id = PlateResult.pluck(:id, :name).to_h
@@ -74,8 +78,7 @@ module Stats
       top_result_id = stats[:result_counts].max_by { |_, c| c }&.first
       top_result_name = plate_result_names_by_id[top_result_id] || ''
       {
-        pitcher_id: pitcher.id,
-        pitcher_name: pitcher.name,
+        **pitcher_attributes(pitcher),
         plate_appearances: stats[:plate_appearances],
         at_bats:,
         hits:,
@@ -89,6 +92,19 @@ module Stats
         ops: (obp + slg).round(3),
         top_result: top_result_name,
         result_counts: build_result_counts(stats[:result_counts], plate_result_names_by_id)
+      }
+    end
+
+    # 投手マスタの識別情報と属性（所属チーム名 / どっち投げ / 投手タイプ / 球速帯）。
+    # 未設定の属性は nil で返し、フロントで非表示にできるようにする。
+    def pitcher_attributes(pitcher)
+      {
+        pitcher_id: pitcher.id,
+        pitcher_name: pitcher.name,
+        team_name: pitcher.team&.name,
+        throw_hand: pitcher.throw_hand,
+        pitcher_style: pitcher.pitcher_style&.name,
+        velocity_zone: pitcher.velocity_zone&.name
       }
     end
 

--- a/spec/services/stats/pitcher_faceoff_aggregator_spec.rb
+++ b/spec/services/stats/pitcher_faceoff_aggregator_spec.rb
@@ -129,6 +129,38 @@ RSpec.describe Stats::PitcherFaceoffAggregator, type: :service do
       end
     end
 
+    context 'with pitcher attributes (team / throw_hand / style / velocity_zone)' do
+      let!(:team) { create(:team, name: '対戦チーム') }
+      let(:pitcher_style) { PitcherStyle.find_by!(name: '本格派') }
+      let(:velocity_zone) { VelocityZone.find_by!(name: '140-150km/h') }
+      let!(:lefty) do
+        Pitcher.create!(name: '左腕投手', created_by_user: user, team:,
+                        throw_hand: :left, pitcher_style:, velocity_zone:)
+      end
+      let!(:bare) { create_pitcher('属性なし投手') }
+
+      before do
+        3.times { |i| create_pa(pitcher_id: lefty.id, plate_result_id: single_result_id, batter_box_number: i + 1) }
+        3.times { |i| create_pa(pitcher_id: bare.id, plate_result_id: single_result_id, batter_box_number: 10 + i) }
+      end
+
+      it 'exposes team_name / throw_hand / pitcher_style / velocity_zone, nil when unset' do
+        result = described_class.new(user_id: user.id).call
+        lefty_row = result[:rows].find { |r| r[:pitcher_name] == '左腕投手' }
+        bare_row = result[:rows].find { |r| r[:pitcher_name] == '属性なし投手' }
+
+        aggregate_failures do
+          expect(lefty_row).to include(
+            team_name: '対戦チーム', throw_hand: 'left',
+            pitcher_style: '本格派', velocity_zone: '140-150km/h'
+          )
+          expect(bare_row).to include(
+            team_name: nil, throw_hand: nil, pitcher_style: nil, velocity_zone: nil
+          )
+        end
+      end
+    end
+
     context 'when tied appearances, sorts by pitcher_name asc' do
       let!(:pitcher_b) { create_pitcher('Bさん') }
       let!(:pitcher_a) { create_pitcher('Aさん') }

--- a/spec/services/stats/pitcher_faceoff_aggregator_spec.rb
+++ b/spec/services/stats/pitcher_faceoff_aggregator_spec.rb
@@ -131,8 +131,13 @@ RSpec.describe Stats::PitcherFaceoffAggregator, type: :service do
 
     context 'with pitcher attributes (team / throw_hand / style / velocity_zone)' do
       let!(:team) { create(:team, name: '対戦チーム') }
-      let(:pitcher_style) { PitcherStyle.find_by!(name: '本格派') }
-      let(:velocity_zone) { VelocityZone.find_by!(name: '140-150km/h') }
+      # シード有無に依存しないよう find_or_create_by で確実に用意する（name は unique）。
+      let(:pitcher_style) do
+        PitcherStyle.find_or_create_by!(name: '本格派') { |style| style.display_order = 1 }
+      end
+      let(:velocity_zone) do
+        VelocityZone.find_or_create_by!(name: '140-150km/h') { |zone| zone.display_order = 4 }
+      end
       let!(:lefty) do
         Pitcher.create!(name: '左腕投手', created_by_user: user, team:,
                         throw_hand: :left, pitcher_style:, velocity_zone:)


### PR DESCRIPTION
## 概要

分析画面「対戦投手別」で投手の所属チーム名・属性を表示できるよう、`Stats::PitcherFaceoffAggregator` のレスポンスに投手属性を追加する。

ippei-shimizu/buzzbase#421 のバックエンド対応。

## 変更内容

- `app/services/stats/pitcher_faceoff_aggregator.rb`
  - 各 row に以下を追加
    - `team_name`: 所属チーム名（`pitcher.team&.name`）
    - `throw_hand`: どっち投げ（enum 文字列 `"right"` / `"left"`、未設定は `nil`）
    - `pitcher_style`: 投手タイプ名
    - `velocity_zone`: 球速帯名
  - N+1 回避のため `team` / `pitcher_style` / `velocity_zone` を `includes` で preload
  - 未設定の属性は `nil` で返し、フロント側で非表示にできるようにする
- `spec/services/stats/pitcher_faceoff_aggregator_spec.rb`
  - 属性付き投手 / 属性なし投手の両方を検証するケースを追加

## 確認

- `bundle exec rspec spec/services/stats/pitcher_faceoff_aggregator_spec.rb` 8 examples, 0 failures
- `bundle exec rubocop app/services/stats/pitcher_faceoff_aggregator.rb` no offenses
