### PR TITLE
Add: 自主練スケジュールのバックエンド

### DIFF
--- a/app/controllers/api/v2/schedules_controller.rb
+++ b/app/controllers/api/v2/schedules_controller.rb
@@ -57,8 +57,12 @@ module Api
 
       def assign_menus(schedule)
         menus = params.dig(:schedule, :menus) || []
+        # 他ユーザーの practice_menu_id を紐付けられないよう、所有メニューに限定する（IDOR 防止）。
+        allowed_ids = schedule.user.practice_menus.where(id: menus.pluck(:practice_menu_id)).pluck(:id).to_set
         schedule.schedule_menus.destroy_all if schedule.persisted?
         menus.each_with_index do |menu, index|
+          next unless allowed_ids.include?(menu[:practice_menu_id].to_i)
+
           schedule.schedule_menus.build(
             practice_menu_id: menu[:practice_menu_id],
             target_value: menu[:target_value],

--- a/app/controllers/api/v2/schedules_controller.rb
+++ b/app/controllers/api/v2/schedules_controller.rb
@@ -1,0 +1,71 @@
+module Api
+  module V2
+    # 自主練スケジュール。無料は3つまで（PlanLimits）。
+    # 通知のリマインド自体は端末側のローカル通知で行う（サーバーは設定の保管のみ）。
+    class SchedulesController < Api::V2::ApplicationController
+      before_action :authenticate_api_v1_user!
+      before_action :load_schedule, only: %i[update destroy]
+
+      def index
+        schedules = current_api_v1_user.schedules.active
+                                       .includes(schedule_menus: :practice_menu)
+                                       .order(:scheduled_time)
+        render json: schedules, each_serializer: ::V2::ScheduleSerializer, status: :ok
+      end
+
+      def create
+        return render json: { error: 'Pro プランでスケジュールを無制限に登録できます' }, status: :forbidden unless current_api_v1_user.can_create_schedule?
+
+        schedule = current_api_v1_user.schedules.build(schedule_params)
+        assign_menus(schedule)
+        if schedule.save
+          render json: schedule, serializer: ::V2::ScheduleSerializer, status: :created
+        else
+          render json: { errors: schedule.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def update
+        @schedule.assign_attributes(schedule_params)
+        assign_menus(@schedule) if params[:schedule].key?(:menus)
+        if @schedule.save
+          render json: @schedule, serializer: ::V2::ScheduleSerializer, status: :ok
+        else
+          render json: { errors: @schedule.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        @schedule.destroy
+        render json: { message: '削除しました' }, status: :ok
+      end
+
+      private
+
+      def load_schedule
+        @schedule = current_api_v1_user.schedules.find(params[:id])
+      end
+
+      # カスタム通知文は Pro 限定。無料ユーザーの指定は無視する。
+      def schedule_params
+        permitted = params.require(:schedule).permit(
+          :title, :days_of_week, :scheduled_time, :note, :notification_enabled, :active, :notification_message
+        )
+        permitted.delete(:notification_message) unless current_api_v1_user.has_entitlement?('custom_notification_messages')
+        permitted
+      end
+
+      def assign_menus(schedule)
+        menus = params.dig(:schedule, :menus) || []
+        schedule.schedule_menus.destroy_all if schedule.persisted?
+        menus.each_with_index do |menu, index|
+          schedule.schedule_menus.build(
+            practice_menu_id: menu[:practice_menu_id],
+            target_value: menu[:target_value],
+            sort_order: index
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/plan_limits.rb
+++ b/app/models/concerns/plan_limits.rb
@@ -7,7 +7,7 @@ module PlanLimits
 
   PRACTICE_MENU_FREE_LIMIT = 5
   MEDIA_UPLOAD_FREE_LIMIT_PER_MONTH = 3
-  SCHEDULE_FREE_LIMIT = 1
+  SCHEDULE_FREE_LIMIT = 3
   MONTHLY_GOAL_FREE_LIMIT = 1
 
   # 練習メニューを新規作成できるか。無料は archived 以外5つまで。
@@ -60,7 +60,7 @@ module PlanLimits
   end
 
   def active_schedules_count
-    0
+    schedules.active.count
   end
 
   def active_monthly_goals_count

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,0 +1,17 @@
+class Schedule < ApplicationRecord
+  belongs_to :user
+  has_many :schedule_menus, -> { order(:sort_order) }, dependent: :destroy, inverse_of: :schedule
+  has_many :practice_menus, through: :schedule_menus
+
+  validates :title, presence: true, length: { maximum: 50 }
+  validates :days_of_week, presence: true
+  validates :scheduled_time, presence: true
+
+  scope :active, -> { where(active: true) }
+
+  # "1,3,5" を整数配列に変換する。
+  # @return [Array<Integer>]
+  def day_numbers
+    days_of_week.to_s.split(',').map(&:to_i)
+  end
+end

--- a/app/models/schedule_menu.rb
+++ b/app/models/schedule_menu.rb
@@ -1,0 +1,4 @@
+class ScheduleMenu < ApplicationRecord
+  belongs_to :schedule
+  belongs_to :practice_menu
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,6 +46,7 @@ class User < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   has_many :condition_logs, dependent: :destroy
   has_many :activity_logs, dependent: :destroy
   has_many :shadow_swing_sessions, dependent: :destroy
+  has_many :schedules, dependent: :destroy
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable

--- a/app/serializers/v2/schedule_serializer.rb
+++ b/app/serializers/v2/schedule_serializer.rb
@@ -1,0 +1,22 @@
+module V2
+  class ScheduleSerializer < ActiveModel::Serializer
+    attributes :id, :title, :days_of_week, :scheduled_time, :note,
+               :notification_enabled, :active, :notification_message, :menus
+
+    def scheduled_time
+      object.scheduled_time&.strftime('%H:%M')
+    end
+
+    # 紐付いた練習メニューを表示用に整形して返す。
+    def menus
+      object.schedule_menus.map do |schedule_menu|
+        {
+          practice_menu_id: schedule_menu.practice_menu_id,
+          name: schedule_menu.practice_menu&.name,
+          unit_label: schedule_menu.practice_menu&.unit_label,
+          target_value: schedule_menu.target_value
+        }
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -280,6 +280,7 @@ Rails.application.routes.draw do
       resources :activity_logs, only: %i[index] do
         collection { get :streak }
       end
+      resources :schedules, only: %i[index create update destroy]
     end
   end
 

--- a/db/migrate/20260627120001_create_schedules.rb
+++ b/db/migrate/20260627120001_create_schedules.rb
@@ -1,0 +1,17 @@
+class CreateSchedules < ActiveRecord::Migration[7.1]
+  def change
+    create_table :schedules do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :title, null: false
+      t.string :days_of_week, null: false       # "1,3,5"（月=1〜日=7）
+      t.time :scheduled_time, null: false
+      t.text :note
+      t.boolean :notification_enabled, null: false, default: true
+      t.boolean :active, null: false, default: true
+      t.string :notification_message            # カスタム通知文（Pro）
+      t.timestamps
+    end
+
+    add_index :schedules, %i[user_id active]
+  end
+end

--- a/db/migrate/20260627120002_create_schedule_menus.rb
+++ b/db/migrate/20260627120002_create_schedule_menus.rb
@@ -1,0 +1,11 @@
+class CreateScheduleMenus < ActiveRecord::Migration[7.1]
+  def change
+    create_table :schedule_menus do |t|
+      t.references :schedule, null: false, foreign_key: true
+      t.references :practice_menu, null: false, foreign_key: true
+      t.float :target_value
+      t.integer :sort_order, null: false, default: 0
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_27_110001) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_27_120002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -529,6 +529,32 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_27_110001) do
     t.index ["follower_id"], name: "index_relationships_on_follower_id"
   end
 
+  create_table "schedule_menus", force: :cascade do |t|
+    t.bigint "schedule_id", null: false
+    t.bigint "practice_menu_id", null: false
+    t.float "target_value"
+    t.integer "sort_order", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["practice_menu_id"], name: "index_schedule_menus_on_practice_menu_id"
+    t.index ["schedule_id"], name: "index_schedule_menus_on_schedule_id"
+  end
+
+  create_table "schedules", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "title", null: false
+    t.string "days_of_week", null: false
+    t.time "scheduled_time", null: false
+    t.text "note"
+    t.boolean "notification_enabled", default: true, null: false
+    t.boolean "active", default: true, null: false
+    t.string "notification_message"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "active"], name: "index_schedules_on_user_id_and_active"
+    t.index ["user_id"], name: "index_schedules_on_user_id"
+  end
+
   create_table "seasons", force: :cascade do |t|
     t.string "name", null: false
     t.bigint "user_id", null: false
@@ -890,6 +916,9 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_27_110001) do
   add_foreign_key "practice_logs", "practice_menus", on_delete: :nullify
   add_foreign_key "practice_logs", "users"
   add_foreign_key "practice_menus", "users"
