### PR TITLE
Add: 目標設定・達成管理のバックエンド

### DIFF
--- a/app/controllers/api/v2/goals_controller.rb
+++ b/app/controllers/api/v2/goals_controller.rb
@@ -27,7 +27,8 @@ module Api
       end
 
       def update
-        if @goal.update(goal_params)
+        # period_type / season_id は作成後に変更不可（Pro 制限の回避を防ぐ）。
+        if @goal.update(update_params)
           render json: ::V2::GoalSerializer.new(@goal).as_json, status: :ok
         else
           render json: { errors: @goal.errors.full_messages }, status: :unprocessable_entity
@@ -60,6 +61,12 @@ module Api
 
       def goal_params
         params.require(:goal).permit(:title, :period_type, :season_id, :month_start, :deadline,
+                                     :metric_key, :target_value, :comparison_type)
+      end
+
+      # 更新では種類（period_type / season_id）を変更させない。
+      def update_params
+        params.require(:goal).permit(:title, :month_start, :deadline,
                                      :metric_key, :target_value, :comparison_type)
       end
     end

--- a/app/controllers/api/v2/goals_controller.rb
+++ b/app/controllers/api/v2/goals_controller.rb
@@ -1,0 +1,67 @@
+module Api
+  module V2
+    # 目標設定・達成管理。無料は月次2つまで、シーズン目標は Pro 限定。
+    class GoalsController < Api::V2::ApplicationController
+      before_action :authenticate_api_v1_user!
+      before_action :load_goal, only: %i[update destroy]
+
+      def index
+        goals = current_api_v1_user.goals.active.order(deadline: :asc)
+        render json: goals, each_serializer: ::V2::GoalSerializer, status: :ok
+      end
+
+      def history
+        goals = current_api_v1_user.goals.where(is_finalized: true).order(deadline: :desc)
+        render json: goals, each_serializer: ::V2::GoalSerializer, status: :ok
+      end
+
+      def create
+        goal = current_api_v1_user.goals.build(goal_params)
+        return render_limit_error(goal) unless allowed_to_create?(goal)
+
+        if goal.save
+          render json: ::V2::GoalSerializer.new(goal).as_json, status: :created
+        else
+          render json: { errors: goal.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def update
+        if @goal.update(goal_params)
+          render json: ::V2::GoalSerializer.new(@goal).as_json, status: :ok
+        else
+          render json: { errors: @goal.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        @goal.destroy
+        render json: { message: '削除しました' }, status: :ok
+      end
+
+      private
+
+      def load_goal
+        @goal = current_api_v1_user.goals.find(params[:id])
+      end
+
+      def allowed_to_create?(goal)
+        if goal.period_type == 'season'
+          current_api_v1_user.can_create_season_goal?
+        else
+          current_api_v1_user.can_create_monthly_goal?
+        end
+      end
+
+      def render_limit_error(goal)
+        message = goal.period_type == 'season' ? 'シーズン目標は Pro プラン限定です' : 'Pro プランで月次目標を無制限に設定できます'
+        render json: { error: message }, status: :forbidden
+      end
+
+      def goal_params
+        params.require(:goal).permit(:title, :period_type, :season_id, :month_start, :deadline,
+                                     :metric_key, :target_value, :comparison_type)
+      end
+    end
+  end
+end

--- a/app/jobs/finalize_goals_job.rb
+++ b/app/jobs/finalize_goals_job.rb
@@ -1,0 +1,31 @@
+class FinalizeGoalsJob < ApplicationJob
+  queue_as :default
+
+  # 期限到来済みの未確定目標を確定し、達成ならバッジを付与する（push はしない）。
+  def perform
+    today = Time.find_zone('Asia/Tokyo').today
+    Goal.active.where(deadline: ...today).find_each do |goal|
+      calculator = ::Goals::ProgressCalculator.new(goal)
+      achieved = calculator.achieved?
+      goal.update!(
+        achieved_value: calculator.current_value,
+        is_achieved: achieved,
+        achieved_at: achieved ? Time.current : nil,
+        is_finalized: true
+      )
+      award_badge(goal) if achieved
+    end
+  end
+
+  private
+
+  def award_badge(goal)
+    season = goal.period_type == 'season'
+    goal.goal_badges.create!(
+      user: goal.user,
+      badge_type: season ? 'season_achieved' : 'monthly_achieved',
+      badge_name: season ? 'シーズン目標達成' : '月間目標達成',
+      awarded_at: Time.current
+    )
+  end
+end

--- a/app/models/concerns/plan_limits.rb
+++ b/app/models/concerns/plan_limits.rb
@@ -8,7 +8,7 @@ module PlanLimits
   PRACTICE_MENU_FREE_LIMIT = 5
   MEDIA_UPLOAD_FREE_LIMIT_PER_MONTH = 3
   SCHEDULE_FREE_LIMIT = 3
-  MONTHLY_GOAL_FREE_LIMIT = 1
+  MONTHLY_GOAL_FREE_LIMIT = 2
 
   # 練習メニューを新規作成できるか。無料は archived 以外5つまで。
   # @return [Boolean]
@@ -64,6 +64,6 @@ module PlanLimits
   end
 
   def active_monthly_goals_count
-    0
+    goals.active.monthly.count
   end
 end

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -1,0 +1,37 @@
+class Goal < ApplicationRecord
+  belongs_to :user
+  belongs_to :season, optional: true
+  has_many :goal_badges, dependent: :destroy
+
+  PERIOD_TYPES = %w[season monthly].freeze
+  COMPARISON_TYPES = %w[greater_than less_than].freeze
+  METRIC_KEYS = %w[practice_days total_swing_count game_count batting_average ops era].freeze
+
+  validates :title, presence: true, length: { maximum: 60 }
+  validates :period_type, inclusion: { in: PERIOD_TYPES }
+  validates :comparison_type, inclusion: { in: COMPARISON_TYPES }
+  validates :metric_key, inclusion: { in: METRIC_KEYS }
+  validates :target_value, presence: true
+  validates :deadline, presence: true
+
+  scope :active, -> { where(is_finalized: false) }
+  scope :monthly, -> { where(period_type: 'monthly') }
+
+  JST = 'Asia/Tokyo'.freeze
+
+  # 集計対象の期間（[from, to] の Time 範囲）。
+  # 月次は当月、シーズンはそのシーズンの試合の最小〜最大日時。
+  # @return [Array(Time, Time), nil]
+  def period_range
+    if period_type == 'monthly' && month_start
+      zone = Time.find_zone(JST)
+      start = zone.local(month_start.year, month_start.month, 1)
+      [start, start.end_of_month]
+    elsif period_type == 'season' && season_id
+      games = MatchResult.joins(:game_result).where(game_results: { season_id: })
+      min = games.minimum(:date_and_time)
+      max = games.maximum(:date_and_time)
+      min && max ? [min, max] : nil
+    end
+  end
+end

--- a/app/models/goal_badge.rb
+++ b/app/models/goal_badge.rb
@@ -1,0 +1,4 @@
+class GoalBadge < ApplicationRecord
+  belongs_to :user
+  belongs_to :goal
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,6 +47,8 @@ class User < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   has_many :activity_logs, dependent: :destroy
   has_many :shadow_swing_sessions, dependent: :destroy
   has_many :schedules, dependent: :destroy
+  has_many :goals, dependent: :destroy
+  has_many :goal_badges, dependent: :destroy
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable

--- a/app/serializers/v2/goal_serializer.rb
+++ b/app/serializers/v2/goal_serializer.rb
@@ -1,0 +1,24 @@
+module V2
+  class GoalSerializer < ActiveModel::Serializer
+    attributes :id, :title, :period_type, :season_id, :month_start, :deadline,
+               :metric_key, :target_value, :comparison_type,
+               :is_achieved, :is_finalized, :achieved_value,
+               :current_value, :progress_percent, :days_remaining
+
+    delegate :current_value, to: :progress
+
+    delegate :progress_percent, to: :progress
+
+    def days_remaining
+      return 0 if object.deadline.nil?
+
+      [(object.deadline - Time.find_zone('Asia/Tokyo').today).to_i, 0].max
+    end
+
+    private
+
+    def progress
+      @progress ||= ::Goals::ProgressCalculator.new(object)
+    end
+  end
+end

--- a/app/services/goals/metric_calculator.rb
+++ b/app/services/goals/metric_calculator.rb
@@ -1,0 +1,83 @@
+module Goals
+  # 目標の指標を、その目標の対象期間で集計して現在値を返す。
+  # MVP対応 metric: practice_days / total_swing_count / game_count / batting_average / ops / era。
+  class MetricCalculator
+    def initialize(goal)
+      @goal = goal
+      @user = goal.user
+    end
+
+    # @return [Numeric] 期間内の現在値。期間が無ければ 0。
+    def current_value
+      range = @goal.period_range
+      return 0 unless range
+
+      from, to = range
+      case @goal.metric_key
+      when 'practice_days' then practice_days(from, to)
+      when 'total_swing_count' then total_swing_count(from, to)
+      when 'game_count' then game_count(from, to)
+      when 'batting_average' then batting_average(from, to)
+      when 'ops' then ops(from, to)
+      when 'era' then era(from, to)
+      else 0
+      end
+    end
+
+    private
+
+    def practice_days(from, to)
+      @user.activity_logs.where(activity_date: from.to_date..to.to_date)
+           .where('intensity_level >= 1').count
+    end
+
+    def total_swing_count(from, to)
+      @user.practice_logs.where(source: 'shadow_swing', logged_on: from.to_date..to.to_date).sum(:amount).to_i
+    end
+
+    def game_count(from, to)
+      MatchResult.joins(:game_result)
+                 .where(game_results: { user_id: @user.id }, date_and_time: from..to).count
+    end
+
+    def batting_scope(from, to)
+      BattingAverage.joins(game_result: :match_result)
+                    .where(game_results: { user_id: @user.id })
+                    .where(match_results: { date_and_time: from..to })
+    end
+
+    def batting_average(from, to)
+      scope = batting_scope(from, to)
+      at_bats = scope.sum(:at_bats)
+      return 0 if at_bats.zero?
+
+      (total_hits(scope).to_f / at_bats).round(3)
+    end
+
+    def ops(from, to)
+      scope = batting_scope(from, to)
+      at_bats = scope.sum(:at_bats)
+      bb = scope.sum(:base_on_balls)
+      hbp = scope.sum(:hit_by_pitch)
+      sf = scope.sum(:sacrifice_fly)
+      obp_denom = at_bats + bb + hbp + sf
+      obp = obp_denom.zero? ? 0 : (total_hits(scope) + bb + hbp).to_f / obp_denom
+      slg = at_bats.zero? ? 0 : scope.sum(:total_bases).to_f / at_bats
+      (obp + slg).round(3)
+    end
+
+    def era(from, to)
+      scope = PitchingResult.joins(game_result: :match_result)
+                            .where(game_results: { user_id: @user.id })
+                            .where(match_results: { date_and_time: from..to })
+      innings = scope.sum(:innings_pitched)
+      return 0 if innings.zero?
+
+      (scope.sum(:earned_run) * 9.0 / innings).round(2)
+    end
+
+    def total_hits(scope)
+      scope.sum(Arel.sql('hit + two_base_hit + three_base_hit + home_run'))
+    end
+  end
+end

--- a/app/services/goals/progress_calculator.rb
+++ b/app/services/goals/progress_calculator.rb
@@ -1,0 +1,34 @@
+module Goals
+  # 目標の進捗率（0〜100）と達成判定を返す。
+  # comparison_type が less_than（防御率など低いほど良い指標）の場合は比率を反転する。
+  class ProgressCalculator
+    def initialize(goal)
+      @goal = goal
+    end
+
+    def current_value
+      @current_value ||= MetricCalculator.new(@goal).current_value
+    end
+
+    def progress_percent
+      target = @goal.target_value.to_f
+      return 0 if target.zero?
+
+      percent =
+        if @goal.comparison_type == 'less_than'
+          current_value.to_f.zero? ? 0 : target / current_value.to_f * 100
+        else
+          current_value.to_f / target * 100
+        end
+      percent.clamp(0, 100).round(1)
+    end
+
+    def achieved?
+      if @goal.comparison_type == 'less_than'
+        current_value.to_f.positive? && current_value <= @goal.target_value
+      else
+        current_value >= @goal.target_value
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -281,6 +281,9 @@ Rails.application.routes.draw do
         collection { get :streak }
       end
       resources :schedules, only: %i[index create update destroy]
+      resources :goals, only: %i[index create update destroy] do
+        collection { get :history }
+      end
     end
   end
 

--- a/db/migrate/20260627130001_create_goals.rb
+++ b/db/migrate/20260627130001_create_goals.rb
@@ -1,0 +1,22 @@
+class CreateGoals < ActiveRecord::Migration[7.1]
+  def change
+    create_table :goals do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :title, null: false
+      t.string :period_type, null: false # season / monthly
+      t.references :season, null: true, foreign_key: { on_delete: :nullify }
+      t.date :month_start
+      t.date :deadline, null: false
+      t.string :metric_key, null: false
+      t.float :target_value, null: false
+      t.string :comparison_type, null: false, default: 'greater_than'
+      t.float :achieved_value
+      t.datetime :achieved_at
+      t.boolean :is_achieved, null: false, default: false
+      t.boolean :is_finalized, null: false, default: false
+      t.timestamps
+    end
+
+    add_index :goals, %i[user_id period_type is_finalized]
+  end
+end

--- a/db/migrate/20260627130002_create_goal_badges.rb
+++ b/db/migrate/20260627130002_create_goal_badges.rb
@@ -1,0 +1,12 @@
+class CreateGoalBadges < ActiveRecord::Migration[7.1]
+  def change
+    create_table :goal_badges do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :goal, null: false, foreign_key: true
+      t.string :badge_type, null: false
+      t.string :badge_name, null: false
+      t.datetime :awarded_at, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_27_120002) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_27_130002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -249,6 +249,39 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_27_120002) do
     t.index ["pitching_result_id"], name: "index_game_results_on_pitching_result_id"
     t.index ["season_id"], name: "index_game_results_on_season_id"
     t.index ["user_id"], name: "index_game_results_on_user_id"
