### PR TITLE
Fix: Herokuデプロイを Release Phase 化しマイグレーションをリリース前に実行

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,16 +23,14 @@ jobs:
       - name: Build and Push Docker image
         run: |
           docker build -t registry.heroku.com/${{ secrets.HEROKU_APP_NAME }}/web .
+          docker tag registry.heroku.com/${{ secrets.HEROKU_APP_NAME }}/web registry.heroku.com/${{ secrets.HEROKU_APP_NAME }}/release
           docker push registry.heroku.com/${{ secrets.HEROKU_APP_NAME }}/web
+          docker push registry.heroku.com/${{ secrets.HEROKU_APP_NAME }}/release
 
+      # web の公開前に release プロセス（Procfile の `release: rails db:migrate`）が実行される。
+      # マイグレーション失敗時はリリースが中止され、新カラム不在のまま新コードが公開される事故を防ぐ。
       - name: Release to Heroku
         run: |
-          heroku container:release web --app ${{ secrets.HEROKU_APP_NAME }}
-        env:
-          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-
-      - name: Run database migrations
-        run: |
-          heroku run rails db:migrate --app ${{ secrets.HEROKU_APP_NAME }}
+          heroku container:release web release --app ${{ secrets.HEROKU_APP_NAME }}
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}


### PR DESCRIPTION
## 概要

Heroku デプロイで **DB マイグレーションがコードリリースより後に走る逆順**になっており、新カラムを参照する新コードが本番稼働した後にカラムが追加されることで `ActiveModel::UnknownAttributeError` が発生する問題を恒久対応する。

ref: ippei-shimizu/buzzbase#426

## 問題

`.github/workflows/main.yml` の従来の順序:

1. `docker build` / `push`
2. `heroku container:release web`（新コードが本番稼働・web dyno 再起動）
3. `heroku run rails db:migrate`（新カラム追加）

手順 2 で再起動した puma プロセスが、手順 3 のマイグレーション完了**前**に対象モデルへアクセスすると、新カラムを含まないスキーマをメモリにキャッシュし、カラム追加後も保持し続けるため、dyno を再起動するまでエラーが継続する。

実際に v1.1.5 リリース時、`Api::V1::MatchResultsController#create` で `unknown attribute 'stadium_id' for MatchResult` の 500 エラーが発生した（応急処置として dyno を手動再起動して解消済み）。

## 変更内容

**Heroku Release Phase** を有効化し、マイグレーションをリリース前（新 dyno がトラフィックを受ける前）に完了させる。

- ビルドステップで `release` イメージも tag & push
- リリースを `heroku container:release web release` に変更し、web / release 両プロセスをリリース
- 別途の `Run database migrations` ステップを削除（Release Phase に統合）

`Procfile` には既に `release: bundle exec rails db:migrate` が定義済みのため変更不要。Release Phase が失敗するとリリース自体が中止されるため、カラム不在のまま新コードが公開される window が消える。

## 確認手順

- このワークフローの実行は `main` への push 時のみ。stg マージ後、本番リリース（main）時に以下を確認する:
  1. デプロイログで release プロセスとして `rails db:migrate` が web 公開前に実行されている
  2. マイグレーションを含むリリースで `UnknownAttributeError` が発生しない

## スコープ外

- `actions/checkout@v4` の Node.js 20 非推奨警告対応（別途）
