### PR TITLE
Add: 練習記録機能のバックエンド（練習メニュー/量ログ/コンディション/activity_logs）

### DIFF
--- a/app/controllers/api/v2/condition_logs_controller.rb
+++ b/app/controllers/api/v2/condition_logs_controller.rb
@@ -1,0 +1,42 @@
+module Api
+  module V2
+    # コンディションログ（1日1回・upsert）。Pro 限定機能。
+    class ConditionLogsController < Api::V2::ApplicationController
+      before_action :authenticate_api_v1_user!
+      before_action :require_pro_entitlement!
+
+      # GET /api/v2/condition_logs/by_date?date=YYYY-MM-DD
+      def by_date
+        log = current_api_v1_user.condition_logs.find_by(logged_on: params[:date])
+        return render json: nil, status: :ok if log.nil?
+
+        render json: log, serializer: ::V2::ConditionLogSerializer, status: :ok
+      end
+
+      # POST /api/v2/condition_logs/upsert
+      def upsert
+        log = current_api_v1_user.condition_logs.find_or_initialize_by(logged_on: condition_log_params[:logged_on])
+        if log.update(condition_log_params)
+          render json: log, serializer: ::V2::ConditionLogSerializer, status: :ok
+        else
+          render json: { errors: log.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def require_pro_entitlement!
+        return if current_api_v1_user.has_entitlement?('detailed_condition_log')
+
+        render json: { error: 'コンディション記録は Pro プラン限定です' }, status: :forbidden
+      end
+
+      def condition_log_params
+        params.require(:condition_log).permit(
+          :logged_on, :fatigue_level, :physical_level, :sleep_hours, :mood, :memo,
+          injuries: %i[part memo]
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/practice_logs_controller.rb
+++ b/app/controllers/api/v2/practice_logs_controller.rb
@@ -1,0 +1,45 @@
+module Api
+  module V2
+    # 練習量記録（量ログ）の作成・取得・削除。
+    # 量記録・閲覧は無料でも全期間・全件可（Pro 差別化はメニュー数・コンディション側）。
+    class PracticeLogsController < Api::V2::ApplicationController
+      before_action :authenticate_api_v1_user!
+
+      def index
+        logs = current_api_v1_user.practice_logs.includes(:practice_menu)
+        logs = logs.where(logged_on: params[:from]..) if params[:from].present?
+        logs = logs.where(logged_on: ..params[:to]) if params[:to].present?
+        logs = logs.order(logged_on: :desc, created_at: :desc)
+        render json: logs, each_serializer: ::V2::PracticeLogSerializer, status: :ok
+      end
+
+      def create
+        menu = current_api_v1_user.practice_menus.find(practice_log_params[:practice_menu_id])
+        log = current_api_v1_user.practice_logs.build(
+          practice_log_params.except(:practice_menu_id).merge(
+            practice_menu: menu,
+            menu_name: menu.name,
+            unit_label: menu.unit_label
+          )
+        )
+        if log.save
+          render json: log, serializer: ::V2::PracticeLogSerializer, status: :created
+        else
+          render json: { errors: log.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        log = current_api_v1_user.practice_logs.find(params[:id])
+        log.destroy
+        render json: { message: '削除しました' }, status: :ok
+      end
+
+      private
+
+      def practice_log_params
+        params.require(:practice_log).permit(:practice_menu_id, :logged_on, :amount, :memo)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/practice_menus_controller.rb
+++ b/app/controllers/api/v2/practice_menus_controller.rb
@@ -1,0 +1,50 @@
+module Api
+  module V2
+    # 練習メニュー マスターの CRUD。
+    # 無料プランは archived 以外 5 件まで（PlanLimits#can_create_practice_menu?）。
+    class PracticeMenusController < Api::V2::ApplicationController
+      before_action :authenticate_api_v1_user!
+      before_action :load_practice_menu, only: %i[update destroy]
+
+      def index
+        menus = current_api_v1_user.practice_menus.active.ordered
+        render json: menus, each_serializer: ::V2::PracticeMenuSerializer, status: :ok
+      end
+
+      def create
+        return render json: { error: 'Pro プランで練習メニューを無制限に登録できます' }, status: :forbidden unless current_api_v1_user.can_create_practice_menu?
+
+        menu = current_api_v1_user.practice_menus.build(practice_menu_params)
+        if menu.save
+          render json: menu, serializer: ::V2::PracticeMenuSerializer, status: :created
+        else
+          render json: { errors: menu.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def update
+        if @practice_menu.update(practice_menu_params)
+          render json: @practice_menu, serializer: ::V2::PracticeMenuSerializer, status: :ok
+        else
+          render json: { errors: @practice_menu.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        # 既存ログの menu_name はスナップショット済みのため、論理削除（archived）で履歴を保つ。
+        @practice_menu.update!(archived: true)
+        render json: { message: '削除しました' }, status: :ok
+      end
+
+      private
+
+      def load_practice_menu
+        @practice_menu = current_api_v1_user.practice_menus.find(params[:id])
+      end
+
+      def practice_menu_params
+        params.require(:practice_menu).permit(:name, :category, :unit, :unit_label, :default_value, :is_favorite, :sort_order)
+      end
+    end
+  end
+end

--- a/app/models/activity_log.rb
+++ b/app/models/activity_log.rb
@@ -1,0 +1,9 @@
+class ActivityLog < ApplicationRecord
+  belongs_to :user
+
+  validates :activity_date, presence: true
+  validates :user_id, uniqueness: { scope: :activity_date }
+
+  scope :in_range, ->(from, to) { where(activity_date: from..to) }
+  scope :recent_days, ->(days) { where(activity_date: (Time.find_zone('Asia/Tokyo').today - (days - 1))..) }
+end

--- a/app/models/concerns/plan_limits.rb
+++ b/app/models/concerns/plan_limits.rb
@@ -5,12 +5,12 @@
 module PlanLimits
   extend ActiveSupport::Concern
 
-  PRACTICE_MENU_FREE_LIMIT = 3
+  PRACTICE_MENU_FREE_LIMIT = 5
   MEDIA_UPLOAD_FREE_LIMIT_PER_MONTH = 3
   SCHEDULE_FREE_LIMIT = 1
   MONTHLY_GOAL_FREE_LIMIT = 1
 
-  # 練習メニューを新規作成できるか。無料は archived 以外3つまで。
+  # 練習メニューを新規作成できるか。無料は archived 以外5つまで。
   # @return [Boolean]
   def can_create_practice_menu?
     return true if has_entitlement?('unlimited_practice_menus')
@@ -52,7 +52,7 @@ module PlanLimits
 
   # 各 Pro 機能 issue で実関連に差し替える。関連未実装のため現状は 0 を返す。
   def practice_menus_count_for_business_rules
-    0
+    practice_menus.where(archived: false).count
   end
 
   def media_attachments_count_this_month

--- a/app/models/condition_log.rb
+++ b/app/models/condition_log.rb
@@ -1,0 +1,14 @@
+class ConditionLog < ApplicationRecord
+  belongs_to :user
+
+  LEVEL_RANGE = (1..4)
+
+  validates :logged_on, presence: true
+  validates :user_id, uniqueness: { scope: :logged_on }
+  validates :fatigue_level, inclusion: { in: LEVEL_RANGE }, allow_nil: true
+  validates :physical_level, inclusion: { in: LEVEL_RANGE }, allow_nil: true
+  validates :sleep_hours, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 24 }, allow_nil: true
+
+  # コンディションログは草・Streak に影響させない（休養日でも記録するため）。
+  # よって activity_logs の再計算フックは持たない。
+end

--- a/app/models/practice_log.rb
+++ b/app/models/practice_log.rb
@@ -1,0 +1,20 @@
+class PracticeLog < ApplicationRecord
+  belongs_to :user
+  belongs_to :practice_menu, optional: true
+
+  SOURCES = %w[manual shadow_swing].freeze
+
+  validates :logged_on, presence: true
+  validates :menu_name, presence: true
+  validates :source, presence: true, inclusion: { in: SOURCES }
+  validates :amount, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+
+  # 練習ログの変化で当日の活動集計（草・Streak）を再計算する。
+  after_commit :recalculate_activity, on: %i[create update destroy]
+
+  private
+
+  def recalculate_activity
+    Activities::DailyActivityRecalculator.new(user_id:, date: logged_on).call
+  end
+end

--- a/app/models/practice_menu.rb
+++ b/app/models/practice_menu.rb
@@ -1,0 +1,16 @@
+class PracticeMenu < ApplicationRecord
+  belongs_to :user
+  has_many :practice_logs, dependent: :nullify
+
+  CATEGORIES = %w[batting pitching defense baserunning training other].freeze
+  UNITS = %w[count minutes distance].freeze
+
+  validates :name, presence: true, length: { maximum: 50 }
+  validates :category, presence: true, inclusion: { in: CATEGORIES }
+  validates :unit, presence: true, inclusion: { in: UNITS }
+  validates :unit_label, length: { maximum: 10 }, allow_nil: true
+
+  scope :active, -> { where(archived: false) }
+  # お気に入り先頭・sort_order 昇順でメニュー一覧を並べる
+  scope :ordered, -> { order(is_favorite: :desc, sort_order: :asc, created_at: :asc) }
+end

--- a/app/models/practice_menu.rb
+++ b/app/models/practice_menu.rb
@@ -2,7 +2,7 @@ class PracticeMenu < ApplicationRecord
   belongs_to :user
   has_many :practice_logs, dependent: :nullify
 
-  CATEGORIES = %w[batting pitching defense baserunning training other].freeze
+  CATEGORIES = %w[batting pitching defense baserunning training care other].freeze
   UNITS = %w[count minutes distance].freeze
 
   validates :name, presence: true, length: { maximum: 50 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,4 @@
-class User < ActiveRecord::Base
+class User < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   include Entitlement
   include PlanLimits
   include SubscriptionCallbacks
@@ -41,6 +41,10 @@ class User < ActiveRecord::Base
   has_many :pitching_results, dependent: :destroy
   has_many :plate_appearances, dependent: :destroy
   has_many :created_pitchers, class_name: 'Pitcher', foreign_key: 'created_by_user_id', dependent: :destroy, inverse_of: :created_by_user
+  has_many :practice_menus, dependent: :destroy
+  has_many :practice_logs, dependent: :destroy
+  has_many :condition_logs, dependent: :destroy
+  has_many :activity_logs, dependent: :destroy
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable

--- a/app/serializers/v2/condition_log_serializer.rb
+++ b/app/serializers/v2/condition_log_serializer.rb
@@ -1,0 +1,5 @@
+module V2
+  class ConditionLogSerializer < ActiveModel::Serializer
+    attributes :id, :logged_on, :fatigue_level, :physical_level, :sleep_hours, :mood, :memo, :injuries
+  end
+end

--- a/app/serializers/v2/practice_log_serializer.rb
+++ b/app/serializers/v2/practice_log_serializer.rb
@@ -1,0 +1,5 @@
+module V2
+  class PracticeLogSerializer < ActiveModel::Serializer
+    attributes :id, :practice_menu_id, :logged_on, :amount, :menu_name, :unit_label, :source, :memo, :created_at
+  end
+end

--- a/app/serializers/v2/practice_menu_serializer.rb
+++ b/app/serializers/v2/practice_menu_serializer.rb
@@ -1,0 +1,5 @@
+module V2
+  class PracticeMenuSerializer < ActiveModel::Serializer
+    attributes :id, :name, :category, :unit, :unit_label, :default_value, :is_favorite, :sort_order
+  end
+end

--- a/app/services/activities/daily_activity_recalculator.rb
+++ b/app/services/activities/daily_activity_recalculator.rb
@@ -1,0 +1,88 @@
+module Activities
+  # 指定ユーザー・日付の activity_logs 行を全再計算する（冪等）。
+  # practice_log（素振り自動生成ログ含む）/ match_result の after_commit から呼ばれ、
+  # 草・Streak の集計基盤となる。コンディションログは集計対象外。
+  #
+  # 集計の前提:
+  # - 日付バケットは JST。practice_log は logged_on（JST 日付）をそのまま使う。
+  # - 素振り本数は source='shadow_swing' の practice_log.amount を集計する
+  #   （ShadowSwingSession テーブルへ依存せず二重計上も避ける）。
+  class DailyActivityRecalculator
+    JST = 'Asia/Tokyo'.freeze
+
+    SWING_L2 = 100
+    SWING_L3 = 300
+    SWING_L4 = 500
+
+    # @param user_id [Integer]
+    # @param date [Date] JST の日付
+    def initialize(user_id:, date:)
+      @user_id = user_id
+      @date = date
+    end
+
+    # @return [ActivityLog, nil] 更新後のレコード。無活動日（強度0）なら削除して nil
+    def call
+      menu_count = practice_menu_count
+      swing_count = total_swing_count
+      game = game_on_day?
+      level = intensity_level(menu_count, swing_count, game)
+
+      activity_log = ActivityLog.find_or_initialize_by(user_id: @user_id, activity_date: @date)
+
+      if level.zero?
+        activity_log.destroy if activity_log.persisted?
+        return nil
+      end
+
+      activity_log.update!(
+        practice_menu_count: menu_count,
+        total_swing_count: swing_count,
+        has_game: game,
+        intensity_level: level
+      )
+      activity_log
+    end
+
+    private
+
+    # その日の練習ログの distinct メニュー数。
+    # メニュー削除済みでも menu_name スナップショットで識別する。
+    def practice_menu_count
+      PracticeLog.where(user_id: @user_id, logged_on: @date)
+                 .distinct
+                 .count(Arel.sql('COALESCE(practice_menu_id::text, menu_name)'))
+    end
+
+    # 素振り由来の練習ログ合計本数。
+    def total_swing_count
+      PracticeLog.where(user_id: @user_id, logged_on: @date, source: 'shadow_swing')
+                 .sum(:amount).to_i
+    end
+
+    # その JST 日に試合（game_result に紐づく match_result）が存在するか。
+    def game_on_day?
+      zone = Time.find_zone(JST)
+      day_start = zone.local(@date.year, @date.month, @date.day)
+      day_end = day_start + 1.day
+      MatchResult.joins(:game_result)
+                 .where(game_results: { user_id: @user_id })
+                 .exists?(date_and_time: day_start...day_end)
+    end
+
+    # 強度 = max(メニュー数レベル, 素振り本数レベル, 試合)。各軸は独立に L0〜L4 へ写像する。
+    def intensity_level(menu_count, swing_count, game)
+      return 4 if game
+
+      [menu_count.clamp(0, 4), swing_level(swing_count)].max
+    end
+
+    def swing_level(swing_count)
+      return 4 if swing_count >= SWING_L4
+      return 3 if swing_count >= SWING_L3
+      return 2 if swing_count >= SWING_L2
+
+      0
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -264,6 +264,15 @@ Rails.application.routes.draw do
       resources :velocity_zones, only: :index
       resources :pitcher_styles, only: :index
       resources :appearance_situations, only: :index
+
+      resources :practice_menus, only: %i[index create update destroy]
+      resources :practice_logs, only: %i[index create destroy]
+      resources :condition_logs, only: [] do
+        collection do
+          get :by_date
+          post :upsert
+        end
+      end
     end
   end
 

--- a/db/migrate/20260627100001_create_practice_menus.rb
+++ b/db/migrate/20260627100001_create_practice_menus.rb
@@ -1,0 +1,18 @@
+class CreatePracticeMenus < ActiveRecord::Migration[7.1]
+  def change
+    create_table :practice_menus do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :name, null: false
+      t.string :category, null: false              # batting/pitching/defense/baserunning/training/other
+      t.string :unit, null: false                  # count/minutes/distance
+      t.string :unit_label                         # 本/球/回/分/km/m 等の表示ラベル
+      t.decimal :default_value, precision: 10, scale: 2
+      t.boolean :is_favorite, null: false, default: false
+      t.integer :sort_order, null: false, default: 0
+      t.boolean :archived, null: false, default: false
+      t.timestamps
+    end
+
+    add_index :practice_menus, %i[user_id archived]
+  end
+end

--- a/db/migrate/20260627100002_create_practice_logs.rb
+++ b/db/migrate/20260627100002_create_practice_logs.rb
@@ -1,0 +1,17 @@
+class CreatePracticeLogs < ActiveRecord::Migration[7.1]
+  def change
+    create_table :practice_logs do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :practice_menu, null: true, foreign_key: { on_delete: :nullify }
+      t.date :logged_on, null: false
+      t.decimal :amount, precision: 10, scale: 2
+      t.string :menu_name, null: false            # メニュー名のスナップショット（改名・削除耐性）
+      t.string :unit_label                        # 単位ラベルのスナップショット
+      t.string :source, null: false, default: 'manual' # manual/shadow_swing
+      t.text :memo
+      t.timestamps
+    end
+
+    add_index :practice_logs, %i[user_id logged_on]
+  end
+end

--- a/db/migrate/20260627100003_create_condition_logs.rb
+++ b/db/migrate/20260627100003_create_condition_logs.rb
@@ -1,0 +1,17 @@
+class CreateConditionLogs < ActiveRecord::Migration[7.1]
+  def change
+    create_table :condition_logs do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date :logged_on, null: false
+      t.integer :fatigue_level                    # 1-4（悪い→良い）
+      t.integer :physical_level                   # 1-4
+      t.decimal :sleep_hours, precision: 4, scale: 1
+      t.string :mood                              # 好調/普通/不調 等のチップ値
+      t.text :memo
+      t.jsonb :injuries, null: false, default: [] # [{part, memo}]
+      t.timestamps
+    end
+
+    add_index :condition_logs, %i[user_id logged_on], unique: true
+  end
+end

--- a/db/migrate/20260627100004_create_activity_logs.rb
+++ b/db/migrate/20260627100004_create_activity_logs.rb
@@ -1,0 +1,15 @@
+class CreateActivityLogs < ActiveRecord::Migration[7.1]
+  def change
+    create_table :activity_logs do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date :activity_date, null: false
+      t.integer :practice_menu_count, null: false, default: 0  # distinct メニュー数
+      t.integer :total_swing_count, null: false, default: 0
+      t.boolean :has_game, null: false, default: false
+      t.integer :intensity_level, null: false, default: 0      # 0-4
+      t.timestamps
+    end
+
+    add_index :activity_logs, %i[user_id activity_date], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_25_130000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_27_100004) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "activity_logs", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.date "activity_date", null: false
+    t.integer "practice_menu_count", default: 0, null: false
+    t.integer "total_swing_count", default: 0, null: false
+    t.boolean "has_game", default: false, null: false
+    t.integer "intensity_level", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "activity_date"], name: "index_activity_logs_on_user_id_and_activity_date", unique: true
+    t.index ["user_id"], name: "index_activity_logs_on_user_id"
+  end
 
   create_table "admin_daily_statistics", force: :cascade do |t|
     t.date "date", null: false
@@ -171,6 +184,21 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_25_130000) do
     t.datetime "updated_at", null: false
     t.index ["subscription_id"], name: "index_cancellation_feedbacks_on_subscription_id"
     t.index ["user_id"], name: "index_cancellation_feedbacks_on_user_id"
+  end
+
+  create_table "condition_logs", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.date "logged_on", null: false
+    t.integer "fatigue_level"
+    t.integer "physical_level"
+    t.decimal "sleep_hours", precision: 4, scale: 1
+    t.string "mood"
+    t.text "memo"
+    t.jsonb "injuries", default: [], null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "logged_on"], name: "index_condition_logs_on_user_id_and_logged_on", unique: true
+    t.index ["user_id"], name: "index_condition_logs_on_user_id"
   end
 
   create_table "contact_qualities", force: :cascade do |t|
@@ -449,6 +477,38 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_25_130000) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "practice_logs", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "practice_menu_id"
+    t.date "logged_on", null: false
+    t.decimal "amount", precision: 10, scale: 2
+    t.string "menu_name", null: false
+    t.string "unit_label"
+    t.string "source", default: "manual", null: false
+    t.text "memo"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["practice_menu_id"], name: "index_practice_logs_on_practice_menu_id"
+    t.index ["user_id", "logged_on"], name: "index_practice_logs_on_user_id_and_logged_on"
+    t.index ["user_id"], name: "index_practice_logs_on_user_id"
+  end
+
+  create_table "practice_menus", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name", null: false
+    t.string "category", null: false
+    t.string "unit", null: false
+    t.string "unit_label"
+    t.decimal "default_value", precision: 10, scale: 2
+    t.boolean "is_favorite", default: false, null: false
+    t.integer "sort_order", default: 0, null: false
+    t.boolean "archived", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "archived"], name: "index_practice_menus_on_user_id_and_archived"
+    t.index ["user_id"], name: "index_practice_menus_on_user_id"
+  end
+
   create_table "prefectures", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -599,6 +659,18 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_25_130000) do
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
+  create_table "stadiums", force: :cascade do |t|
+    t.string "name", null: false
+    t.bigint "prefecture_id"
+    t.bigint "created_by_user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["created_by_user_id"], name: "index_stadiums_on_created_by_user_id"
+    t.index ["name", "prefecture_id"], name: "index_stadiums_on_name_prefecture_id_not_null", unique: true, where: "(prefecture_id IS NOT NULL)"
+    t.index ["name"], name: "index_stadiums_on_name"
+    t.index ["prefecture_id"], name: "index_stadiums_on_prefecture_id"
+  end
+
   create_table "subscriptions", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "status", default: "free", null: false
