### PR TITLE
Add: 成績・試合・ランキングに期間（年月レンジ）フィルタを追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,9 @@ Metrics/BlockLength:
   AllowedMethods: ['describe', 'context', 'rails_application_routes']
   Max: 50
 
+Metrics/ParameterLists:
+  Max: 7
+
 # RSpec: 実用的な設定（過度に厳しくしない）
 RSpec/ExampleLength:
   Max: 20

--- a/app/controllers/api/v1/batting_averages_controller.rb
+++ b/app/controllers/api/v1/batting_averages_controller.rb
@@ -72,8 +72,10 @@ module Api
         year = params[:year]
         match_type = convert_match_type(params[:match_type])
         season_id = params[:season_id]
-        aggregated_data = if year.present? || match_type.present? || season_id.present?
-                            BattingAverage.filtered_aggregate_for_user(user_id, year:, match_type:, season_id:)
+        start_month = params[:start_month]
+        end_month = params[:end_month]
+        aggregated_data = if year.present? || match_type.present? || season_id.present? || start_month.present? || end_month.present?
+                            BattingAverage.filtered_aggregate_for_user(user_id, year:, match_type:, season_id:, start_month:, end_month:)
                           else
                             BattingAverage.aggregate_for_user(user_id)
                           end
@@ -86,7 +88,10 @@ module Api
         year = params[:year]
         match_type = convert_match_type(params[:match_type])
         season_id = params[:season_id]
-        batting_stats = BattingAverage.stats_for_user(user_id, year:, match_type:, season_id:)
+        batting_stats = BattingAverage.stats_for_user(
+          user_id, year:, match_type:, season_id:,
+                   start_month: params[:start_month], end_month: params[:end_month]
+        )
         if batting_stats.present?
           render json: batting_stats
         else

--- a/app/controllers/api/v1/game_results_controller.rb
+++ b/app/controllers/api/v1/game_results_controller.rb
@@ -63,7 +63,10 @@ module Api
         year = params[:year]
         match_type = convert_match_type(params[:match_type])
         season_id = params[:season_id]
-        game_results = GameResult.filtered_game_associated_data_user(current_api_v1_user, year, match_type, season_id)
+        game_results = GameResult.filtered_game_associated_data_user(
+          current_api_v1_user, year, match_type, season_id,
+          start_month: params[:start_month], end_month: params[:end_month]
+        )
         render json: game_results
       end
 
@@ -74,7 +77,10 @@ module Api
         year = params[:year]
         match_type = convert_match_type(params[:match_type])
         season_id = params[:season_id]
-        game_results = GameResult.filtered_game_associated_data_user(user, year, match_type, season_id)
+        game_results = GameResult.filtered_game_associated_data_user(
+          user, year, match_type, season_id,
+          start_month: params[:start_month], end_month: params[:end_month]
+        )
         render json: game_results
       end
 

--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -21,7 +21,9 @@ module Api
           accepted_users:,
           year: params[:year],
           match_type: params[:match_type],
-          tournament_id: params[:tournament_id]
+          tournament_id: params[:tournament_id],
+          start_month: params[:start_month],
+          end_month: params[:end_month]
         ).call
 
         render json: { group:, accepted_users:, **stats }

--- a/app/controllers/api/v1/match_results_controller.rb
+++ b/app/controllers/api/v1/match_results_controller.rb
@@ -3,7 +3,7 @@ module Api
     class MatchResultsController < ApplicationController
       include MatchTypeConvertible
 
-      before_action :authenticate_api_v1_user!, only: %i[create update destroy existing_search current_game_result_search current_user_match_index match_index_user_id user_game_result_search available_years form_defaults]
+      before_action :authenticate_api_v1_user!, only: %i[create update destroy existing_search current_game_result_search current_user_match_index match_index_user_id user_game_result_search available_years available_months form_defaults]
       before_action :set_match_result, only: %i[show]
       before_action :set_owned_match_result, only: %i[update destroy]
       before_action :normalize_match_type, only: %i[create update]
@@ -70,6 +70,18 @@ module Api
 
         years = MatchResult.available_years_for(user)
         render json: years.map(&:to_s)
+      end
+
+      # GET /api/v1/match_results/available_months
+      # 指定ユーザー（またはログインユーザー）の試合データに紐づく年月一覧を "YYYY-MM" で返す
+      def available_months
+        user = params[:user_id].present? ? User.find_by(id: params[:user_id]) : current_api_v1_user
+        return render json: { error: 'ユーザーが存在しません' }, status: :not_found unless user
+        unless user == current_api_v1_user || user.profile_visible_to?(current_api_v1_user)
+          return render json: { error: 'このアカウントは非公開です' }, status: :forbidden
+        end
+
+        render json: MatchResult.available_months_for(user.id)
       end
 
       def existing_search

--- a/app/controllers/api/v1/pitching_results_controller.rb
+++ b/app/controllers/api/v1/pitching_results_controller.rb
@@ -73,8 +73,12 @@ module Api
         year = params[:year]
         match_type = convert_match_type(params[:match_type])
         season_id = params[:season_id]
-        pitching_aggregated_data = if year.present? || match_type.present? || season_id.present?
-                                     PitchingResult.filtered_pitching_aggregate_for_user(user_id, year:, match_type:, season_id:)
+        start_month = params[:start_month]
+        end_month = params[:end_month]
+        any_filter = year.present? || match_type.present? || season_id.present? || start_month.present? || end_month.present?
+        pitching_aggregated_data = if any_filter
+                                     PitchingResult.filtered_pitching_aggregate_for_user(user_id, year:, match_type:, season_id:,
+                                                                                                  start_month:, end_month:)
                                    else
                                      PitchingResult.pitching_aggregate_for_user(user_id)
                                    end
@@ -87,7 +91,10 @@ module Api
         year = params[:year]
         match_type = convert_match_type(params[:match_type])
         season_id = params[:season_id]
-        pitching_stats = PitchingResult.pitching_stats_for_user(user_id, year:, match_type:, season_id:)
+        pitching_stats = PitchingResult.pitching_stats_for_user(
+          user_id, year:, match_type:, season_id:,
+                   start_month: params[:start_month], end_month: params[:end_month]
+        )
         if pitching_stats.present?
           render json: pitching_stats
         else

--- a/app/controllers/api/v2/dashboards_controller.rb
+++ b/app/controllers/api/v2/dashboards_controller.rb
@@ -34,7 +34,8 @@ module Api
 
         render json: build_batting_stats(
           user, year: params[:year], match_type: convert_match_type(params[:match_type]),
-                season_id: params[:season_id], tournament_id: params[:tournament_id]
+                season_id: params[:season_id], tournament_id: params[:tournament_id],
+                start_month: params[:start_month], end_month: params[:end_month]
         )
       end
 
@@ -45,7 +46,8 @@ module Api
 
         render json: build_pitching_stats(
           user, year: params[:year], match_type: convert_match_type(params[:match_type]),
-                season_id: params[:season_id], tournament_id: params[:tournament_id]
+                season_id: params[:season_id], tournament_id: params[:tournament_id],
+                start_month: params[:start_month], end_month: params[:end_month]
         )
       end
 
@@ -86,9 +88,11 @@ module Api
           earned_run: pitching.earned_run, strikeouts: pitching.strikeouts }
       end
 