+  end
+
+  create_table "goal_badges", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "goal_id", null: false
+    t.string "badge_type", null: false
+    t.string "badge_name", null: false
+    t.datetime "awarded_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["goal_id"], name: "index_goal_badges_on_goal_id"
+    t.index ["user_id"], name: "index_goal_badges_on_user_id"
+  end
+
+  create_table "goals", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "title", null: false
+    t.string "period_type", null: false
+    t.bigint "season_id"
+    t.date "month_start"
+    t.date "deadline", null: false
+    t.string "metric_key", null: false
+    t.float "target_value", null: false
+    t.string "comparison_type", default: "greater_than", null: false
+    t.float "achieved_value"
+    t.datetime "achieved_at"
+    t.boolean "is_achieved", default: false, null: false
+    t.boolean "is_finalized", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["season_id"], name: "index_goals_on_season_id"
+    t.index ["user_id", "period_type", "is_finalized"], name: "index_goals_on_user_id_and_period_type_and_is_finalized"
+    t.index ["user_id"], name: "index_goals_on_user_id"
   end
 
   create_table "group_invitations", force: :cascade do |t|
@@ -886,6 +919,10 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_27_120002) do
   add_foreign_key "game_results", "pitching_results"
   add_foreign_key "game_results", "seasons", on_delete: :nullify
   add_foreign_key "game_results", "users"