@@ -625,18 +697,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_25_130000) do
     t.index ["stripe_customer_id"], name: "index_subscriptions_on_stripe_customer_id", unique: true, where: "(stripe_customer_id IS NOT NULL)"
     t.index ["stripe_subscription_id"], name: "index_subscriptions_on_stripe_subscription_id", unique: true, where: "(stripe_subscription_id IS NOT NULL)"
     t.index ["user_id"], name: "index_subscriptions_on_user_id", unique: true
-  end
-
-  create_table "stadiums", force: :cascade do |t|
-    t.string "name", null: false
-    t.bigint "prefecture_id"
-    t.bigint "created_by_user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["created_by_user_id"], name: "index_stadiums_on_created_by_user_id"
-    t.index ["name", "prefecture_id"], name: "index_stadiums_on_name_prefecture_id_not_null", unique: true, where: "(prefecture_id IS NOT NULL)"
-    t.index ["name"], name: "index_stadiums_on_name"
-    t.index ["prefecture_id"], name: "index_stadiums_on_prefecture_id"
   end
 
   create_table "teams", force: :cascade do |t|
@@ -773,11 +833,13 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_25_130000) do
     t.index ["status"], name: "index_webhook_events_on_status"
   end
 
+  add_foreign_key "activity_logs", "users"
   add_foreign_key "admin_refresh_tokens", "admin_users"
   add_foreign_key "baseball_notes", "users"
   add_foreign_key "batting_averages", "users"
   add_foreign_key "cancellation_feedbacks", "subscriptions", on_delete: :nullify
   add_foreign_key "cancellation_feedbacks", "users"