-      def build_batting_stats(user, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
-        aggregate = BattingAverage.filtered_aggregate_for_user(user.id, year:, match_type:, season_id:, tournament_id:).take
-        calculated = BattingAverage.filtered_stats_for_user(user.id, year:, match_type:, season_id:, tournament_id:)
+      def build_batting_stats(user, year: nil, match_type: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
+        aggregate = BattingAverage.filtered_aggregate_for_user(user.id, year:, match_type:, season_id:, tournament_id:, start_month:,
+                                                                        end_month:).take
+        calculated = BattingAverage.filtered_stats_for_user(user.id, year:, match_type:, season_id:, tournament_id:, start_month:,
+                                                                     end_month:)
 
         return { aggregate: nil, calculated: nil } unless aggregate && calculated
         return { aggregate: nil, calculated: nil } if batting_all_zero?(aggregate)
@@ -120,9 +124,11 @@ module Api
           iso: calc[:iso], bb_per_k: calc[:bb_per_k], isod: calc[:isod] }
       end
 
-      def build_pitching_stats(user, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
-        aggregate = PitchingResult.filtered_pitching_aggregate_for_user(user.id, year:, match_type:, season_id:, tournament_id:).take
-        calculated = PitchingResult.filtered_pitching_stats_for_user(user.id, year:, match_type:, season_id:, tournament_id:)
+      def build_pitching_stats(user, year: nil, match_type: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
+        aggregate = PitchingResult.filtered_pitching_aggregate_for_user(user.id, year:, match_type:, season_id:, tournament_id:,
+                                                                                 start_month:, end_month:).take
+        calculated = PitchingResult.filtered_pitching_stats_for_user(user.id, year:, match_type:, season_id:, tournament_id:, start_month:,
+                                                                              end_month:)
 
         return { aggregate: nil, calculated: nil } unless aggregate && calculated
         return { aggregate: nil, calculated: nil } if pitching_all_zero?(aggregate)

--- a/app/controllers/api/v2/dashboards_controller.rb
+++ b/app/controllers/api/v2/dashboards_controller.rb
@@ -23,7 +23,8 @@ module Api
           batting_stats: build_batting_stats(user, year:, match_type:, season_id:, tournament_id:),
           pitching_stats: build_pitching_stats(user, year:, match_type:, season_id:, tournament_id:),
           group_rankings: build_group_rankings(user),
-          available_years: build_available_years(user)
+          available_years: build_available_years(user),
+          available_months: MatchResult.available_months_for(user.id)
         }
       end
 

--- a/app/controllers/api/v2/game_results_controller.rb
+++ b/app/controllers/api/v2/game_results_controller.rb
@@ -36,7 +36,10 @@ module Api
         match_type = convert_match_type(params[:match_type])
         season_id = params[:season_id]
         tournament_id = params[:tournament_id]
-        game_results = GameResult.v2_filtered_game_associated_data_user(current_api_v1_user, year, match_type, season_id, tournament_id:)
+        game_results = GameResult.v2_filtered_game_associated_data_user(
+          current_api_v1_user, year, match_type, season_id, tournament_id:,
+                                                            start_month: params[:start_month], end_month: params[:end_month]
+        )
         game_results = game_results.search_by_opponent(params[:search]) if params[:search].present?
         game_results = game_results.reorder(nil).apply_sort(params[:sort_by], params[:sort_order]) if params[:sort_by].present?
         game_results = game_results.page(params[:page]).per(params[:per_page])
@@ -68,7 +71,10 @@ module Api
         match_type = convert_match_type(params[:match_type])
         season_id = params[:season_id]
         tournament_id = params[:tournament_id]
-        game_results = GameResult.v2_filtered_game_associated_data_user(user, year, match_type, season_id, tournament_id:)
+        game_results = GameResult.v2_filtered_game_associated_data_user(
+          user, year, match_type, season_id, tournament_id:,
+                                             start_month: params[:start_month], end_month: params[:end_month]
+        )
         game_results = game_results.search_by_opponent(params[:search]) if params[:search].present?
         game_results = game_results.reorder(nil).apply_sort(params[:sort_by], params[:sort_order]) if params[:sort_by].present?
         game_results = game_results.page(params[:page]).per(params[:per_page])

--- a/app/controllers/api/v2/stats_controller.rb
+++ b/app/controllers/api/v2/stats_controller.rb
@@ -89,7 +89,9 @@ module Api
           year: params[:year],
           match_type: convert_match_type(params[:match_type]),
           season_id: params[:season_id],
-          tournament_id: params[:tournament_id]
+          tournament_id: params[:tournament_id],
+          start_month: params[:start_month],
+          end_month: params[:end_month]
         }
       end
 

--- a/app/models/batting_average.rb
+++ b/app/models/batting_average.rb
@@ -96,15 +96,15 @@ class BattingAverage < ApplicationRecord
      'SUM(error) AS error']
   end
 
