### PR TITLE
Fix: PR #246 リリースブランチのレビュー指摘対応（非公開ガード/索引/決定性/Concern統一）

### DIFF
--- a/app/controllers/api/v2/dashboards_controller.rb
+++ b/app/controllers/api/v2/dashboards_controller.rb
@@ -30,6 +30,8 @@ module Api
       # GET /api/v2/dashboard/batting_stats
       def batting_stats
         user = params[:user_id].present? ? User.find(params[:user_id]) : current_api_v1_user
+        return if render_forbidden_if_private!(user)
+
         render json: build_batting_stats(
           user, year: params[:year], match_type: convert_match_type(params[:match_type]),
                 season_id: params[:season_id], tournament_id: params[:tournament_id]
@@ -39,6 +41,8 @@ module Api
       # GET /api/v2/dashboard/pitching_stats
       def pitching_stats
         user = params[:user_id].present? ? User.find(params[:user_id]) : current_api_v1_user
+        return if render_forbidden_if_private!(user)
+
         render json: build_pitching_stats(
           user, year: params[:year], match_type: convert_match_type(params[:match_type]),
                 season_id: params[:season_id], tournament_id: params[:tournament_id]

--- a/app/services/stats/batting_average_recalculator.rb
+++ b/app/services/stats/batting_average_recalculator.rb
@@ -83,46 +83,72 @@ module Stats
       !PlateAppearance.exists?(game_result_id: @game_result_id)
     end
 
-    # 全カラム一気に組み立てる都合上 ABC が高くなるが、各行は独立した集計式で複雑度は低いため許容する。
-    def aggregate_stats # rubocop:disable Metrics/AbcSize
-      scope = PlateAppearance.where(game_result_id: @game_result_id)
-      with_plate_result = scope.joins(:plate_result)
-      # times_at_bat と at_bats は野球統計上は別概念（前者は打席数、後者は打数）だが、
-      # 本アプリでは既存集計テーブルに揃えて同一値で運用している（旧仕様 batting_average も同様）。
-      counted = with_plate_result.where(plate_results: { counted_in_at_bats: true }).count
+    # 集計対象を 1 クエリで取り出す SELECT 句。COUNT(*) FILTER と SUM を 1 度に発行し、
+    # 1 試合分の COUNT/SUM を個別に投げていた ~16 クエリを 1 クエリに集約する。
+    # plate_result_id が NULL の PA も総打席数・各 SUM に含めるため LEFT JOIN を使う
+    # （counted_in_at_bats フィルタは NULL 結合行を自然に除外する）。
+    # 補間値は全て本クラスの整数定数のためインジェクションの懸念は無い。
+    AGGREGATE_SQL = <<~SQL.squish.freeze
+      COUNT(*) AS plate_appearances,
+      COUNT(*) FILTER (WHERE plate_results.counted_in_at_bats = TRUE) AS counted,
+      COUNT(*) FILTER (WHERE plate_appearances.plate_result_id = #{SINGLE_HIT_ID}) AS single,
+      COUNT(*) FILTER (WHERE plate_appearances.plate_result_id = #{DOUBLE_HIT_ID}) AS double,
+      COUNT(*) FILTER (WHERE plate_appearances.plate_result_id = #{TRIPLE_HIT_ID}) AS triple,
+      COUNT(*) FILTER (WHERE plate_appearances.plate_result_id = #{HOME_RUN_ID}) AS homer,
+      COUNT(*) FILTER (WHERE plate_appearances.plate_result_id IN (#{STRIKE_OUT_IDS.join(',')})) AS strike_out,
+      COUNT(*) FILTER (WHERE plate_appearances.plate_result_id = #{BASE_ON_BALLS_ID}) AS base_on_balls,
+      COUNT(*) FILTER (WHERE plate_appearances.plate_result_id = #{HIT_BY_PITCH_ID}) AS hit_by_pitch,
+      COUNT(*) FILTER (WHERE plate_appearances.plate_result_id = #{SACRIFICE_HIT_ID}) AS sacrifice_hit,
+      COUNT(*) FILTER (WHERE plate_appearances.plate_result_id = #{SACRIFICE_FLY_ID}) AS sacrifice_fly,
+      COUNT(*) FILTER (WHERE plate_appearances.plate_result_id = #{ERROR_ID}) AS error,
+      COALESCE(SUM(plate_appearances.rbi), 0) AS runs_batted_in,
+      COALESCE(SUM(plate_appearances.run_scored), 0) AS run,
+      COALESCE(SUM(plate_appearances.stolen_bases), 0) AS stealing_base,
+      COALESCE(SUM(plate_appearances.caught_stealing), 0) AS caught_stealing
+    SQL
 
-      # `batting_averages.hit` は本番運用上「単打のみ」を保持する semantics で揃える。
-      # 2B/3B/HR は別カラムで内訳として持つため、ここで全安打を入れると
-      # マイページ系 (`BattingAverage.stats_for_user` の `SUM(hit + 2B + 3B + HR)`)
-      # で二重計上になる。集計の真は SUM(hit) + SUM(2B) + SUM(3B) + SUM(HR)。
-      single = scope.where(plate_result_id: SINGLE_HIT_ID).count
-      double = scope.where(plate_result_id: DOUBLE_HIT_ID).count
-      triple = scope.where(plate_result_id: TRIPLE_HIT_ID).count
-      homer  = scope.where(plate_result_id: HOME_RUN_ID).count
+    AGGREGATE_KEYS = %i[
+      plate_appearances counted single double triple homer strike_out base_on_balls
+      hit_by_pitch sacrifice_hit sacrifice_fly error runs_batted_in run
+      stealing_base caught_stealing
+    ].freeze
+
+    # ハッシュ各キーへの代入が多く ABC が高くなるが、各行は単純なルックアップで複雑度は低いため許容する。
+    def aggregate_stats # rubocop:disable Metrics/AbcSize
+      row = PlateAppearance.where(game_result_id: @game_result_id)
+                           .left_joins(:plate_result)
+                           .pick(Arel.sql(AGGREGATE_SQL))
+      stats = AGGREGATE_KEYS.zip(Array.wrap(row).map(&:to_i)).to_h
 
       {
-        plate_appearances: scope.count,
-        times_at_bat: counted,
-        at_bats: counted,
-        hit: single,
-        two_base_hit: double,
-        three_base_hit: triple,
-        home_run: homer,
-        # 塁打 (TB) = 単打×1 + 2B×2 + 3B×3 + HR×4。既に取得済みのカウントを再利用して
-        # 同じ COUNT クエリを 4 本余計に発行しないようにする。
+        plate_appearances: stats[:plate_appearances],
+        # times_at_bat と at_bats は野球統計上は別概念（前者は打席数、後者は打数）だが、
+        # 本アプリでは既存集計テーブルに揃えて同一値で運用している（旧仕様 batting_average も同様）。
+        times_at_bat: stats[:counted],
+        at_bats: stats[:counted],
+        # `batting_averages.hit` は本番運用上「単打のみ」を保持する semantics で揃える。
+        # 2B/3B/HR は別カラムで内訳として持つため、ここで全安打を入れると
+        # マイページ系 (`BattingAverage.stats_for_user` の `SUM(hit + 2B + 3B + HR)`)
+        # で二重計上になる。集計の真は SUM(hit) + SUM(2B) + SUM(3B) + SUM(HR)。
+        hit: stats[:single],
+        two_base_hit: stats[:double],
+        three_base_hit: stats[:triple],
+        home_run: stats[:homer],
+        # 塁打 (TB) = 単打×1 + 2B×2 + 3B×3 + HR×4。
         total_bases: BattingFormulas.total_bases(
-          singles: single, doubles: double, triples: triple, home_runs: homer
+          singles: stats[:single], doubles: stats[:double],
+          triples: stats[:triple], home_runs: stats[:homer]
         ),
-        runs_batted_in: scope.sum(:rbi).to_i,
-        run: scope.sum(:run_scored).to_i,
-        strike_out: scope.where(plate_result_id: STRIKE_OUT_IDS).count,
-        base_on_balls: scope.where(plate_result_id: BASE_ON_BALLS_ID).count,
-        hit_by_pitch: scope.where(plate_result_id: HIT_BY_PITCH_ID).count,
-        sacrifice_hit: scope.where(plate_result_id: SACRIFICE_HIT_ID).count,
-        sacrifice_fly: scope.where(plate_result_id: SACRIFICE_FLY_ID).count,
-        stealing_base: scope.sum(:stolen_bases).to_i,
-        caught_stealing: scope.sum(:caught_stealing).to_i,
-        error: scope.where(plate_result_id: ERROR_ID).count
+        runs_batted_in: stats[:runs_batted_in],
+        run: stats[:run],
+        strike_out: stats[:strike_out],
+        base_on_balls: stats[:base_on_balls],
+        hit_by_pitch: stats[:hit_by_pitch],
+        sacrifice_hit: stats[:sacrifice_hit],
+        sacrifice_fly: stats[:sacrifice_fly],
+        stealing_base: stats[:stealing_base],
+        caught_stealing: stats[:caught_stealing],
+        error: stats[:error]
       }
     end
   end

--- a/app/services/stats/batting_trend_aggregator.rb
+++ b/app/services/stats/batting_trend_aggregator.rb
@@ -122,10 +122,12 @@ module Stats
       sum_sql = SUM_COLUMNS.map { |col| "SUM(COALESCE(batting_averages.#{col}, 0)) AS #{col}" }.join(', ')
       scope = filtered_scope
               .group('game_results.id, match_results.date_and_time')
+      # 同一日時に複数試合があると取得順が非決定的になるため、game_results.id を
+      # 二次キーにして直近 N 試合の取り出しと並び順を安定させる。
       scope = if limit
-                scope.order(Arel.sql('match_results.date_and_time DESC')).limit(limit)
+                scope.order(Arel.sql('match_results.date_and_time DESC, game_results.id DESC')).limit(limit)
               else
-                scope.order(Arel.sql('match_results.date_and_time ASC'))
+                scope.order(Arel.sql('match_results.date_and_time ASC, game_results.id ASC'))
               end
       rows = scope.pluck(Arel.sql("match_results.date_and_time, #{sum_sql}"))
       rows.reverse! if limit

--- a/app/services/stats/count_situation_aggregator.rb
+++ b/app/services/stats/count_situation_aggregator.rb
@@ -4,9 +4,10 @@ module Stats
   # カウント状況別（初球 / 有利カウント / 追い込み）の打席集計サービス。
   #
   # plate_appearances の first_pitch_swing / final_balls / final_strikes は
-  # 新仕様で記録されたカラムなので、これらが NULL の旧 PA は集計対象外。
-  # filtered_scope 段階で `final_strikes IS NOT NULL` を入れることで、
-  # 新仕様の PA だけを 3 条件で抽出する。
+  # 新仕様で記録されたカラム。集計対象は「BSO カウントを記録した PA」または
+  # 「初球で結果が決まった PA（first_pitch_swing = TRUE）」とする。初球は定義上
+  # カウントが 0-0 で自明なため、記録側で BSO カウントを入力していなくても対象に含める。
+  # 有利 / 追い込みは final_* を参照する FILTER 側で NULL が自然に除外される。
   #
   # 母数 0 のときは batting_average を 0.0 で返し、クライアント側で
   # 「対象データなし」UI に分岐させる。
@@ -86,12 +87,14 @@ module Stats
     def filtered_scope
       @filtered_scope ||= begin
         # is_new_format には index があるため、先頭でこれを当てて新仕様 PA に
-        # 絞ってから final_strikes / plate_result_id NULL の防御を重ねる。
-        # final_strikes / final_balls / first_pitch_swing 自体には index が
-        # 無く、データ量が増えるとフルスキャンになる懸念があるための前段。
+        # 絞ってから対象条件を重ねる。final_strikes / first_pitch_swing 自体には
+        # index が無く、データ量が増えるとフルスキャンになる懸念があるための前段。
+        # 「カウント記録あり OR 初球で結果が決まった」を対象とし、初球で BSO 未入力の
+        # PA を取りこぼさない。
         scope = PlateAppearance.joins(game_result: :match_result)
                                .where(user_id: @user_id, is_new_format: true)
-                               .where.not(final_strikes: nil)
+                               .where('plate_appearances.final_strikes IS NOT NULL OR ' \
+                                      'plate_appearances.first_pitch_swing = TRUE')
                                .where.not(plate_result_id: nil)
         scope = apply_year_filter(scope)
         scope = apply_match_type_filter(scope)

--- a/app/services/stats/pitcher_attribute_summary_aggregator.rb
+++ b/app/services/stats/pitcher_attribute_summary_aggregator.rb
@@ -17,6 +17,8 @@ module Stats
   # マスタが nil の投手は key: nil の「未設定」バケットに集約し、
   # mobile 側で末尾に表示する。
   class PitcherAttributeSummaryAggregator # rubocop:disable Metrics/ClassLength
+    include Concerns::FilterableConcern
+
     Recalc = ::Stats::BattingAverageRecalculator
     HIT_RESULT_IDS = Recalc::HIT_RESULT_IDS
     TOTAL_BASES_BY_RESULT_ID = {
@@ -241,34 +243,6 @@ module Stats
         scope = apply_season_filter(scope)
         apply_tournament_filter(scope)
       end
-    end
-
-    def apply_year_filter(scope)
-      return scope if @year.blank? || @year.to_s == '通算'
-
-      yr = @year.to_i
-      range_start = Time.zone.local(yr, 1, 1)
-      range_end = Time.zone.local(yr + 1, 1, 1)
-      scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
-                  range_start, range_end)
-    end
-
-    def apply_match_type_filter(scope)
-      return scope if @match_type.blank? || @match_type == '全て'
-
-      scope.where(match_results: { match_type: @match_type })
-    end
-
-    def apply_season_filter(scope)
-      return scope if @season_id.blank?
-
-      scope.where(game_results: { season_id: @season_id })
-    end
-
-    def apply_tournament_filter(scope)
-      return scope if @tournament_id.blank?
-
-      scope.where(match_results: { tournament_id: @tournament_id })
     end
   end
 end

--- a/db/migrate/20260625120000_add_index_to_plate_appearances_plate_result_id.rb
+++ b/db/migrate/20260625120000_add_index_to_plate_appearances_plate_result_id.rb
@@ -1,0 +1,8 @@
+class AddIndexToPlateAppearancesPlateResultId < ActiveRecord::Migration[7.1]
+  def change
+    # 新仕様の各 Aggregator (HitDirectionAggregator / PlateAppearanceBreakdownService 等) が
+    # plate_result_id を WHERE / GROUP BY 条件に使うが、他の FK 列と違いインデックスが無く
+    # user_id 絞り込み後に seqscan になる。データ増加で顕在化する前に索引を張る。
+    add_index :plate_appearances, :plate_result_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_17_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_25_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -399,6 +399,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_17_000000) do
     t.index ["is_new_format"], name: "index_plate_appearances_on_is_new_format"
     t.index ["pitch_type_id"], name: "index_plate_appearances_on_pitch_type_id"
     t.index ["pitcher_id"], name: "index_plate_appearances_on_pitcher_id"
+    t.index ["plate_result_id"], name: "index_plate_appearances_on_plate_result_id"
     t.index ["swing_type"], name: "index_plate_appearances_on_swing_type", where: "(swing_type IS NOT NULL)"
     t.index ["timing_id"], name: "index_plate_appearances_on_timing_id"
     t.index ["user_id"], name: "index_plate_appearances_on_user_id"

--- a/spec/requests/api/v2/dashboards_spec.rb
+++ b/spec/requests/api/v2/dashboards_spec.rb
@@ -269,6 +269,16 @@ RSpec.describe 'Api::V2::Dashboards', type: :request do
         expect(json['aggregate']['hit']).to eq(3)
       end
     end
+
+    context 'when target user is private and viewer is not a follower' do
+      let(:private_user) { create(:user, is_private: true) }
+
+      it 'returns 403' do
+        get '/api/v2/dashboard/batting_stats', params: { user_id: private_user.id },
+                                               headers: auth_headers_for(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
   end
 
   describe 'GET /api/v2/dashboard/pitching_stats' do
@@ -297,6 +307,16 @@ RSpec.describe 'Api::V2::Dashboards', type: :request do
         expect(json['calculated']).to include('era', 'whip')
         expect(json).not_to have_key('recent_game_results')
         expect(json).not_to have_key('batting_stats')
+      end
+    end
+
+    context 'when target user is private and viewer is not a follower' do
+      let(:private_user) { create(:user, is_private: true) }
+
+      it 'returns 403' do
+        get '/api/v2/dashboard/pitching_stats', params: { user_id: private_user.id },
+                                                headers: auth_headers_for(user)
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end

--- a/spec/services/stats/count_situation_aggregator_spec.rb
+++ b/spec/services/stats/count_situation_aggregator_spec.rb
@@ -62,6 +62,32 @@ RSpec.describe Stats::CountSituationAggregator, type: :service do
       end
     end
 
+    context 'with first_pitch PAs that have no BSO count recorded' do
+      before do
+        # 初球で結果が決まった打席はカウントが 0-0 で自明なため、記録側で
+        # BSO カウント（final_balls / final_strikes）を入力しないのが正しい。
+        # それでも first_pitch に集計され、対象打席数にも含まれる。
+        create_pa(plate_result_id: single_result_id, first_pitch_swing: true,
+                  final_balls: nil, final_strikes: nil)
+        create_pa(plate_result_id: strikeout_result_id, first_pitch_swing: true,
+                  final_balls: nil, final_strikes: nil, batter_box_number: 2)
+      end
+
+      it 'includes first_pitch PAs even when final_strikes is NULL' do
+        result = described_class.new(user_id: user.id).call
+
+        aggregate_failures do
+          expect(result[:total_target_pa]).to eq(2)
+          expect(result[:first_pitch][:at_bats]).to eq(2)
+          expect(result[:first_pitch][:hits]).to eq(1)
+          expect(result[:first_pitch][:batting_average]).to eq((1.0 / 2).round(3))
+          # カウント未入力なので有利 / 追い込みには計上されない
+          expect(result[:favorable_count][:at_bats]).to eq(0)
+          expect(result[:pinch_count][:at_bats]).to eq(0)
+        end
+      end
+    end
+
     context 'with favorable_count PAs' do
       before do
         # 有利カウント (final_balls > final_strikes): ヒット


### PR DESCRIPTION
## 概要

PR #246（リリースブランチ `release/game-stats-202605`）のコードレビュー指摘のうち、対応が必要と判断したものに対応する。base は当該リリースブランチ。

## 対応した指摘

| 重要度 | 指摘 | 対応 |
| ---- | ---- | ---- |
| 🔴 Critical | DashboardsController の `batting_stats` / `pitching_stats` で非公開アカウントの成績が漏洩 | `render_forbidden_if_private!` で 403 ガードを追加（403 テストも追加） |
| 🟠 Major | `plate_appearances.plate_result_id` にインデックスが無く seqscan | 索引追加マイグレーションを追加 |
| 🟠 Major | BattingAverageRecalculator が 1 回の集計で ~16 クエリ発行 | COUNT(*) FILTER と SUM をまとめた 1 クエリに集約（LEFT JOIN で従来と等価。golden master / 不変性テストで検証） |
| 🟡 Minor | BattingTrendAggregator が同一日時の試合で取得順が非決定的 | `game_results.id` を二次ソートキーに追加 |
| 🟡 Minor | PitcherAttributeSummaryAggregator が FilterableConcern 未 include | Concern に統一し重複定義を削除 |

## 対応を見送った指摘

- 🟡 **safe_divide の重複定義の集約**: 5 クラスで `to_i.zero?` と `zero?` の実装差があり、まとめるには慎重な確認が必要。現状の集計結果は常に整数で実害が無いため別タスク。
- 🟡 **BattingTrendAggregator の同日 2 試合キー重複**: チャートライブラリ側の仕様確認が必要なためフロントと要相談。

## 対応不要と判断した指摘

- 🟡 **GameSummaryService#recent_form の INNER JOIN**: `match_results.opponent_team_id` は `null: false` + FK 制約付きで NULL になり得ないため、INNER JOIN で試合が除外される懸念は発生しない。

## テスト

- `spec/services/stats/`（139 examples）, `spec/qa/aggregation_golden_spec.rb` / `batting_average_invariance_spec.rb`（9 examples）, `spec/requests/api/v2/dashboards_spec.rb` / `stats_spec.rb` すべて 0 failures
- RuboCop offense なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