+  add_foreign_key "condition_logs", "users"
   add_foreign_key "device_tokens", "users"
   add_foreign_key "game_results", "batting_averages"
   add_foreign_key "game_results", "match_results", on_delete: :cascade
@@ -811,6 +873,9 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_25_130000) do
   add_foreign_key "plate_appearances", "pitchers"
   add_foreign_key "plate_appearances", "timings"
   add_foreign_key "plate_appearances", "users"
+  add_foreign_key "practice_logs", "practice_menus", on_delete: :nullify
+  add_foreign_key "practice_logs", "users"
+  add_foreign_key "practice_menus", "users"
   add_foreign_key "seasons", "users"
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/spec/factories/activity_logs.rb
+++ b/spec/factories/activity_logs.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :activity_log do
+    user
+    activity_date { Time.find_zone('Asia/Tokyo').today }
+    practice_menu_count { 1 }
+    total_swing_count { 0 }
+    has_game { false }
+    intensity_level { 1 }
+  end
+end

--- a/spec/factories/condition_logs.rb
+++ b/spec/factories/condition_logs.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :condition_log do
+    user
+    logged_on { Time.find_zone('Asia/Tokyo').today }
+    fatigue_level { 3 }
+    physical_level { 3 }
+    sleep_hours { 7.0 }
+    mood { '好調' }
+    injuries { [] }
+  end
+end