+  add_foreign_key "schedule_menus", "practice_menus"
+  add_foreign_key "schedule_menus", "schedules"
+  add_foreign_key "schedules", "users"
   add_foreign_key "seasons", "users"
   add_foreign_key "shadow_swing_sessions", "practice_logs", on_delete: :nullify
   add_foreign_key "shadow_swing_sessions", "users"

--- a/spec/factories/schedules.rb
+++ b/spec/factories/schedules.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :schedule do
+    user
+    title { '朝の素振り' }
+    days_of_week { '1,3,5' }
+    scheduled_time { '06:00' }
+    notification_enabled { true }
+    active { true }
+  end
+end

--- a/spec/requests/api/v2/schedules_spec.rb
+++ b/spec/requests/api/v2/schedules_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::Schedules', type: :request do
+  let(:user) { create(:user) }
+
+  def make_pro(target)
+    target.subscription.update!(status: 'active', expires_at: 1.month.from_now)
+  end
+
+  describe 'GET /api/v2/schedules' do
+    context '未認証' do
+      it '401' do
+        get '/api/v2/schedules'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    it 'active なスケジュールを返す' do
+      create(:schedule, user:, title: '朝練')
+      create(:schedule, user:, title: '休止中', active: false)
+      get '/api/v2/schedules', headers: auth_headers_for(user)
+      titles = response.parsed_body.pluck('title')
+      expect(titles).to include('朝練')
+      expect(titles).not_to include('休止中')
+    end
+  end
+
+  describe 'POST /api/v2/schedules' do
+    let(:menu) { create(:practice_menu, user:) }
+    let(:params) do
+      {
+        schedule: {
+          title: '朝の素振り', days_of_week: '1,3,5', scheduled_time: '06:00',
+          menus: [{ practice_menu_id: menu.id, target_value: 200 }]
+        }
+      }
+    end
+
+    it 'メニュー紐付きで作成する' do
+      post '/api/v2/schedules', params:, headers: auth_headers_for(user)
+      expect(response).to have_http_status(:created)
+      body = response.parsed_body
+      expect(body['title']).to eq('朝の素振り')
+      expect(body['menus'].first['practice_menu_id']).to eq(menu.id)
+    end
+
+    context '無料ユーザーが上限(3)を超える' do
+      before { create_list(:schedule, 3, user:) }
+
+      it '403' do
+        post '/api/v2/schedules', params:, headers: auth_headers_for(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'カスタム通知文' do
+      let(:custom_params) do
+        { schedule: { title: 'x', days_of_week: '1', scheduled_time: '06:00', notification_message: '頑張れ' } }
+      end
+
+      it '無料ユーザーは無視される' do
+        post '/api/v2/schedules', params: custom_params, headers: auth_headers_for(user)
+        expect(response.parsed_body['notification_message']).to be_nil
+      end
+
+      it 'Pro ユーザーは保存される' do
+        make_pro(user)
+        post '/api/v2/schedules', params: custom_params, headers: auth_headers_for(user)
+        expect(response.parsed_body['notification_message']).to eq('頑張れ')
+      end
+    end
+  end
+
+  describe 'DELETE /api/v2/schedules/:id' do
+    let!(:schedule) { create(:schedule, user:) }
+
+    it '削除する' do
+      delete "/api/v2/schedules/#{schedule.id}", headers: auth_headers_for(user)
+      expect(response).to have_http_status(:ok)
+      expect(Schedule.exists?(schedule.id)).to be(false)
+    end
+  end
+end

--- a/spec/requests/api/v2/schedules_spec.rb
+++ b/spec/requests/api/v2/schedules_spec.rb
@@ -44,6 +44,16 @@ RSpec.describe 'Api::V2::Schedules', type: :request do
       expect(body['menus'].first['practice_menu_id']).to eq(menu.id)
     end
 
+    it '他ユーザーのメニューは紐付けられない（IDOR防止）' do
+      other_menu = create(:practice_menu, user: create(:user))
+      post '/api/v2/schedules',
+           params: { schedule: { title: 'x', days_of_week: '1', scheduled_time: '06:00',
+                                 menus: [{ practice_menu_id: other_menu.id, target_value: 1 }] } },
+           headers: auth_headers_for(user)
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body['menus']).to be_empty
+    end
+
     context '無料ユーザーが上限(3)を超える' do
       before { create_list(:schedule, 3, user:) }
 


### PR DESCRIPTION
## 概要
自主練スケジュール（#324）のバックエンド。**#320 back にスタック**（マージ順: #321→#319→#320→本PR）。

Refs ippei-shimizu/buzzbase#324

## 変更内容
- `schedules`（title/days_of_week/scheduled_time/notification_enabled/active/notification_message）, `schedule_menus`（practice_menu 紐付け・target_value）
- PlanLimits: 無料は**3つまで**（SCHEDULE_FREE_LIMIT 1→3）、`active_schedules_count` を実関連に
- v2 CRUD・シリアライザ（menus 埋め込み）。**カスタム通知文は Pro 限定**（custom_notification_messages、無料は無視）
- リマインドは端末ローカル通知（mobile）で実施。サーバーは設定保管のみ

## テスト
- `rspec` 7 examples / 0 failures、`rubocop` クリーン
