### PR TITLE
Add: 草機能・Streak のバックエンド

### DIFF
--- a/app/controllers/api/v2/activity_logs_controller.rb
+++ b/app/controllers/api/v2/activity_logs_controller.rb
@@ -1,0 +1,54 @@
+module Api
+  module V2
+    # 草機能（ヒートマップ）と Streak を返す。
+    # 無料は直近30日（grass_recent_30days）、Pro は全期間（grass_full_history）。
+    class ActivityLogsController < Api::V2::ApplicationController
+      before_action :authenticate_api_v1_user!
+
+      FREE_WINDOW_DAYS = 30
+
+      # GET /api/v2/activity_logs?from=&to=
+      def index
+        zone = Time.find_zone('Asia/Tokyo')
+        today = zone.today
+        from = parse_date(params[:from]) || (today - 364)
+        to = parse_date(params[:to]) || today
+
+        # 無料ユーザーは直近30日までにクランプ（サーバー側で強制）。
+        from = [from, today - (FREE_WINDOW_DAYS - 1)].max unless current_api_v1_user.has_entitlement?('grass_full_history')
+
+        logs = current_api_v1_user.activity_logs.in_range(from, to).order(:activity_date)
+        streak = ::Activities::StreakCalculator.new(current_api_v1_user)
+
+        render json: {
+          from:,
+          to:,
+          current_streak_days: streak.current,
+          longest_streak_days: streak.longest,
+          total_active_days: streak.total_active_days,
+          data: ActiveModelSerializers::SerializableResource.new(logs, each_serializer: ::V2::ActivityLogSerializer)
+        }, status: :ok
+      end
+
+      # GET /api/v2/activity_logs/streak
+      def streak
+        calculator = ::Activities::StreakCalculator.new(current_api_v1_user)
+        render json: {
+          current_streak_days: calculator.current,
+          longest_streak_days: calculator.longest,
+          total_active_days: calculator.total_active_days
+        }, status: :ok
+      end
+
+      private
+
+      def parse_date(value)
+        return nil if value.blank?
+
+        Date.parse(value)
+      rescue ArgumentError
+        nil
+      end
+    end
+  end
+end

--- a/app/models/match_result.rb
+++ b/app/models/match_result.rb
@@ -22,6 +22,9 @@ class MatchResult < ApplicationRecord
   validates :inning_format, presence: true, inclusion: { in: [7, 9] }
   validates :appearance_type, presence: true, inclusion: { in: APPEARANCE_TYPES }
 
+  # 試合の有無は草・Streak の強度に効くため、当日の activity_logs を再計算する。
+  after_commit :recalculate_activity, on: %i[create update destroy]
+
   # 指定ユーザーの試合データに紐づく年度を新しい順で返す
   # @param user [User]
   # @return [Array<Integer>]
@@ -30,5 +33,14 @@ class MatchResult < ApplicationRecord
       .pluck(Arel.sql('DISTINCT EXTRACT(YEAR FROM date_and_time)::int'))
       .sort
       .reverse
+  end
+
+  private
+
+  def recalculate_activity
+    activity_date = date_and_time&.in_time_zone('Asia/Tokyo')&.to_date
+    return unless activity_date
+
+    Activities::DailyActivityRecalculator.new(user_id:, date: activity_date).call
   end
 end

--- a/app/serializers/v2/activity_log_serializer.rb
+++ b/app/serializers/v2/activity_log_serializer.rb
@@ -1,0 +1,5 @@
+module V2
+  class ActivityLogSerializer < ActiveModel::Serializer
+    attributes :activity_date, :intensity_level, :has_game, :total_swing_count, :practice_menu_count
+  end
+end

--- a/app/services/activities/streak_calculator.rb
+++ b/app/services/activities/streak_calculator.rb
@@ -1,0 +1,51 @@
+module Activities
+  # ユーザーの連続活動日数（Streak）を算出する。
+  # 当日まだ未活動でも、前日まで連続していれば streak は継続中として数える
+  # （その日が終わるまでは途切れ扱いにしない）。
+  class StreakCalculator
+    JST = 'Asia/Tokyo'.freeze
+
+    def initialize(user)
+      @user = user
+    end
+
+    # 現在の連続日数
+    # @return [Integer]
+    def current
+      today = Time.find_zone(JST).today
+      start = active_dates.include?(today) ? today : today - 1
+      streak = 0
+      day = start
+      while active_dates.include?(day)
+        streak += 1
+        day -= 1
+      end
+      streak
+    end
+
+    # 最長の連続日数
+    # @return [Integer]
+    def longest
+      sorted = active_dates.to_a.sort
+      return 0 if sorted.empty?
+
+      longest = 1
+      run = 1
+      sorted.each_cons(2) do |prev, current_date|
+        run = current_date == prev + 1 ? run + 1 : 1
+        longest = [longest, run].max
+      end
+      longest
+    end
+
+    def total_active_days
+      active_dates.size
+    end
+
+    private
+
+    def active_dates
+      @active_dates ||= @user.activity_logs.pluck(:activity_date).to_set
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -277,6 +277,9 @@ Rails.application.routes.draw do
         member { post :complete }
         collection { get :stats }
       end