--- a/spec/factories/practice_logs.rb
+++ b/spec/factories/practice_logs.rb
@@ -1,0 +1,19 @@
+FactoryBot.define do
+  factory :practice_log do
+    user
+    practice_menu { association :practice_menu, user: }
+    logged_on { Time.find_zone('Asia/Tokyo').today }
+    amount { 100 }
+    menu_name { practice_menu&.name || 'メニュー' }
+    unit_label { '本' }
+    source { 'manual' }
+
+    # 素振りカウンターが完了時に自動生成するログ。
+    trait :shadow_swing do
+      practice_menu { nil }
+      menu_name { '素振り' }
+      unit_label { '本' }
+      source { 'shadow_swing' }
+    end
+  end
+end

--- a/spec/factories/practice_menus.rb
+++ b/spec/factories/practice_menus.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :practice_menu do
+    user
+    sequence(:name) { |n| "練習メニュー#{n}" }
+    category { 'batting' }
+    unit { 'count' }
+    unit_label { '本' }
+    default_value { 200 }
+    is_favorite { false }
+    sort_order { 0 }
+    archived { false }
+  end
+end

--- a/spec/models/practice_log_spec.rb
+++ b/spec/models/practice_log_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe PracticeLog, type: :model do
+  let(:user) { create(:user) }
+  let(:today) { Time.find_zone('Asia/Tokyo').today }
+
+  describe 'バリデーション' do
+    it 'menu_name 必須' do
+      log = build(:practice_log, user:, menu_name: nil)
+      expect(log).not_to be_valid
+    end
+
+    it 'source は許可値のみ' do
+      log = build(:practice_log, user:, source: 'invalid')
+      expect(log).not_to be_valid
+    end
+  end
+
+  describe 'activity_logs との連動' do
+    it '作成すると当日の activity_log が再計算される' do
+      expect do
+        create(:practice_log, user:, logged_on: today)
+      end.to change { ActivityLog.where(user:, activity_date: today).count }.from(0).to(1)
+    end
+
+    it '削除すると activity_log も再計算される（活動0なら削除）' do
+      log = create(:practice_log, user:, logged_on: today)
+      expect do
+        log.destroy
+      end.to change { ActivityLog.where(user:, activity_date: today).count }.from(1).to(0)
+    end
+  end
+end

