### PR TITLE
Add: 素振りカウンターのバックエンド

### DIFF
--- a/app/controllers/api/v2/shadow_swing_sessions_controller.rb
+++ b/app/controllers/api/v2/shadow_swing_sessions_controller.rb
@@ -1,0 +1,48 @@
+module Api
+  module V2
+    # 素振りカウンターのセッション。基本機能は無料（shadow_swing_basic）。
+    # 開始時に作成し、完了時に練習ログを自動生成する。
+    class ShadowSwingSessionsController < Api::V2::ApplicationController
+      before_action :authenticate_api_v1_user!
+
+      # POST /api/v2/shadow_swing_sessions
+      def create
+        session = current_api_v1_user.shadow_swing_sessions.build(
+          target_count: params.require(:shadow_swing_session).permit(:target_count)[:target_count],
+          logged_on: Time.find_zone('Asia/Tokyo').today
+        )
+        if session.save
+          render json: session, serializer: ::V2::ShadowSwingSessionSerializer, status: :created
+        else
+          render json: { errors: session.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # POST /api/v2/shadow_swing_sessions/:id/complete
+      def complete
+        session = current_api_v1_user.shadow_swing_sessions.find(params[:id])
+        session.complete!(swing_count: complete_params[:swing_count].to_i)
+        render json: session, serializer: ::V2::ShadowSwingSessionSerializer, status: :ok
+      end
+
+      # GET /api/v2/shadow_swing_sessions/stats
+      def stats
+        zone = Time.find_zone('Asia/Tokyo')
+        today = zone.today
+        logs = current_api_v1_user.practice_logs.where(source: 'shadow_swing')
+
+        render json: {
+          today_count: logs.where(logged_on: today).sum(:amount).to_i,
+          month_count: logs.where(logged_on: today.beginning_of_month..today).sum(:amount).to_i,
+          total_count: logs.sum(:amount).to_i
+        }, status: :ok
+      end
+
+      private
+
+      def complete_params
+        params.require(:shadow_swing_session).permit(:swing_count)
+      end
+    end
+  end
+end

--- a/app/models/shadow_swing_session.rb
+++ b/app/models/shadow_swing_session.rb
@@ -1,0 +1,30 @@
+class ShadowSwingSession < ApplicationRecord
+  belongs_to :user
+  belongs_to :practice_log, optional: true
+
+  MENU_NAME = '素振り'.freeze
+  UNIT_LABEL = '本'.freeze
+
+  validates :logged_on, presence: true
+  validates :target_count, numericality: { greater_than: 0 }
+  validates :swing_count, numericality: { greater_than_or_equal_to: 0 }
+
+  # セッションを完了し、素振り由来の練習ログを自動生成する。
+  # 練習ログの after_commit で当日の activity_logs（草・Streak）が再計算される。
+  # @param swing_count [Integer] 実際に振った本数
+  # @return [self]
+  def complete!(swing_count:)
+    transaction do
+      log = user.practice_logs.create!(
+        practice_menu: nil,
+        logged_on:,
+        amount: swing_count,
+        menu_name: MENU_NAME,
+        unit_label: UNIT_LABEL,
+        source: 'shadow_swing'
+      )
+      update!(swing_count:, completed_at: Time.current, practice_log: log)
+    end
+    self
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,6 +45,7 @@ class User < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   has_many :practice_logs, dependent: :destroy
   has_many :condition_logs, dependent: :destroy
   has_many :activity_logs, dependent: :destroy
+  has_many :shadow_swing_sessions, dependent: :destroy
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable

--- a/app/serializers/v2/shadow_swing_session_serializer.rb
+++ b/app/serializers/v2/shadow_swing_session_serializer.rb
@@ -1,0 +1,5 @@
+module V2
+  class ShadowSwingSessionSerializer < ActiveModel::Serializer
+    attributes :id, :logged_on, :target_count, :swing_count, :completed_at, :practice_log_id
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -273,6 +273,10 @@ Rails.application.routes.draw do
           post :upsert
         end
       end
+      resources :shadow_swing_sessions, only: %i[create] do
+        member { post :complete }
+        collection { get :stats }
+      end
     end
   end
 

--- a/db/migrate/20260627110001_create_shadow_swing_sessions.rb
+++ b/db/migrate/20260627110001_create_shadow_swing_sessions.rb
@@ -1,0 +1,15 @@
+class CreateShadowSwingSessions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :shadow_swing_sessions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date :logged_on, null: false
+      t.integer :target_count, null: false
+      t.integer :swing_count, null: false, default: 0
+      t.datetime :completed_at
+      t.references :practice_log, null: true, foreign_key: { on_delete: :nullify }
+      t.timestamps
+    end
+
+    add_index :shadow_swing_sessions, %i[user_id logged_on]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_27_100004) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_27_110001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -538,6 +538,20 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_27_100004) do
     t.index ["user_id"], name: "index_seasons_on_user_id"
   end
 