+  add_foreign_key "goal_badges", "goals"
+  add_foreign_key "goal_badges", "users"
+  add_foreign_key "goals", "seasons", on_delete: :nullify
+  add_foreign_key "goals", "users"
   add_foreign_key "group_invitations", "groups"
   add_foreign_key "group_invitations", "users"
   add_foreign_key "group_invite_links", "groups"

--- a/spec/factories/goals.rb
+++ b/spec/factories/goals.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :goal do
+    user
+    title { '今月20日練習' }
+    period_type { 'monthly' }
+    month_start { Time.find_zone('Asia/Tokyo').today.beginning_of_month }
+    deadline { Time.find_zone('Asia/Tokyo').today.end_of_month }
+    metric_key { 'practice_days' }
+    target_value { 20 }
+    comparison_type { 'greater_than' }
+  end
+end

--- a/spec/requests/api/v2/goals_spec.rb
+++ b/spec/requests/api/v2/goals_spec.rb
@@ -67,6 +67,18 @@ RSpec.describe 'Api::V2::Goals', type: :request do
     end
   end
 
+  describe 'PATCH /api/v2/goals/:id' do
+    it '更新で種類（period_type）は変更できない（Pro制限回避防止）' do
+      goal = create(:goal, user:, period_type: 'monthly')
+      patch "/api/v2/goals/#{goal.id}",
+            params: { goal: { period_type: 'season', title: '変更' } },
+            headers: auth_headers_for(user)
+      expect(response).to have_http_status(:ok)
+      expect(goal.reload.period_type).to eq('monthly')
+      expect(goal.title).to eq('変更')
+    end
+  end
+
   describe 'FinalizeGoalsJob' do
     it '期限切れ目標を確定し達成ならバッジ付与' do
       goal = create(:goal, user:, deadline: today - 1, target_value: 1, metric_key: 'practice_days',

--- a/spec/requests/api/v2/goals_spec.rb
+++ b/spec/requests/api/v2/goals_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::Goals', type: :request do
+  let(:user) { create(:user) }
+  let(:today) { Time.find_zone('Asia/Tokyo').today }
+
+  def make_pro(target)
+    target.subscription.update!(status: 'active', expires_at: 1.month.from_now)
+  end
+
+  describe 'GET /api/v2/goals' do
+    context '未認証' do
+      it '401' do
+        get '/api/v2/goals'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    it 'アクティブな目標を進捗付きで返す' do
+      create(:goal, user:, target_value: 20)
+      create(:practice_log, :shadow_swing, user:, logged_on: today, amount: 100)
+      get '/api/v2/goals', headers: auth_headers_for(user)
+      expect(response).to have_http_status(:ok)
+      goal = response.parsed_body.first
+      expect(goal).to have_key('progress_percent')
+      expect(goal).to have_key('current_value')
+      expect(goal['current_value']).to eq(1) # 当日の練習日数 = 1
+    end
+  end
+
+  describe 'POST /api/v2/goals' do
+    let(:params) do
+      { goal: { title: '月20日', period_type: 'monthly', month_start: today.beginning_of_month,
+                deadline: today.end_of_month, metric_key: 'practice_days', target_value: 20 } }
+    end
+
+    it '月次目標を作成する' do
+      post '/api/v2/goals', params:, headers: auth_headers_for(user)
+      expect(response).to have_http_status(:created)
+    end
+
+    context '無料ユーザーが月次3つ目' do
+      before { create_list(:goal, 2, user:) }
+
+      it '403' do
+        post '/api/v2/goals', params:, headers: auth_headers_for(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'シーズン目標' do
+      let(:season_params) do
+        { goal: { title: 'season', period_type: 'season', deadline: today + 30,
+                  metric_key: 'batting_average', target_value: 0.3 } }
+      end
+
+      it '無料は403' do
+        post '/api/v2/goals', params: season_params, headers: auth_headers_for(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'Pro は作成できる' do
+        make_pro(user)
+        post '/api/v2/goals', params: season_params, headers: auth_headers_for(user)
+        expect(response).to have_http_status(:created)
+      end
+    end
+  end
+
+  describe 'FinalizeGoalsJob' do
+    it '期限切れ目標を確定し達成ならバッジ付与' do
+      goal = create(:goal, user:, deadline: today - 1, target_value: 1, metric_key: 'practice_days',
+                           month_start: (today - 1).beginning_of_month)
+      create(:activity_log, user:, activity_date: today - 1, intensity_level: 2)
+
+      expect { FinalizeGoalsJob.new.perform }.to change { user.goal_badges.count }.by(1)
+      expect(goal.reload.is_finalized).to be(true)
+      expect(goal.is_achieved).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
目標設定・達成管理（#323）のバックエンド。**#324 back にスタック**。
Refs ippei-shimizu/buzzbase#323

## 変更内容
- `goals`（period_type=season|monthly, metric_key, target_value, comparison_type, deadline, is_achieved/is_finalized）, `goal_badges`
- `Goals::MetricCalculator`（指標を対象期間で集計: practice_days/total_swing_count/game_count/batting_average/ops/era）＋ `ProgressCalculator`（progress_percent・達成判定。less_than=防御率は反転）
- `FinalizeGoalsJob`（期限到来分をDB確定＋バッジ付与、**push なし**）
- PlanLimits: **月次は無料2つ**（MONTHLY_GOAL 1→2）、**シーズン目標は Pro**（season_goals）
- v2 CRUD＋history、serializer に progress_percent/current_value/days_remaining

## テスト
- `rspec` 7 examples / 0 failures、`rubocop` クリーン
## MVPメモ
- 指標は MVP サブセット。シーズン目標の対象期間はそのシーズンの試合日時の最小〜最大で近似