--- a/spec/requests/api/v2/condition_logs_spec.rb
+++ b/spec/requests/api/v2/condition_logs_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::ConditionLogs', type: :request do
+  let(:user) { create(:user) }
+  let(:today) { Time.find_zone('Asia/Tokyo').today }
+
+  def make_pro(target)
+    target.subscription.update!(status: 'active', expires_at: 1.month.from_now)
+  end
+
+  describe 'POST /api/v2/condition_logs/upsert' do
+    let(:params) do
+      { condition_log: { logged_on: today, fatigue_level: 3, physical_level: 4, sleep_hours: 7.5, mood: '好調',
+                         injuries: [{ part: '右肩', memo: '軽い張り' }] } }
+    end
+
+    context '無料ユーザー' do
+      it '403（Pro 限定）' do
+        post '/api/v2/condition_logs/upsert', params:, headers: auth_headers_for(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'Pro ユーザー' do
+      before { make_pro(user) }
+
+      it '作成できる' do
+        post '/api/v2/condition_logs/upsert', params:, headers: auth_headers_for(user)
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['mood']).to eq('好調')
+      end
+
+      it '同日は upsert（更新）になる' do
+        create(:condition_log, user:, logged_on: today, mood: '不調')
+        expect do
+          post '/api/v2/condition_logs/upsert', params:, headers: auth_headers_for(user)
+        end.not_to(change { user.condition_logs.count })
+        expect(user.condition_logs.find_by(logged_on: today).mood).to eq('好調')
+      end
+    end
+  end
+
+  describe 'GET /api/v2/condition_logs/by_date' do
+    before { make_pro(user) }
+
+    it '当日の記録を返す' do
+      create(:condition_log, user:, logged_on: today, mood: '普通')
+      get '/api/v2/condition_logs/by_date', params: { date: today.to_s }, headers: auth_headers_for(user)
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['mood']).to eq('普通')
+    end
+  end
+end