+      resources :activity_logs, only: %i[index] do
+        collection { get :streak }
+      end
     end
   end
 

--- a/spec/requests/api/v2/activity_logs_spec.rb
+++ b/spec/requests/api/v2/activity_logs_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::ActivityLogs', type: :request do
+  let(:user) { create(:user) }
+  let(:today) { Time.find_zone('Asia/Tokyo').today }
+
+  def make_pro(target)
+    target.subscription.update!(status: 'active', expires_at: 1.month.from_now)
+  end
+
+  describe 'GET /api/v2/activity_logs' do
+    context '未認証' do
+      it '401' do
+        get '/api/v2/activity_logs'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '認証済み' do
+      before do
+        create(:activity_log, user:, activity_date: today, intensity_level: 2)
+        create(:activity_log, user:, activity_date: today - 1, intensity_level: 1)
+      end
+
+      it 'ヒートマップデータと streak を返す' do
+        get '/api/v2/activity_logs', headers: auth_headers_for(user)
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body['current_streak_days']).to eq(2)
+        expect(body['data'].size).to eq(2)
+      end
+    end
+
+    context '無料ユーザーが31日以上前を要求' do
+      before do
+        create(:activity_log, user:, activity_date: today)
+        create(:activity_log, user:, activity_date: today - 40)
+      end
+
+      it '直近30日にクランプされ古いデータは含まれない' do
+        get '/api/v2/activity_logs', params: { from: (today - 60).to_s }, headers: auth_headers_for(user)
+        dates = response.parsed_body['data'].pluck('activity_date')
+        expect(dates).to include(today.to_s)
+        expect(dates).not_to include((today - 40).to_s)
+      end
+    end
+
+    context 'Pro ユーザー' do
+      before do
+        make_pro(user)
+        create(:activity_log, user:, activity_date: today - 40)
+      end
+
+      it '全期間を取得できる' do
+        get '/api/v2/activity_logs', params: { from: (today - 60).to_s }, headers: auth_headers_for(user)
+        dates = response.parsed_body['data'].pluck('activity_date')
+        expect(dates).to include((today - 40).to_s)
+      end
+    end
+  end
+
+  describe 'GET /api/v2/activity_logs/streak' do
+    before do
+      create(:activity_log, user:, activity_date: today)
+      create(:activity_log, user:, activity_date: today - 1)
+      create(:activity_log, user:, activity_date: today - 2)
+    end
+
+    it '現在/最長/通算を返す' do
+      get '/api/v2/activity_logs/streak', headers: auth_headers_for(user)
+      body = response.parsed_body
+      expect(body['current_streak_days']).to eq(3)
+      expect(body['longest_streak_days']).to eq(3)
+      expect(body['total_active_days']).to eq(3)
+    end
+  end
+
+  describe '試合作成時の活動反映' do
+    it '試合を作ると当日の activity_log に has_game が立つ' do
+      create(:game_result, user:)
+      activity_log = user.activity_logs.find_by(activity_date: today)
+      expect(activity_log.has_game).to be(true)
+      expect(activity_log.intensity_level).to eq(4)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
草機能・Streak（#320）のバックエンド。**#319 back にスタック**（マージ順: #321 → #319 → 本PR）。
activity_logs の正本担当。

Refs ippei-shimizu/buzzbase#320

## 変更内容
- `MatchResult` の after_commit で当日の `activity_logs` を再計算（試合あり=has_game→強度L4、JST集計）
- `Activities::StreakCalculator`: 現在/最長/通算。当日まだ未活動でも前日まで連続なら継続中扱い
- v2 API: `activity_logs#index`（ヒートマップ＋streak）/ `streak`
- 無料は**直近30日にサーバー側クランプ**（grass_recent_30days）、Pro は全期間（grass_full_history）

## テスト
- `rspec` 全 1280 examples / 0 failures、`rubocop` クリーン
- 範囲クランプ・streak・試合作成での has_game 反映を検証
