### PR TITLE
Update: existing_search のレスポンスに stadium_name を追加 (#425)

### DIFF
--- a/app/controllers/api/v1/match_results_controller.rb
+++ b/app/controllers/api/v1/match_results_controller.rb
@@ -73,11 +73,13 @@ module Api
       end
 
       def existing_search
-        @match_result = MatchResult.find_by(game_result_id: params[:game_result_id], user_id: params[:user_id])
+        @match_result = MatchResult.includes(:stadium).find_by(game_result_id: params[:game_result_id], user_id: params[:user_id])
         if @match_result
           game_result = GameResult.includes(:season).find_by(id: params[:game_result_id])
           season_id = game_result&.season_id
-          render json: @match_result.as_json.merge(season_id:)
+          # 編集画面が球場名表示のために stadium 一覧を追加取得しなくて済むよう、
+          # stadium_id だけでなく解決済みの stadium_name も返す。
+          render json: @match_result.as_json.merge(season_id:, stadium_name: @match_result.stadium&.name)
         else
           render json: { message: 'No matching record found' }, status: :not_found
         end

--- a/spec/requests/api/v1/match_results_spec.rb
+++ b/spec/requests/api/v1/match_results_spec.rb
@@ -147,6 +147,37 @@ RSpec.describe 'Api::V1::MatchResults', type: :request do
     end
   end
 
+  describe 'GET /api/v1/existing_search' do
+    let(:stadium) { create(:stadium, name: '神宮球場') }
+    let(:match_result) do
+      game_result = create(:game_result, user:)
+      game_result.match_result
+    end
+
+    it 'stadium_id がある場合は stadium_name を含めて返す' do
+      match_result.update!(stadium_id: stadium.id)
+      get '/api/v1/existing_search',
+          params: { game_result_id: match_result.game_result_id, user_id: user.id },
+          headers: auth_headers_for(user)
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json['stadium_id']).to eq(stadium.id)
+      expect(json['stadium_name']).to eq('神宮球場')
+    end
+
+    it 'stadium_id が NULL の場合は stadium_name が nil になる' do
+      match_result.update!(stadium_id: nil)
+      get '/api/v1/existing_search',
+          params: { game_result_id: match_result.game_result_id, user_id: user.id },
+          headers: auth_headers_for(user)
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json['stadium_name']).to be_nil
+    end
+  end
+
   describe 'GET /api/v1/match_results/available_years' do
     # game_result factory が after(:create) で match_result を自動生成するため、
     # game_result を作成 → 自動生成された match_result の date_and_time を更新


### PR DESCRIPTION
## 概要

ippei-shimizu/buzzbase#425 対応の back 側。試合編集画面が球場名表示のために stadium 一覧を追加取得しているのを撤廃できるよう、`existing_search`（試合編集時の既存試合フェッチに使う v1 エンドポイント）のレスポンスに解決済みの `stadium_name` を追加する。

base は stadium 機能を含む `release/game-stats-202605`（stg にはまだ stadium 機能が無いため）。

## 変更内容

- `existing_search` で `MatchResult.includes(:stadium)` により stadium を eager load
- レスポンスに `stadium_name: @match_result.stadium&.name` を追加（stadium 未設定時は `nil`）

## 背景

front の `record/page.tsx` は編集時に `searchStadiums({ per_page: 100 })` を追加で呼び、id から名前を best-effort に引き当てている。`per_page: 100` を超える球場があると名前が見つからずフィールドが空になる。back が `stadium_name` を返せば front の追加リクエストと件数依存フォールバックを撤廃できる。

## テスト

- `existing_search` の stadium_name 返却（stadium あり / NULL）の request spec を追加
- `spec/requests/api/v1/match_results_spec.rb` 34 examples / 0 failures、RuboCop offense なし

## 関連

- Issue: ippei-shimizu/buzzbase#425
- front 側の PR は本 PR デプロイ後にマージする想定

🤖 Generated with [Claude Code](https://claude.com/claude-code)