--- a/spec/requests/api/v2/practice_logs_spec.rb
+++ b/spec/requests/api/v2/practice_logs_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::PracticeLogs', type: :request do
+  let(:user) { create(:user) }
+  let(:today) { Time.find_zone('Asia/Tokyo').today }
+  let!(:menu) { create(:practice_menu, user:, name: '素振り', unit_label: '本') }
+
+  describe 'POST /api/v2/practice_logs' do
+    let(:params) { { practice_log: { practice_menu_id: menu.id, logged_on: today, amount: 200, memo: '外角重点' } } }
+
+    context '未認証' do
+      it '401' do
+        post '/api/v2/practice_logs', params: { practice_log: { practice_menu_id: menu.id, logged_on: today, amount: 1 } }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    it 'メニュー名・単位ラベルをスナップショットして作成する' do
+      post '/api/v2/practice_logs', params:, headers: auth_headers_for(user)
+      expect(response).to have_http_status(:created)
+      body = response.parsed_body
+      expect(body['menu_name']).to eq('素振り')
+      expect(body['unit_label']).to eq('本')
+      expect(body['amount'].to_f).to eq(200.0)
+    end
+
+    it '作成で当日の activity_log が再計算される' do
+      expect do
+        post '/api/v2/practice_logs', params:, headers: auth_headers_for(user)
+      end.to change { user.activity_logs.where(activity_date: today).count }.from(0).to(1)
+    end
+  end
+
+  describe 'GET /api/v2/practice_logs' do
+    let!(:log_today) { create(:practice_log, user:, practice_menu: menu, logged_on: today) }
+    let!(:log_old) { create(:practice_log, user:, practice_menu: menu, logged_on: today - 40) }
+
+    it 'from で期間絞り込みできる（無料でも全期間取得可）' do
+      get '/api/v2/practice_logs', params: { from: (today - 7).to_s }, headers: auth_headers_for(user)
+      expect(response).to have_http_status(:ok)
+      ids = response.parsed_body.pluck('id')
+      expect(ids).to include(log_today.id)
+      expect(ids).not_to include(log_old.id)
+    end
+  end
+
+  describe 'DELETE /api/v2/practice_logs/:id' do
+    let!(:log) { create(:practice_log, user:, practice_menu: menu, logged_on: today) }
+
+    it '削除できる' do
+      delete "/api/v2/practice_logs/#{log.id}", headers: auth_headers_for(user)
+      expect(response).to have_http_status(:ok)
+      expect(PracticeLog.exists?(log.id)).to be(false)
+    end
+  end
+end