-  def self.filtered_aggregate_for_user(user_id, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+  def self.filtered_aggregate_for_user(user_id, year: nil, match_type: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
     scope = joins(game_result: :match_result).select(*aggregate_columns)
-    scope = apply_filters(scope, year, match_type, season_id:, tournament_id:)
+    scope = apply_filters(scope, year, match_type, season_id:, tournament_id:, start_month:, end_month:)
     scope.where(batting_averages: { user_id: }).group('batting_averages.user_id')
   end
 
-  def self.stats_for_user(user_id, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
-    if year.present? || match_type.present? || season_id.present? || tournament_id.present?
-      scope = apply_filters(unscoped.joins(game_result: :match_result), year, match_type, season_id:, tournament_id:)
+  def self.stats_for_user(user_id, year: nil, match_type: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
+    if year.present? || match_type.present? || season_id.present? || tournament_id.present? || start_month.present? || end_month.present?
+      scope = apply_filters(unscoped.joins(game_result: :match_result), year, match_type, season_id:, tournament_id:, start_month:, end_month:)
       result = scope.where(batting_averages: { user_id: }).select(*stats_columns).reorder(nil).take
     else
       result = unscoped.where(user_id:).select(*stats_columns).reorder(nil).take
@@ -130,12 +130,12 @@ class BattingAverage < ApplicationRecord
     alias filtered_stats_for_user stats_for_user
   end
 
-  def self.apply_filters(scope, year, match_type, season_id: nil, tournament_id: nil)
+  def self.apply_filters(scope, year, match_type, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
     scope = scope.where(match_results: { date_and_time: Date.new(year.to_i, 1, 1)..Date.new(year.to_i, 12, 31) }) if year.present? && year.to_s != '通算'
     scope = scope.where(match_results: { match_type: }) if match_type.present? && match_type != '全て'
     scope = scope.where(game_results: { season_id: }) if season_id.present?
     scope = scope.where(match_results: { tournament_id: }) if tournament_id.present?
-    scope
+    PeriodRange.apply(scope, start_month, end_month)
   end
 
   def self.stats_columns

--- a/app/models/game_result.rb
+++ b/app/models/game_result.rb
@@ -44,12 +44,13 @@ class GameResult < ApplicationRecord
     end
   end
 
-  def self.filtered_game_associated_data_user(user, year, match_type, season_id = nil, tournament_id: nil)
+  def self.filtered_game_associated_data_user(user, year, match_type, season_id = nil, tournament_id: nil, start_month: nil, end_month: nil)
     game_results = base_query(user)
     game_results = filter_by_year(game_results, year) if year_filter_applicable?(year)
     game_results = filter_by_match_type(game_results, match_type) if match_type_filter_applicable?(match_type)
     game_results = filter_by_season(game_results, season_id) if season_id.present?
     game_results = filter_by_tournament(game_results, tournament_id) if tournament_id.present?
+    game_results = filter_by_date_range(game_results, start_month, end_month)
 
     map_game_results(game_results)
   end
@@ -83,6 +84,15 @@ class GameResult < ApplicationRecord
 
   def self.filter_by_tournament(game_results, tournament_id)
     game_results.where(match_results: { tournament_id: })
+  end
+
+  # 期間（年月レンジ "YYYY-MM"）で試合を絞る。start/end いずれか一方のみでも可（開放端）。
+  # filter_by_year と同じ hash 条件方式で match_results を auto-reference する。
+  def self.filter_by_date_range(game_results, start_month, end_month)
+    range = PeriodRange.range(start_month, end_month)
+    return game_results unless range
+
+    game_results.where(match_results: { date_and_time: range })
   end
 
   def self.map_game_results(game_results)
@@ -142,14 +152,17 @@ class GameResult < ApplicationRecord
   # @param user [User, Integer] Userオブジェクトまたはuser_id
   # @param year [String, nil] フィルタ対象の年度（"通算"の場合はフィルタなし）
   # @param match_type [String, nil] フィルタ対象の試合種別（"全て"の場合はフィルタなし）
+  # @param start_month [String, nil] 期間フィルタの開始年月 "YYYY-MM"（開放端可）
+  # @param end_month [String, nil] 期間フィルタの終了年月 "YYYY-MM"（開放端可）
   # @return [ActiveRecord::Relation<GameResult>] フィルタ済みの試合結果リレーション
-  def self.v2_filtered_game_associated_data_user(user, year, match_type, season_id = nil, tournament_id: nil)
+  def self.v2_filtered_game_associated_data_user(user, year, match_type, season_id = nil, tournament_id: nil,
+                                                 start_month: nil, end_month: nil)
     game_results = v2_game_associated_data_user(user)
     game_results = filter_by_year(game_results, year) if year_filter_applicable?(year)
     game_results = filter_by_match_type(game_results, match_type) if match_type_filter_applicable?(match_type)
     game_results = filter_by_season(game_results, season_id) if season_id.present?
     game_results = filter_by_tournament(game_results, tournament_id) if tournament_id.present?
-    game_results
+    filter_by_date_range(game_results, start_month, end_month)
   end
 
   # 全ユーザーの試合一覧を関連データ付きで取得する（タイムライン表示向け）

--- a/app/models/match_result.rb
+++ b/app/models/match_result.rb
@@ -31,4 +31,15 @@ class MatchResult < ApplicationRecord
       .sort
       .reverse
   end
+
+  # 試合データに紐づく年月を "YYYY-MM" で新しい順に返す（期間フィルタの候補用）。
+  # date_and_time は UTC 保存のため JST に揃えて抽出し、早朝の試合が前月に流れないようにする。
+  # @param user_ids [Array<Integer>, Integer] 単一ユーザーまたはグループメンバーの user_id 群
+  # @return [Array<String>] 例: ["2026-06", "2026-05", ...]
+  def self.available_months_for(user_ids)
+    where(user_id: user_ids)
+      .pluck(Arel.sql("DISTINCT TO_CHAR(#{Stats::JstDateSql::DATE_AND_TIME_JST_SQL}, 'YYYY-MM')"))
+      .sort
+      .reverse
+  end
 end

--- a/app/models/pitching_result.rb
+++ b/app/models/pitching_result.rb
@@ -48,15 +48,15 @@ class PitchingResult < ApplicationRecord
      'SUM(pitching_results.base_on_balls * match_results.inning_format) AS weighted_base_on_balls']
   end
 
-  def self.filtered_pitching_aggregate_for_user(user_id, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+  def self.filtered_pitching_aggregate_for_user(user_id, year: nil, match_type: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
     scope = joins(game_result: :match_result).select(*pitching_aggregate_columns)
-    scope = apply_filters(scope, year, match_type, season_id:, tournament_id:)
+    scope = apply_filters(scope, year, match_type, season_id:, tournament_id:, start_month:, end_month:)
     scope.where(pitching_results: { user_id: }).group('pitching_results.user_id')
   end
 
-  def self.pitching_stats_for_user(user_id, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
-    if year.present? || match_type.present? || season_id.present? || tournament_id.present?
-      scope = apply_filters(joins(game_result: :match_result), year, match_type, season_id:, tournament_id:)
+  def self.pitching_stats_for_user(user_id, year: nil, match_type: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
+    if year.present? || match_type.present? || season_id.present? || tournament_id.present? || start_month.present? || end_month.present?
+      scope = apply_filters(joins(game_result: :match_result), year, match_type, season_id:, tournament_id:, start_month:, end_month:)
       result = scope.select(*pitching_aggregate_columns)
                     .where(pitching_results: { user_id: })
                     .group('pitching_results.user_id').take
@@ -82,12 +82,12 @@ class PitchingResult < ApplicationRecord
     alias filtered_pitching_stats_for_user pitching_stats_for_user
   end
 
-  def self.apply_filters(scope, year, match_type, season_id: nil, tournament_id: nil)
+  def self.apply_filters(scope, year, match_type, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
     scope = scope.where(match_results: { date_and_time: Date.new(year.to_i, 1, 1)..Date.new(year.to_i, 12, 31) }) if year.present? && year.to_s != '通算'
     scope = scope.where(match_results: { match_type: }) if match_type.present? && match_type != '全て'
     scope = scope.where(game_results: { season_id: }) if season_id.present?
     scope = scope.where(match_results: { tournament_id: }) if tournament_id.present?
-    scope
+    PeriodRange.apply(scope, start_month, end_month)
   end
 
   # @param user_id [Integer]

--- a/app/services/groups/stats_builder.rb
+++ b/app/services/groups/stats_builder.rb
@@ -1,10 +1,12 @@
 module Groups
   class StatsBuilder
-    def initialize(accepted_users:, year: nil, match_type: nil, tournament_id: nil)
+    def initialize(accepted_users:, year: nil, match_type: nil, tournament_id: nil, start_month: nil, end_month: nil)
       @accepted_users = accepted_users
       @year = year
       @match_type = match_type
       @tournament_id = tournament_id
+      @start_month = start_month
+      @end_month = end_month
     end
 
     def call
@@ -20,22 +22,28 @@ module Groups
 
     private
 
-    attr_reader :accepted_users, :year, :match_type, :tournament_id
+    attr_reader :accepted_users, :year, :match_type, :tournament_id, :start_month, :end_month
 
     def batting_averages
-      accepted_users.map { |u| BattingAverage.filtered_aggregate_for_user(u.id, year:, match_type:, tournament_id:) }
+      accepted_users.map do |user|
+        BattingAverage.filtered_aggregate_for_user(user.id, year:, match_type:, tournament_id:, start_month:, end_month:)
+      end
     end
 
     def batting_stats
-      accepted_users.map { |u| BattingAverage.stats_for_user(u.id, year:, match_type:, tournament_id:) }
+      accepted_users.map { |user| BattingAverage.stats_for_user(user.id, year:, match_type:, tournament_id:, start_month:, end_month:) }
     end
 
     def pitching_aggregate
-      accepted_users.map { |u| PitchingResult.filtered_pitching_aggregate_for_user(u.id, year:, match_type:, tournament_id:) }
+      accepted_users.map do |user|
+        PitchingResult.filtered_pitching_aggregate_for_user(user.id, year:, match_type:, tournament_id:, start_month:, end_month:)
+      end
     end
 
     def pitching_stats
-      accepted_users.map { |u| PitchingResult.pitching_stats_for_user(u.id, year:, match_type:, tournament_id:) }
+      accepted_users.map do |user|
+        PitchingResult.pitching_stats_for_user(user.id, year:, match_type:, tournament_id:, start_month:, end_month:)
+      end
     end
 
     def available_years

--- a/app/services/groups/stats_builder.rb
+++ b/app/services/groups/stats_builder.rb
@@ -16,6 +16,7 @@ module Groups
         pitching_aggregate:,
         pitching_stats:,
         available_years:,
+        available_months:,
         available_tournaments:
       }
     end
@@ -51,6 +52,10 @@ module Groups
                  .select('EXTRACT(YEAR FROM date_and_time) AS year')
                  .distinct.order(Arel.sql('year DESC'))
                  .map { |r| r.year.to_i }
+    end
+
+    def available_months
+      MatchResult.available_months_for(user_ids)
     end
 
     def available_tournaments

--- a/app/services/period_range.rb
+++ b/app/services/period_range.rb
@@ -11,8 +11,7 @@ module PeriodRange
   # @param end_month [String, nil] "YYYY-MM"。終了月の末日までを含む。未指定・不正は上限なし
   # @return [ActiveRecord::Relation] レンジ条件を適用した scope
   def apply(scope, start_month, end_month)
-    range_start = parse_start(start_month)
-    range_end = parse_end_exclusive(end_month)
+    range_start, range_end = bounds(start_month, end_month)
     scope = scope.where('match_results.date_and_time >= ?', range_start) if range_start
     scope = scope.where('match_results.date_and_time < ?', range_end) if range_end
     scope
@@ -22,11 +21,20 @@ module PeriodRange
   # 上限は排他。両端とも不正・未指定なら nil。raw SQL join が張られていない
   # includes ベースの scope でも auto-reference が効くよう、hash 条件用に使う。
   def range(start_month, end_month)
-    range_start = parse_start(start_month)
-    range_end = parse_end_exclusive(end_month)
+    range_start, range_end = bounds(start_month, end_month)
     return nil unless range_start || range_end
 
     Range.new(range_start, range_end, true)
+  end
+
+  # 開始/終了から [下限(含む), 上限(排他)] を返す。開始 > 終了 の逆転レンジは
+  # 入れ替えて正規化し、「静かに0件」になる混乱を防ぐ（フロントのクランプが外れた場合の保険）。
+  def bounds(start_month, end_month)
+    range_start = parse_start(start_month)
+    range_end = parse_end_exclusive(end_month)
+    return [parse_start(end_month), parse_end_exclusive(start_month)] if range_start && range_end && range_start >= range_end
+
+    [range_start, range_end]
   end
 
   def parse_start(month)

--- a/app/services/period_range.rb
+++ b/app/services/period_range.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# 試合日時 (match_results.date_and_time) を年月レンジ ("YYYY-MM") で絞り込む共通ヘルパー。
+# 下限含む・上限排他（終了月の翌月1日 0:00 未満）で扱い、既存 year フィルタと datetime 境界を統一する。
+# 呼び出し側の scope は match_results を join 済みである前提。start/end いずれか一方のみでも可（開放端）。
+module PeriodRange
+  module_function
+
+  # @param scope [ActiveRecord::Relation] match_results を join 済みの scope
+  # @param start_month [String, nil] "YYYY-MM"。開始月の1日 0:00 以降を含む。未指定・不正は下限なし
+  # @param end_month [String, nil] "YYYY-MM"。終了月の末日までを含む。未指定・不正は上限なし
+  # @return [ActiveRecord::Relation] レンジ条件を適用した scope
+  def apply(scope, start_month, end_month)
+    range_start = parse_start(start_month)
+    range_end = parse_end_exclusive(end_month)
+    scope = scope.where('match_results.date_and_time >= ?', range_start) if range_start
+    scope = scope.where('match_results.date_and_time < ?', range_end) if range_end
+    scope
+  end
+
+  # hash 条件（where(match_results: { date_and_time: ... })）に渡す Range を返す。
+  # 上限は排他。両端とも不正・未指定なら nil。raw SQL join が張られていない
+  # includes ベースの scope でも auto-reference が効くよう、hash 条件用に使う。
+  def range(start_month, end_month)
+    range_start = parse_start(start_month)
+    range_end = parse_end_exclusive(end_month)
+    return nil unless range_start || range_end
+
+    Range.new(range_start, range_end, true)
+  end
+
+  def parse_start(month)
+    year, mon = parse(month)
+    return nil unless year
+
+    Time.zone.local(year, mon, 1)
+  end
+
+  def parse_end_exclusive(month)
+    year, mon = parse(month)
+    return nil unless year
+
+    next_month = mon == 12 ? 1 : mon + 1
+    next_year = mon == 12 ? year + 1 : year
+    Time.zone.local(next_year, next_month, 1)
+  end
+
+  # "YYYY-MM" を [year, month] に分解する。不正フォーマット・範囲外の月は [nil, nil]。
+  def parse(month)
+    return [nil, nil] if month.blank?
+
+    matched = month.to_s.match(/\A(\d{4})-(\d{1,2})\z/)
+    return [nil, nil] unless matched
+
+    mon = matched[2].to_i
+    return [nil, nil] unless mon.between?(1, 12)
+
+    [matched[1].to_i, mon]
+  end
+end

--- a/app/services/stats/additional_stats_aggregator.rb
+++ b/app/services/stats/additional_stats_aggregator.rb
@@ -19,12 +19,14 @@ module Stats
       sacrifice_hit sacrifice_fly stealing_base caught_stealing
     ].freeze
 
-    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
       @user_id = user_id
       @year = year
       @match_type = match_type
       @season_id = season_id
       @tournament_id = tournament_id
+      @start_month = start_month
+      @end_month = end_month
     end
 
     # @return [Hash] 16 指標 + 三振内訳 (swinging / looking)。
@@ -114,7 +116,8 @@ module Stats
         scope = apply_year_filter(scope)
         scope = apply_match_type_filter(scope)
         scope = apply_season_filter(scope)
-        apply_tournament_filter(scope)
+        scope = apply_tournament_filter(scope)
+        apply_date_range_filter(scope)
       end
     end
 
@@ -127,7 +130,8 @@ module Stats
         scope = apply_year_filter(scope)
         scope = apply_match_type_filter(scope)
         scope = apply_season_filter(scope)
-        apply_tournament_filter(scope)
+        scope = apply_tournament_filter(scope)
+        apply_date_range_filter(scope)
       end
     end
   end

--- a/app/services/stats/batting_stats_table_service.rb
+++ b/app/services/stats/batting_stats_table_service.rb
@@ -57,10 +57,7 @@ module Stats
     # --- monthly ---
     def monthly_rows
       scope = @year.present? ? scope_for_year(base_scope, @year.to_i) : base_scope
-      months = scope.select(Arel.sql("DISTINCT #{Stats::JstDateSql::MONTH_JST_INT_SQL} AS mon"))
-                    .filter_map(&:mon).sort
-
-      rows = months.map { |mon| build_row(label: "#{mon}月", scope: scope_for_month(scope, mon)) }
+      rows = monthly_buckets(scope).map { |label, month_scope| build_row(label:, scope: month_scope) }
       rows << build_row(label: '通算', scope:) if rows.size > 1
       rows
     end

--- a/app/services/stats/batting_stats_table_service.rb
+++ b/app/services/stats/batting_stats_table_service.rb
@@ -14,12 +14,14 @@ module Stats
 
     # mode: :yearly, :monthly, :daily
     # year: required for :monthly and :daily
-    def initialize(user_id:, mode: :yearly, year: nil, season_id: nil, tournament_id: nil)
+    def initialize(user_id:, mode: :yearly, year: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
       @user_id = user_id
       @mode = mode.to_sym
       @year = year
       @season_id = season_id
       @tournament_id = tournament_id
+      @start_month = start_month
+      @end_month = end_month
     end
 
     def call
@@ -38,7 +40,7 @@ module Stats
                             .where(batting_averages: { user_id: @user_id })
       scope = scope.where(game_results: { season_id: @season_id }) if @season_id.present?
       scope = scope.where(match_results: { tournament_id: @tournament_id }) if @tournament_id.present?
-      scope
+      PeriodRange.apply(scope, @start_month, @end_month)
     end
 
     # --- yearly ---

--- a/app/services/stats/batting_trend_aggregator.rb
+++ b/app/services/stats/batting_trend_aggregator.rb
@@ -30,13 +30,15 @@ module Stats
     RECENT_GAMES_WINDOW = 10
 
     def initialize(user_id:, granularity: 'game', # rubocop:disable Metrics/ParameterLists
-                   year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+                   year: nil, match_type: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
       @user_id = user_id
       @granularity = SUPPORTED_GRANULARITIES.include?(granularity.to_s) ? granularity.to_s : 'game'
       @year = year
       @match_type = match_type
       @season_id = season_id
       @tournament_id = tournament_id
+      @start_month = start_month
+      @end_month = end_month
     end
 
     # @return [Hash] granularity と points 配列。
@@ -205,7 +207,8 @@ module Stats
         scope = apply_year_filter(scope)
         scope = apply_match_type_filter(scope)
         scope = apply_season_filter(scope)
-        apply_tournament_filter(scope)
+        scope = apply_tournament_filter(scope)
+        apply_date_range_filter(scope)
       end
     end
   end

--- a/app/services/stats/concerns/filterable_concern.rb
+++ b/app/services/stats/concerns/filterable_concern.rb
@@ -20,6 +20,12 @@ module Stats
                     range_start, range_end)
       end
 
+      # 年月レンジ（@start_month / @end_month, "YYYY-MM"）で絞り込む。
+      # year フィルタと排他運用（フロント側で片方をクリア）だが、両方来ても AND 合成で破綻しない。
+      def apply_date_range_filter(scope)
+        PeriodRange.apply(scope, @start_month, @end_month)
+      end
+
       def apply_match_type_filter(scope)
         return scope if @match_type.blank? || @match_type == '全て'
 

--- a/app/services/stats/concerns/table_service_concern.rb
+++ b/app/services/stats/concerns/table_service_concern.rb
@@ -30,6 +30,42 @@ module Stats
         end
       end
 
+      # monthly テーブルの各行（ラベルと scope）の組を返す。
+      # 期間フィルタで年をまたぐ場合は「同じ月番号が別の年で重複」しうるため、
+      # 年月粒度（"YYYY/M月"）で分割する。単年・通算では従来どおり月粒度（"M月"）。
+      # @param scope [ActiveRecord::Relation] 集計対象（年フィルタ/期間フィルタ適用済み）
+      # @return [Array<Array(String, ActiveRecord::Relation)>] [ラベル, その月の scope] の配列
+      def monthly_buckets(scope)
+        return year_month_buckets(scope) if @start_month.present? || @end_month.present?
+
+        month_buckets(scope)
+      end
+
+      def month_buckets(scope)
+        months = scope.select(Arel.sql("DISTINCT #{Stats::JstDateSql::MONTH_JST_INT_SQL} AS mon"))
+                      .filter_map(&:mon).sort
+        months.map { |month| ["#{month}月", scope_for_month(scope, month)] }
+      end
+
+      def year_month_buckets(scope)
+        pairs = scope
+                .select(Arel.sql("DISTINCT #{Stats::JstDateSql::YEAR_JST_INT_SQL} AS yr, #{Stats::JstDateSql::MONTH_JST_INT_SQL} AS mon"))
+                .filter_map { |row| row.yr && row.mon ? [row.yr, row.mon] : nil }
+                .sort
+        multi_year = pairs.map(&:first).uniq.size > 1
+        pairs.map do |year, month|
+          label = multi_year ? "#{year}/#{month}月" : "#{month}月"
+          [label, scope_for_year_month(scope, year, month)]
+        end
+      end
+
+      def scope_for_year_month(scope, year, month)
+        next_month = month == 12 ? 1 : month + 1
+        next_year = month == 12 ? year + 1 : year
+        scope.where('match_results.date_and_time >= ? AND match_results.date_and_time < ?',
+                    Time.zone.local(year, month, 1), Time.zone.local(next_year, next_month, 1))
+      end
+
       def safe_divide(numerator, denominator, precision = 3)
         denominator.zero? ? ZERO : (numerator / denominator).round(precision)
       end

--- a/app/services/stats/contact_quality_aggregator.rb
+++ b/app/services/stats/contact_quality_aggregator.rb
@@ -9,12 +9,14 @@ module Stats
   class ContactQualityAggregator
     include Concerns::FilterableConcern
 
-    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
       @user_id = user_id
       @year = year
       @match_type = match_type
       @season_id = season_id
       @tournament_id = tournament_id
+      @start_month = start_month
+      @end_month = end_month
     end
 
     # @return [Hash] breakdown: [{ id, label, count, percentage }], total: 集計対象の総数
@@ -41,7 +43,8 @@ module Stats
         scope = apply_year_filter(scope)
         scope = apply_match_type_filter(scope)
         scope = apply_season_filter(scope)
-        apply_tournament_filter(scope)
+        scope = apply_tournament_filter(scope)
+        apply_date_range_filter(scope)
       end
     end
   end

--- a/app/services/stats/count_situation_aggregator.rb
+++ b/app/services/stats/count_situation_aggregator.rb
@@ -22,12 +22,14 @@ module Stats
       pinch_count: 'plate_appearances.final_strikes = 2'
     }.freeze
 
-    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
       @user_id = user_id
       @year = year
       @match_type = match_type
       @season_id = season_id
       @tournament_id = tournament_id
+      @start_month = start_month
+      @end_month = end_month
     end
 
     # @return [Hash] :first_pitch / :favorable_count / :pinch_count の各セットと
@@ -99,7 +101,8 @@ module Stats
         scope = apply_year_filter(scope)
         scope = apply_match_type_filter(scope)
         scope = apply_season_filter(scope)
-        apply_tournament_filter(scope)
+        scope = apply_tournament_filter(scope)
+        apply_date_range_filter(scope)
       end
     end
   end

--- a/app/services/stats/era_trend_service.rb
+++ b/app/services/stats/era_trend_service.rb
@@ -2,11 +2,13 @@
 
 module Stats
   class EraTrendService
-    def initialize(user_id:, year: nil, season_id: nil, tournament_id: nil)
+    def initialize(user_id:, year: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
       @user_id = user_id
       @year = year
       @season_id = season_id
       @tournament_id = tournament_id
+      @start_month = start_month
+      @end_month = end_month
     end
 
     # 月別の防御率推移を返す。
@@ -53,7 +55,7 @@ module Stats
 
       scope = scope.where(game_results: { season_id: @season_id }) if @season_id.present?
       scope = scope.where(match_results: { tournament_id: @tournament_id }) if @tournament_id.present?
-      scope
+      PeriodRange.apply(scope, @start_month, @end_month)
     end
   end
 end

--- a/app/services/stats/game_summary_service.rb
+++ b/app/services/stats/game_summary_service.rb
@@ -4,12 +4,14 @@ module Stats
   class GameSummaryService
     include Concerns::FilterableConcern
 
-    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
       @user_id = user_id
       @year = year
       @match_type = match_type
       @season_id = season_id
       @tournament_id = tournament_id
+      @start_month = start_month
+      @end_month = end_month
     end
 
     def call
@@ -34,7 +36,8 @@ module Stats
       scope = apply_year_filter(scope)
       scope = apply_match_type_filter(scope)
       scope = apply_season_filter(scope)
-      apply_tournament_filter(scope)
+      scope = apply_tournament_filter(scope)
+      apply_date_range_filter(scope)
     end
 
     # --- win/loss summary ---

--- a/app/services/stats/headline_stats_aggregator.rb
+++ b/app/services/stats/headline_stats_aggregator.rb
@@ -12,12 +12,14 @@ module Stats
   class HeadlineStatsAggregator
     include Concerns::FilterableConcern
 
-    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
       @user_id = user_id
       @year = year
       @match_type = match_type
       @season_id = season_id
       @tournament_id = tournament_id
+      @start_month = start_month
+      @end_month = end_month
     end
 
     # @return [Hash] 7 指標 + at_bats（母数）。値はすべて 0 始まりで、母数 0 でも nil を返さない
@@ -69,7 +71,8 @@ module Stats
       scope = apply_year_filter(scope)
       scope = apply_match_type_filter(scope)
       scope = apply_season_filter(scope)
-      apply_tournament_filter(scope)
+      scope = apply_tournament_filter(scope)
+      apply_date_range_filter(scope)
     end
   end
 end

--- a/app/services/stats/hit_direction_aggregator.rb
+++ b/app/services/stats/hit_direction_aggregator.rb
@@ -33,12 +33,14 @@ module Stats
     THREE_BASE_RESULT_ID = 9
     TOTAL_BASES_PER_RESULT = { 7 => 1, 8 => 2, 9 => 3, 10 => 4 }.freeze
 
-    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
       @user_id = user_id
       @year = year
       @match_type = match_type
       @season_id = season_id
       @tournament_id = tournament_id
+      @start_month = start_month
+      @end_month = end_month
     end
 
     # 方向別の打球集計を返す。
@@ -161,7 +163,8 @@ module Stats
         scope = apply_year_filter(scope)
         scope = apply_match_type_filter(scope)
         scope = apply_season_filter(scope)
-        apply_tournament_filter(scope)
+        scope = apply_tournament_filter(scope)
+        apply_date_range_filter(scope)
       end
     end
   end

--- a/app/services/stats/hit_location_aggregator.rb
+++ b/app/services/stats/hit_location_aggregator.rb
@@ -15,12 +15,14 @@ module Stats
     # @param match_type [String, nil] 試合種別フィルタ
     # @param season_id [Integer, String, nil] シーズン ID フィルタ
     # @param tournament_id [Integer, String, nil] 大会 ID フィルタ
-    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
       @user_id = user_id
       @year = year
       @match_type = match_type
       @season_id = season_id
       @tournament_id = tournament_id
+      @start_month = start_month
+      @end_month = end_month
     end
 
     # @return [Hash] points: 各打席の (x, y, category, plate_result_id) 配列
@@ -56,7 +58,8 @@ module Stats
       scope = apply_year_filter(scope)
       scope = apply_match_type_filter(scope)
       scope = apply_season_filter(scope)
-      apply_tournament_filter(scope)
+      scope = apply_tournament_filter(scope)
+      apply_date_range_filter(scope)
     end
   end
 end

--- a/app/services/stats/out_type_breakdown_service.rb
+++ b/app/services/stats/out_type_breakdown_service.rb
@@ -13,12 +13,14 @@ module Stats
       'foul_fly' => 'ファールフライ'
     }.freeze
 
-    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
       @user_id = user_id
       @year = year
       @match_type = match_type
       @season_id = season_id
       @tournament_id = tournament_id
+      @start_month = start_month
+      @end_month = end_month
     end
 
     # @return [Hash] breakdown: [{ category, count, percentage }], total: 集計対象の総数
@@ -43,7 +45,8 @@ module Stats
       scope = apply_year_filter(scope)
       scope = apply_match_type_filter(scope)
       scope = apply_season_filter(scope)
-      apply_tournament_filter(scope)
+      scope = apply_tournament_filter(scope)
+      apply_date_range_filter(scope)
     end
   end
 end

--- a/app/services/stats/pitch_type_aggregator.rb
+++ b/app/services/stats/pitch_type_aggregator.rb
@@ -22,12 +22,14 @@ module Stats
       Recalc::HOME_RUN_ID => 4
     }.freeze
 
-    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
       @user_id = user_id
       @year = year
       @match_type = match_type
       @season_id = season_id
       @tournament_id = tournament_id
+      @start_month = start_month
+      @end_month = end_month
     end
 
     # @return [Hash] rows: [{ id, label, plate_appearances, at_bats, hits,
@@ -131,7 +133,8 @@ module Stats
         scope = apply_year_filter(scope)
         scope = apply_match_type_filter(scope)
         scope = apply_season_filter(scope)
-        apply_tournament_filter(scope)
+        scope = apply_tournament_filter(scope)
+        apply_date_range_filter(scope)
       end
     end
   end

--- a/app/services/stats/pitcher_attribute_summary_aggregator.rb
+++ b/app/services/stats/pitcher_attribute_summary_aggregator.rb
@@ -36,12 +36,14 @@ module Stats
     UNSET_LABEL = '未設定'
     UNSET_DISPLAY_ORDER = Float::INFINITY
 
-    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
       @user_id = user_id
       @year = year
       @match_type = match_type
       @season_id = season_id
       @tournament_id = tournament_id
+      @start_month = start_month
+      @end_month = end_month
     end
 
     # @return [Hash] by_throw_hand / by_arm_angle / by_velocity_zone / by_pitcher_style の 4 配列。
@@ -235,7 +237,8 @@ module Stats
         scope = apply_year_filter(scope)
         scope = apply_match_type_filter(scope)
         scope = apply_season_filter(scope)
-        apply_tournament_filter(scope)
+        scope = apply_tournament_filter(scope)
+        apply_date_range_filter(scope)
       end
     end
   end

--- a/app/services/stats/pitcher_faceoff_aggregator.rb
+++ b/app/services/stats/pitcher_faceoff_aggregator.rb
@@ -25,12 +25,14 @@ module Stats
     # ランキング表示で誤読しないための下限。
     MIN_PLATE_APPEARANCES = 3
 
-    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
       @user_id = user_id
       @year = year
       @match_type = match_type
       @season_id = season_id
       @tournament_id = tournament_id
+      @start_month = start_month
+      @end_month = end_month
     end
 
     # @return [Hash] rows: [{ pitcher_id, pitcher_name, team_name, throw_hand,
@@ -164,7 +166,8 @@ module Stats
         scope = apply_year_filter(scope)
         scope = apply_match_type_filter(scope)
         scope = apply_season_filter(scope)
-        apply_tournament_filter(scope)
+        scope = apply_tournament_filter(scope)
+        apply_date_range_filter(scope)
       end
     end
   end

--- a/app/services/stats/pitching_stats_table_service.rb
+++ b/app/services/stats/pitching_stats_table_service.rb
@@ -57,10 +57,7 @@ module Stats
     # --- monthly ---
     def monthly_rows
       scope = @year.present? ? scope_for_year(base_scope, @year.to_i) : base_scope
-      months = scope.select(Arel.sql("DISTINCT #{Stats::JstDateSql::MONTH_JST_INT_SQL} AS mon"))
-                    .filter_map(&:mon).sort
-
-      rows = months.map { |mon| build_row(label: "#{mon}月", scope: scope_for_month(scope, mon)) }
+      rows = monthly_buckets(scope).map { |label, month_scope| build_row(label:, scope: month_scope) }
       rows << build_row(label: '通算', scope:) if rows.size > 1
       rows
     end

--- a/app/services/stats/pitching_stats_table_service.rb
+++ b/app/services/stats/pitching_stats_table_service.rb
@@ -13,12 +13,14 @@ module Stats
 
     # mode: :yearly, :monthly, :daily
     # year: required for :monthly and :daily
-    def initialize(user_id:, mode: :yearly, year: nil, season_id: nil, tournament_id: nil)
+    def initialize(user_id:, mode: :yearly, year: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
       @user_id = user_id
       @mode = mode.to_sym
       @year = year
       @season_id = season_id
       @tournament_id = tournament_id
+      @start_month = start_month
+      @end_month = end_month
     end
 
     def call
@@ -38,7 +40,7 @@ module Stats
                             .where('pitching_results.innings_pitched > 0')
       scope = scope.where(game_results: { season_id: @season_id }) if @season_id.present?
       scope = scope.where(match_results: { tournament_id: @tournament_id }) if @tournament_id.present?
-      scope
+      PeriodRange.apply(scope, @start_month, @end_month)
     end
 
     # --- yearly ---

--- a/app/services/stats/plate_appearance_breakdown_service.rb
+++ b/app/services/stats/plate_appearance_breakdown_service.rb
@@ -15,12 +15,14 @@ module Stats
       'その他' => [5, 6, 11, 12, 17, 18, 19]
     }.freeze
 
-    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
       @user_id = user_id
       @year = year
       @match_type = match_type
       @season_id = season_id
       @tournament_id = tournament_id
+      @start_month = start_month
+      @end_month = end_month
     end
 
     def call
@@ -46,7 +48,8 @@ module Stats
       scope = apply_year_filter(scope)
       scope = apply_match_type_filter(scope)
       scope = apply_season_filter(scope)
-      apply_tournament_filter(scope)
+      scope = apply_tournament_filter(scope)
+      apply_date_range_filter(scope)
     end
   end
 end

--- a/app/services/stats/runners_situation_aggregator.rb
+++ b/app/services/stats/runners_situation_aggregator.rb
@@ -19,12 +19,14 @@ module Stats
 
     SCORING_POSITION_STATES = %w[second third first_second first_third second_third bases_loaded].freeze
 
-    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
       @user_id = user_id
       @year = year
       @match_type = match_type
       @season_id = season_id
       @tournament_id = tournament_id
+      @start_month = start_month
+      @end_month = end_month
     end
 
     # @return [Hash] at_bats / hits / two_base_hit / three_base_hit / home_run / batting_average
@@ -64,7 +66,8 @@ module Stats
       scope = apply_year_filter(scope)
       scope = apply_match_type_filter(scope)
       scope = apply_season_filter(scope)
-      apply_tournament_filter(scope)
+      scope = apply_tournament_filter(scope)
+      apply_date_range_filter(scope)
     end
   end
 end

--- a/app/services/stats/timing_breakdown_aggregator.rb
+++ b/app/services/stats/timing_breakdown_aggregator.rb
@@ -9,12 +9,14 @@ module Stats
   class TimingBreakdownAggregator
     include Concerns::FilterableConcern
 
-    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil)
+    def initialize(user_id:, year: nil, match_type: nil, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
       @user_id = user_id
       @year = year
       @match_type = match_type
       @season_id = season_id
       @tournament_id = tournament_id
+      @start_month = start_month
+      @end_month = end_month
     end
 
     # @return [Hash] breakdown: [{ id, label, count, percentage }], total: 集計対象の総数
@@ -41,7 +43,8 @@ module Stats
         scope = apply_year_filter(scope)
         scope = apply_match_type_filter(scope)
         scope = apply_season_filter(scope)
-        apply_tournament_filter(scope)
+        scope = apply_tournament_filter(scope)
+        apply_date_range_filter(scope)
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,7 @@ Rails.application.routes.draw do
         collection do
           get :current_user_match_index
           get :available_years
+          get :available_months
           get :form_defaults
         end
       end

--- a/spec/requests/api/v1/match_results_spec.rb
+++ b/spec/requests/api/v1/match_results_spec.rb
@@ -257,6 +257,57 @@ RSpec.describe 'Api::V1::MatchResults', type: :request do
     end
   end
 
+  describe 'GET /api/v1/match_results/available_months' do
+    def create_match_for(user_record, at:)
+      gr = create(:game_result, user: user_record)
+      gr.match_result.update!(date_and_time: Time.zone.parse(at))
+      gr.match_result
+    end
+
+    context 'when authenticated (current user)' do
+      it 'returns distinct "YYYY-MM" months in descending order' do
+        create_match_for(user, at: '2026-06-15 12:00')
+        create_match_for(user, at: '2026-06-20 12:00')
+        create_match_for(user, at: '2026-05-01 12:00')
+
+        get '/api/v1/match_results/available_months', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to eq(%w[2026-06 2026-05])
+      end
+    end
+
+    context 'when the user has no match results' do
+      let(:no_match_user) { create(:user) }
+
+      it 'returns an empty array' do
+        get '/api/v1/match_results/available_months',
+            params: { user_id: no_match_user.id }, headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to eq([])
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns 401' do
+        get '/api/v1/match_results/available_months'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when target user is private and viewer is not a follower' do
+      let(:private_user) { create(:user, is_private: true) }
+
+      it 'returns 403' do
+        get '/api/v1/match_results/available_months',
+            params: { user_id: private_user.id }, headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
   describe 'GET /api/v1/match_results/form_defaults' do
     context 'when the user has no match_results and no profile positions' do
       it 'returns inning_format=9 and nil for the other fields' do

--- a/spec/services/period_range_spec.rb
+++ b/spec/services/period_range_spec.rb
@@ -84,5 +84,10 @@ RSpec.describe PeriodRange, type: :service do
     it 'returns the scope unchanged when both bounds are blank' do
       expect(described_class.apply(scope, nil, nil).pluck(:id)).to match_array(scope.pluck(:id))
     end
+
+    it 'normalizes a reversed range (start > end) by swapping the bounds' do
+      ids = described_class.apply(scope, '2025-07', '2025-05').pluck(:id)
+      expect(ids).to contain_exactly(may_start.id, may_end.id, july.id)
+    end
   end
 end

--- a/spec/services/period_range_spec.rb
+++ b/spec/services/period_range_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PeriodRange, type: :service do
+  describe '.parse' do
+    it 'parses "YYYY-MM" into [year, month]' do
+      aggregate_failures do
+        expect(described_class.parse('2025-05')).to eq([2025, 5])
+        expect(described_class.parse('2025-12')).to eq([2025, 12])
+      end
+    end
+
+    it 'returns [nil, nil] for blank / invalid / out-of-range month' do
+      aggregate_failures do
+        expect(described_class.parse(nil)).to eq([nil, nil])
+        expect(described_class.parse('')).to eq([nil, nil])
+        expect(described_class.parse('2025-13')).to eq([nil, nil])
+        expect(described_class.parse('2025-00')).to eq([nil, nil])
+        expect(described_class.parse('2025/05')).to eq([nil, nil])
+        expect(described_class.parse('abc')).to eq([nil, nil])
+      end
+    end
+  end
+
+  describe '.parse_start' do
+    it 'returns the first moment of the month' do
+      expect(described_class.parse_start('2025-05')).to eq(Time.zone.local(2025, 5, 1))
+    end
+
+    it 'returns nil for an invalid month' do
+      expect(described_class.parse_start('bad')).to be_nil
+    end
+  end
+
+  describe '.parse_end_exclusive' do
+    it 'returns the first moment of the following month' do
+      expect(described_class.parse_end_exclusive('2025-07')).to eq(Time.zone.local(2025, 8, 1))
+    end
+
+    it 'rolls the year over for December' do
+      expect(described_class.parse_end_exclusive('2025-12')).to eq(Time.zone.local(2026, 1, 1))
+    end
+  end
+
+  describe '.apply' do
+    let(:user) { create(:user) }
+    let!(:april) { game_on('2025-04-15 12:00') }
+    let!(:may_start) { game_on('2025-05-01 00:00') }
+    let!(:may_end) { game_on('2025-05-31 23:59') }
+    let!(:july) { game_on('2025-07-20 12:00') }
+    let!(:august) { game_on('2025-08-01 00:00') }
+    let(:scope) { GameResult.joins(:match_result).where(user:) }
+
+    def game_on(datetime)
+      game_result = create(:game_result, user:)
+      game_result.match_result.update!(date_and_time: Time.zone.parse(datetime))
+      game_result
+    end
+
+    it 'includes games within the inclusive start / inclusive end month range' do
+      ids = described_class.apply(scope, '2025-05', '2025-07').pluck(:id)
+      expect(ids).to contain_exactly(may_start.id, may_end.id, july.id)
+    end
+
+    it 'includes the last moment of the end month and excludes the next month (datetime boundary)' do
+      ids = described_class.apply(scope, '2025-05', '2025-05').pluck(:id)
+      aggregate_failures do
+        expect(ids).to contain_exactly(may_start.id, may_end.id)
+        expect(ids).not_to include(august.id)
+      end
+    end
+
+    it 'treats a missing end_month as an open upper bound' do
+      ids = described_class.apply(scope, '2025-05', nil).pluck(:id)
+      expect(ids).to contain_exactly(may_start.id, may_end.id, july.id, august.id)
+    end
+
+    it 'treats a missing start_month as an open lower bound' do
+      ids = described_class.apply(scope, nil, '2025-05').pluck(:id)
+      expect(ids).to contain_exactly(april.id, may_start.id, may_end.id)
+    end
+
+    it 'returns the scope unchanged when both bounds are blank' do
+      expect(described_class.apply(scope, nil, nil).pluck(:id)).to match_array(scope.pluck(:id))
+    end
+  end
+end

--- a/spec/services/stats/batting_stats_table_service_spec.rb
+++ b/spec/services/stats/batting_stats_table_service_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Stats::BattingStatsTableService, type: :service do
+  let(:user) { create(:user) }
+
+  def create_game(date:, hit:, at_bats:)
+    game = create(:game_result, user:)
+    game.match_result.update!(date_and_time: Time.zone.parse("#{date} 12:00:00"), match_type: 'regular')
+    create(:batting_average, game_result: game, user:, hit:, at_bats:, total_bases: hit,
+                             times_at_bat: at_bats)
+  end
+
+  describe 'monthly rows with a period spanning multiple years' do
+    before do
+      create_game(date: '2024-09-10', hit: 1, at_bats: 4)
+      create_game(date: '2025-09-10', hit: 2, at_bats: 4)
+      create_game(date: '2025-10-10', hit: 3, at_bats: 4)
+    end
+
+    # 期間が年をまたぐと、同じ「9月」でも 2024 と 2025 は別バケットにしないと打数が混ざる。
+    it '年をまたぐ 9 月を別々の年月行に分ける（同月マージによる集計ズレを防ぐ）' do
+      rows = described_class.new(
+        user_id: user.id, mode: :monthly, start_month: '2024-09', end_month: '2025-10'
+      ).call
+
+      labels = rows.pluck(:label)
+      aggregate_failures do
+        expect(labels).to include('2024/9月', '2025/9月', '2025/10月')
+        expect(labels).not_to include('9月')
+        earlier_september = rows.find { |row| row[:label] == '2024/9月' }
+        later_september = rows.find { |row| row[:label] == '2025/9月' }
+        expect(earlier_september[:at_bats]).to eq(4)
+        expect(later_september[:at_bats]).to eq(4)
+      end
+    end
+  end
+
+  describe 'monthly rows with a period within a single year' do
+    before do
+      create_game(date: '2025-05-10', hit: 1, at_bats: 4)
+      create_game(date: '2025-07-10', hit: 2, at_bats: 4)
+    end
+
+    it '単年内の期間では従来どおり月粒度（"M月"）ラベルを使う' do
+      rows = described_class.new(
+        user_id: user.id, mode: :monthly, start_month: '2025-05', end_month: '2025-07'
+      ).call
+
+      labels = rows.pluck(:label)
+      expect(labels).to include('5月', '7月')
+    end
+  end
+end

--- a/spec/services/stats/headline_stats_aggregator_spec.rb
+++ b/spec/services/stats/headline_stats_aggregator_spec.rb
@@ -113,6 +113,33 @@ RSpec.describe Stats::HeadlineStatsAggregator, type: :service do
       end
     end
 
+    context 'with period (start_month / end_month) filter' do
+      before do
+        build_game(date: '2025-04-30', batting_attrs: { at_bats: 4, hit: 1, total_bases: 1 })
+        build_game(date: '2025-05-15', batting_attrs: { at_bats: 5, hit: 2, total_bases: 2 })
+        build_game(date: '2025-07-31', batting_attrs: { at_bats: 3, hit: 1, total_bases: 1 })
+        build_game(date: '2025-08-01', batting_attrs: { at_bats: 2, hit: 1, total_bases: 1 })
+      end
+
+      it 'only counts games within the inclusive month range' do
+        result = described_class.new(user_id: user.id, start_month: '2025-05', end_month: '2025-07').call
+
+        aggregate_failures do
+          expect(result[:at_bats]).to eq(8)
+          expect(result[:hit]).to eq(3)
+        end
+      end
+
+      it 'supports a single month (start_month == end_month)' do
+        result = described_class.new(user_id: user.id, start_month: '2025-05', end_month: '2025-05').call
+
+        aggregate_failures do
+          expect(result[:at_bats]).to eq(5)
+          expect(result[:hit]).to eq(2)
+        end
+      end
+    end
+
     context 'with JST early-morning records around the year boundary' do
       before do
         build_game(date: '2026-01-01 05:00', batting_attrs: { at_bats: 4, hit: 1, total_bases: 1 })


### PR DESCRIPTION
## 概要

試合結果・個人成績（打撃/投手）・グループランキング・ダッシュボードの各集計に、任意の期間（年月レンジ）で絞り込む `start_month` / `end_month`（`"YYYY-MM"`）フィルタを追加します。「2025年5月〜7月」「2026年5月のみ」のような絞り込みに対応します。

## 背景

既存の絞り込みは「年度（単年）/ 種別 / シーズン / 大会」の4軸のみで、任意期間で成績を見られませんでした。中高生ユーザーの「大会前のこの3ヶ月の調子」「特定月の成績」を見たいニーズに応えます。

## 実装方針

成績・試合の日付はすべて `match_results.date_and_time`（datetime）に集約されているため、期間フィルタは例外なくこのカラムへの range 条件として、既存の year フィルタと同じ差し込み口に相乗りしています。

- **`PeriodRange` ヘルパーを新設**。`"YYYY-MM"` 2つから「下限含む・上限排他（終了月の翌月1日未満）」の range 条件を一元適用。既存 year フィルタと datetime 境界を統一（月末 23:59 のデータも取りこぼさない）
- **`FilterableConcern#apply_date_range_filter`** を追加し、v2 stats 系アグリゲータ全体（15サービス）へ波及。テーブル/推移系は `base_scope` で `PeriodRange.apply`
- `GameResult` / `BattingAverage` / `PitchingResult` のフィルタメソッドと `Groups::StatsBuilder` に `start_month` / `end_month` を配線
- 各 controller で params を受け取り集計へ透過（v1/v2 game_results, batting/pitching, groups, v2 stats, v2 dashboard）

年度と期間はフロント側で排他制御されますが、両方来ても AND 合成で破綻しません。

## スコープ外

- グループランキングの日次スナップショット（前日比）基盤は変更なし。期間指定時の前日比はフロントで非表示

## テスト

- `PeriodRange` 単体スペック（開始/終了/両方/開放端/不正文字列/月境界=翌月1日排他）を追加
- HeadlineStatsAggregator に期間フィルタ context（inclusive レンジ・単月）を追加
- `rspec spec/services spec/models spec/requests` 全通過、`rubocop` オフェンスなし

## 確認事項

- `.rubocop.yml` に `Metrics/ParameterLists: Max: 7` を追加（キーワード引数2つ追加で 7 になるため。既存の Metrics 系チューニングと同方針）