+  create_table "shadow_swing_sessions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.date "logged_on", null: false
+    t.integer "target_count", null: false
+    t.integer "swing_count", default: 0, null: false
+    t.datetime "completed_at"
+    t.bigint "practice_log_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["practice_log_id"], name: "index_shadow_swing_sessions_on_practice_log_id"
+    t.index ["user_id", "logged_on"], name: "index_shadow_swing_sessions_on_user_id_and_logged_on"
+    t.index ["user_id"], name: "index_shadow_swing_sessions_on_user_id"
+  end
+
   create_table "solid_queue_blocked_executions", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.string "queue_name", null: false
@@ -877,6 +891,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_27_100004) do
   add_foreign_key "practice_logs", "users"
   add_foreign_key "practice_menus", "users"
   add_foreign_key "seasons", "users"
+  add_foreign_key "shadow_swing_sessions", "practice_logs", on_delete: :nullify
+  add_foreign_key "shadow_swing_sessions", "users"
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/spec/factories/shadow_swing_sessions.rb
+++ b/spec/factories/shadow_swing_sessions.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :shadow_swing_session do
+    user
+    logged_on { Time.find_zone('Asia/Tokyo').today }
+    target_count { 200 }
+    swing_count { 0 }
+  end
+end

--- a/spec/requests/api/v2/shadow_swing_sessions_spec.rb
+++ b/spec/requests/api/v2/shadow_swing_sessions_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::ShadowSwingSessions', type: :request do
+  let(:user) { create(:user) }
+  let(:today) { Time.find_zone('Asia/Tokyo').today }
+
+  describe 'POST /api/v2/shadow_swing_sessions' do
+    context '未認証' do
+      it '401' do
+        post '/api/v2/shadow_swing_sessions',
+             params: { shadow_swing_session: { target_count: 200 } }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    it 'セッションを作成する（無料で利用可）' do
+      post '/api/v2/shadow_swing_sessions',
+           params: { shadow_swing_session: { target_count: 200 } },
+           headers: auth_headers_for(user)
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body['target_count']).to eq(200)
+    end
+  end
+
+  describe 'POST /api/v2/shadow_swing_sessions/:id/complete' do
+    let!(:session) { create(:shadow_swing_session, user:, target_count: 200) }
+
+    it '完了時に素振りの練習ログを自動生成する' do
+      expect do
+        post "/api/v2/shadow_swing_sessions/#{session.id}/complete",
+             params: { shadow_swing_session: { swing_count: 200 } },
+             headers: auth_headers_for(user)
+      end.to change { user.practice_logs.where(source: 'shadow_swing').count }.from(0).to(1)
+
+      expect(response).to have_http_status(:ok)
+      log = user.practice_logs.find_by(source: 'shadow_swing')
+      expect(log.menu_name).to eq('素振り')
+      expect(log.amount.to_i).to eq(200)
+      expect(session.reload.practice_log_id).to eq(log.id)
+    end
+
+    it '完了で当日の activity_logs が再計算され、本数が強度に反映される' do
+      post "/api/v2/shadow_swing_sessions/#{session.id}/complete",
+           params: { shadow_swing_session: { swing_count: 300 } },
+           headers: auth_headers_for(user)
+
+      activity_log = user.activity_logs.find_by(activity_date: today)
+      expect(activity_log.total_swing_count).to eq(300)
+      expect(activity_log.intensity_level).to eq(3)
+    end
+
+    it '素振り本数を二重計上しない（ShadowSwingSession と練習ログで重複しない）' do
+      post "/api/v2/shadow_swing_sessions/#{session.id}/complete",
+           params: { shadow_swing_session: { swing_count: 150 } },
+           headers: auth_headers_for(user)
+
+      expect(user.activity_logs.find_by(activity_date: today).total_swing_count).to eq(150)
+    end
+  end
+
+  describe 'GET /api/v2/shadow_swing_sessions/stats' do
+    before do
+      create(:practice_log, :shadow_swing, user:, logged_on: today, amount: 100)
+      create(:practice_log, :shadow_swing, user:, logged_on: today - 40, amount: 50)
+    end
+
+    it '今日・今月・通算の本数を返す' do
+      get '/api/v2/shadow_swing_sessions/stats', headers: auth_headers_for(user)
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body['today_count']).to eq(100)
+      expect(body['total_count']).to eq(150)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
素振りカウンター（#319）のバックエンド。**#321 back にスタック**（マージ順: #321 → 本PR）。

Refs ippei-shimizu/buzzbase#319

## 変更内容
- `shadow_swing_sessions`（user/logged_on/target_count/swing_count/completed_at/practice_log_id）
- `ShadowSwingSession#complete!`: 完了時に **素振りの練習ログ（source=shadow_swing）を自動生成**。練習ログの after_commit で当日の activity_logs（草・Streak）を再計算
- v2 API: `create`（開始）/ `complete`（完了→ログ生成）/ `stats`（今日・今月・通算本数）
- 基本機能は **無料**（shadow_swing_basic）。素振り本数は practice_logs から集計し**二重計上しない**

## テスト
- `rspec` 6 examples / 0 failures、`rubocop` クリーン