--- a/spec/requests/api/v2/practice_menus_spec.rb
+++ b/spec/requests/api/v2/practice_menus_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::PracticeMenus', type: :request do
+  let(:user) { create(:user) }
+
+  def make_pro(target)
+    target.subscription.update!(status: 'active', expires_at: 1.month.from_now)
+  end
+
+  describe 'GET /api/v2/practice_menus' do
+    context '未認証' do
+      it '401' do
+        get '/api/v2/practice_menus'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '認証済み' do
+      before do
+        create(:practice_menu, user:, name: '素振り')
+        create(:practice_menu, user:, name: '削除済み', archived: true)
+      end
+
+      it 'archived を除いた自分のメニューを返す' do
+        get '/api/v2/practice_menus', headers: auth_headers_for(user)
+        expect(response).to have_http_status(:ok)
+        names = response.parsed_body.pluck('name')
+        expect(names).to include('素振り')
+        expect(names).not_to include('削除済み')
+      end
+    end
+  end
+
+  describe 'POST /api/v2/practice_menus' do
+    let(:params) do
+      { practice_menu: { name: 'ティー', category: 'batting', unit: 'count', unit_label: '球', default_value: 150 } }
+    end
+
+    it '作成できる' do
+      post '/api/v2/practice_menus', params:, headers: auth_headers_for(user)
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body['name']).to eq('ティー')
+    end
+
+    context '無料ユーザーが上限(5)を超える' do
+      before { create_list(:practice_menu, 5, user:) }
+
+      it '403 を返す' do
+        post '/api/v2/practice_menus', params:, headers: auth_headers_for(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'Pro ユーザーは上限を超えて作成できる' do
+      before do
+        make_pro(user)
+        create_list(:practice_menu, 5, user:)
+      end
+
+      it '201' do
+        post '/api/v2/practice_menus', params:, headers: auth_headers_for(user)
+        expect(response).to have_http_status(:created)
+      end
+    end
+  end
+
+  describe 'DELETE /api/v2/practice_menus/:id' do
+    let!(:menu) { create(:practice_menu, user:) }
+
+    it '論理削除（archived）する' do
+      delete "/api/v2/practice_menus/#{menu.id}", headers: auth_headers_for(user)
+      expect(response).to have_http_status(:ok)
+      expect(menu.reload.archived).to be(true)
+    end
+  end
+end

--- a/spec/services/activities/daily_activity_recalculator_spec.rb
+++ b/spec/services/activities/daily_activity_recalculator_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe Activities::DailyActivityRecalculator do
+  let(:user) { create(:user) }
+  let(:today) { Time.find_zone('Asia/Tokyo').today }
+
+  def recalc
+    described_class.new(user_id: user.id, date: today).call
+  end
+
+  describe '#call' do
+    context '練習も試合も無い日' do
+      it 'activity_log を作らず nil を返す' do
+        expect(recalc).to be_nil
+        expect(ActivityLog.where(user:, activity_date: today)).to be_empty
+      end
+    end
+
+    context '1メニューだけ記録した日' do
+      before { create(:practice_log, user:, logged_on: today) }
+
+      it 'intensity_level 1 で作られる' do
+        log = recalc
+        expect(log.practice_menu_count).to eq(1)
+        expect(log.intensity_level).to eq(1)
+      end
+    end
+
+    context '2種のメニューを記録した日' do
+      before do
+        menu_a = create(:practice_menu, user:)
+        menu_b = create(:practice_menu, user:)
+        create(:practice_log, user:, practice_menu: menu_a, logged_on: today)
+        create(:practice_log, user:, practice_menu: menu_b, logged_on: today)
+      end
+
+      it 'intensity_level 2' do
+        expect(recalc.intensity_level).to eq(2)
+      end
+    end
+
+    context '同じメニューを2回記録した日' do
+      before do
+        menu = create(:practice_menu, user:)
+        create(:practice_log, user:, practice_menu: menu, logged_on: today)
+        create(:practice_log, user:, practice_menu: menu, logged_on: today)
+      end
+
+      it 'distinct メニュー数は1なので intensity_level 1' do
+        expect(recalc.practice_menu_count).to eq(1)
+        expect(recalc.intensity_level).to eq(1)
+      end
+    end
+
+    context '素振り300本を記録した日' do
+      before { create(:practice_log, :shadow_swing, user:, logged_on: today, amount: 300) }
+
+      it 'total_swing_count 300 / intensity_level 3' do
+        log = recalc
+        expect(log.total_swing_count).to eq(300)
+        expect(log.intensity_level).to eq(3)
+      end
+    end
+
+    context '試合がある日' do
+      before { create(:game_result, user:) }
+
+      it 'has_game true / intensity_level 4' do
+        log = recalc
+        expect(log.has_game).to be(true)
+        expect(log.intensity_level).to eq(4)
+      end
+    end
+
+    context 'コンディションのみ記録した日' do
+      before { create(:condition_log, user:, logged_on: today) }
+
+      it '草に影響しない（activity_log は作られない）' do
+        expect(recalc).to be_nil
+      end
+    end
+
+    context '一度作った後に活動が無くなった日' do
+      before { create(:activity_log, user:, activity_date: today, intensity_level: 2) }
+
+      it '再計算で activity_log が削除される' do
+        expect(recalc).to be_nil
+        expect(ActivityLog.where(user:, activity_date: today)).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

練習記録機能（#321）のバックエンド実装。Pro リリースの土台となる `activity_logs`（草・Streak の集計基盤）もここで作成する。

Refs ippei-shimizu/buzzbase#321
設計: `docs/strategy/product/pro-plan-prd/05-pro-feature-practice-log.md`、`pro-plan-design/03-ux-information-architecture.md`

## 変更内容

### テーブル / モデル
- `practice_menus`（メニューマスター: name/category/unit(count|minutes|distance)/unit_label/default_value/is_favorite/archived）
- `practice_logs`（量ログ: logged_on/amount/menu_name・unit_label スナップショット/source(manual|shadow_swing)/memo）
- `condition_logs`（疲労/体調/睡眠/気分/怪我[jsonb {part,memo}]、user×logged_on で一意=1日1回upsert）
- `activity_logs`（user×date 集計: practice_menu_count(distinct)/total_swing_count/has_game/intensity_level(0-4)）

### 集計サービス
- `Activities::DailyActivityRecalculator`: practice_log の `after_commit` で当日分を**全再計算（冪等）**。
  - 強度 = max(distinctメニュー数, 素振り本数レベル, 試合)。L2=2種or素振り100+/L3=3種or300+/L4=4種+or500+or試合
  - 素振り本数は `source='shadow_swing'` の練習ログから集計（ShadowSwingSession 非依存・二重計上回避）
  - コンディションログは集計対象外（休養日でも記録するため草に影響させない）
  - 日付バケットは JST

### API（api/v2）
- `practice_menus`（index/create/update/destroy、削除は archived 論理削除）
- `practice_logs`（index[期間filter]/create[メニュー名スナップショット]/destroy）
- `condition_logs`（by_date/upsert）

### 無料 / Pro 境界
- 練習メニュー登録: 無料 **5件**まで / Pro 無制限（`PlanLimits` 3→5）
- コンディションログ: **Pro 限定**（`detailed_condition_log`）
- 量記録・閲覧: 無料も全期間・全件

## テスト
- `rspec` 全 **1268 examples / 0 failures**、`rubocop` クリーン
- 追加: 練習メニュー/量ログ/コンディションの request spec、recalculator の service spec、after_commit 連動の model spec

## 補足
- mobile 側 UI は別 PR（feature/321-practice-log-mobile）
- `activity_logs` の読み取り・ヒートマップ・game_result 集約フックは #320 で追加
