### PR TITLE
Add: 打撃推移グラフにシーズン粒度を追加（#322）

### DIFF
--- a/app/controllers/api/v2/stats_controller.rb
+++ b/app/controllers/api/v2/stats_controller.rb
@@ -54,6 +54,11 @@ module Api
       end
 
       def batting_trend
+        # シーズン粒度（シーズン跨ぎ推移）は Pro 限定。既存の試合/月/年/直近10は無料据え置き。
+        if params[:granularity].to_s == 'season' && !current_api_v1_user.has_entitlement?('season_transition_graph')
+          return render json: { error: 'シーズン推移は Pro プラン限定です' }, status: :forbidden
+        end
+
         render json: Stats::BattingTrendAggregator.new(
           **aggregator_params, granularity: params[:granularity]
         ).call

--- a/app/services/stats/batting_trend_aggregator.rb
+++ b/app/services/stats/batting_trend_aggregator.rb
@@ -23,7 +23,7 @@ module Stats
     # - `month`: 月単独（各月でリセット）
     # - `year`: 年単独（シーズン比較）
     # - `recent_games`: 直近 RECENT_GAMES_WINDOW 試合だけを取り出してその中で累積
-    SUPPORTED_GRANULARITIES = %w[game month year recent_games].freeze
+    SUPPORTED_GRANULARITIES = %w[game month year recent_games season].freeze
 
     # 「直近 N 試合」モードの N。短期コンディションの可視化に使うため
     # 10 に固定する（NPB / MLB の hot streak 表示で一般的な値）。
@@ -46,6 +46,7 @@ module Stats
       points = case @granularity
                when 'month' then aggregate_by_month
                when 'year' then aggregate_by_year
+               when 'season' then aggregate_by_season
                when 'recent_games' then aggregate_by_recent_games
                else aggregate_by_game
                end
@@ -90,6 +91,19 @@ module Stats
         build_point(
           key: row[:key],
           label: "#{row[:year]}年",
+          period_stats: row,
+          cumulative_stats: row
+        )
+      end
+    end
+
+    # シーズンごとの SUM をそのまま使い、シーズン単独の打率等を返す（シーズン跨ぎ比較）。
+    # season_id が未割り当ての試合は集計対象外（INNER JOIN seasons）。
+    def aggregate_by_season
+      aggregate_per_season_rows.map do |row|
+        build_point(
+          key: row[:key],
+          label: row[:season_name],
           period_stats: row,
           cumulative_stats: row
         )
@@ -170,6 +184,23 @@ module Stats
         {
           key: format('%<year>04d', year: year.to_i),
           year: year.to_i
+        }.merge(SUM_COLUMNS.zip(values.map(&:to_i)).to_h)
+      end
+    end
+
+    def aggregate_per_season_rows
+      sum_sql = SUM_COLUMNS.map { |col| "SUM(COALESCE(batting_averages.#{col}, 0)) AS #{col}" }.join(', ')
+      rows = filtered_scope
+             .joins('INNER JOIN seasons ON seasons.id = game_results.season_id')
+             .group('seasons.id, seasons.name, seasons.created_at')
+             .order(Arel.sql('seasons.created_at ASC'))
+             .pluck(Arel.sql("seasons.id, seasons.name, #{sum_sql}"))
+
+      rows.map do |row|
+        season_id, season_name, *values = row
+        {
+          key: "season-#{season_id}",
+          season_name:
         }.merge(SUM_COLUMNS.zip(values.map(&:to_i)).to_h)
       end
     end

--- a/spec/requests/api/v2/stats_batting_trend_season_spec.rb
+++ b/spec/requests/api/v2/stats_batting_trend_season_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::Stats batting_trend (season)', type: :request do
+  let(:user) { create(:user) }
+
+  def make_pro(target)
+    target.subscription.update!(status: 'active', expires_at: 1.month.from_now)
+  end
+
+  describe 'GET /api/v2/stats/batting_trend?granularity=season' do
+    context '無料ユーザー' do
+      it 'シーズン粒度は403（Pro限定）' do
+        get '/api/v2/stats/batting_trend', params: { granularity: 'season' }, headers: auth_headers_for(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it '月粒度（既存）は無料でも200' do
+        get '/api/v2/stats/batting_trend', params: { granularity: 'month' }, headers: auth_headers_for(user)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'Pro ユーザー' do
+      before { make_pro(user) }
+
+      it 'シーズン単位の推移を返す' do
+        season = create(:season, user:, name: '2026春')
+        game = create(:game_result, user:, season:)
+        create(:batting_average, game_result: game, user:, at_bats: 4, hit: 2, total_bases: 2)
+
+        get '/api/v2/stats/batting_trend', params: { granularity: 'season' }, headers: auth_headers_for(user)
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body['granularity']).to eq('season')
+        expect(body['points'].first['label']).to eq('2026春')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
シーズン跨ぎ推移グラフ（#322）の打撃側バックエンド。**#323 back にスタック**。
Refs ippei-shimizu/buzzbase#322

## 変更内容
- `BattingTrendAggregator` に `season` 粒度を追加（seasons を join しシーズン単位で集計、ラベルはシーズン名）
- `stats#batting_trend` で **シーズン粒度を Pro ゲート**（season_transition_graph、無料は403）。既存の 試合/月/年/直近10 は無料据え置き
- 自己ベスト強調は points から**クライアント側で算出**するため back 変更なし

## 範囲
- 投手 ERA 推移のシーズン/粒度拡張は**返り値形状の変更を伴うため follow-up**（別PR）。本PRは打撃のシーズン粒度

## テスト
- `rspec` 全 1299 examples / 0 failures、`rubocop` クリーン
