### PR TITLE
Fix: Herokuデプロイの release プロセスがハングする問題を修正

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,14 +20,21 @@ jobs:
         run: |
           echo ${{ secrets.HEROKU_API_KEY }} | docker login --username=_ --password-stdin registry.heroku.com
 
+      # コンテナ（Docker）デプロイでは Procfile は無視され、各プロセスはイメージの CMD で起動する。
+      # web はそのまま（CMD=rails server）、release プロセス用は CMD を db:migrate に上書きした
+      # 別イメージをビルドする。web と同じ CMD のままだと release phase で Puma が常駐して
+      # リリースが完了せずハングする。
       - name: Build and Push Docker image
+        env:
+          HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
         run: |
-          docker build -t registry.heroku.com/${{ secrets.HEROKU_APP_NAME }}/web .
-          docker tag registry.heroku.com/${{ secrets.HEROKU_APP_NAME }}/web registry.heroku.com/${{ secrets.HEROKU_APP_NAME }}/release
-          docker push registry.heroku.com/${{ secrets.HEROKU_APP_NAME }}/web
-          docker push registry.heroku.com/${{ secrets.HEROKU_APP_NAME }}/release
+          docker build -t "registry.heroku.com/$HEROKU_APP_NAME/web" .
+          docker push "registry.heroku.com/$HEROKU_APP_NAME/web"
+          printf 'FROM registry.heroku.com/%s/web\nCMD ["./bin/rails", "db:migrate"]\n' "$HEROKU_APP_NAME" > Dockerfile.release
+          docker build -f Dockerfile.release -t "registry.heroku.com/$HEROKU_APP_NAME/release" .
+          docker push "registry.heroku.com/$HEROKU_APP_NAME/release"
 
-      # web の公開前に release プロセス（Procfile の `release: rails db:migrate`）が実行される。
+      # web の公開前に release プロセス（db:migrate）が実行される。
       # マイグレーション失敗時はリリースが中止され、新カラム不在のまま新コードが公開される事故を防ぐ。
       - name: Release to Heroku
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,14 +30,17 @@ jobs:
         run: |
           docker build -t "registry.heroku.com/$HEROKU_APP_NAME/web" .
           docker push "registry.heroku.com/$HEROKU_APP_NAME/web"
-          printf 'FROM registry.heroku.com/%s/web\nCMD ["./bin/rails", "db:migrate"]\n' "$HEROKU_APP_NAME" > Dockerfile.release
-          docker build -f Dockerfile.release -t "registry.heroku.com/$HEROKU_APP_NAME/release" .
+          # release プロセス用: web イメージの CMD を db:migrate に上書きした別イメージ。
+          # FROM は直前にビルドしたローカルの web を参照し、COPY が無いのでコンテキストは空（stdin）で十分。
+          printf 'FROM registry.heroku.com/%s/web\nCMD ["./bin/rails", "db:migrate"]\n' "$HEROKU_APP_NAME" \
+            | docker build -t "registry.heroku.com/$HEROKU_APP_NAME/release" -
           docker push "registry.heroku.com/$HEROKU_APP_NAME/release"
 
       # web の公開前に release プロセス（db:migrate）が実行される。
       # マイグレーション失敗時はリリースが中止され、新カラム不在のまま新コードが公開される事故を防ぐ。
       - name: Release to Heroku
-        run: |
-          heroku container:release web release --app ${{ secrets.HEROKU_APP_NAME }}
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+          HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
+        run: |
+          heroku container:release web release --app "$HEROKU_APP_NAME"


### PR DESCRIPTION
## 概要

Heroku デプロイの release phase が完了せずハングする問題を修正します。

## 原因

Heroku の **コンテナ（Docker）デプロイでは Procfile が無視され、各プロセスは Docker イメージの CMD で起動**します。ビルドステップは release イメージを web イメージのコピー（`docker tag`）としてタグ付けしているだけで、CMD が web と同じ `["./bin/rails", "server"]` のままでした。

そのため `heroku container:release web release` の release phase で **release プロセスが `rails server`（Puma）を起動して常駐 → リリースが完了せず、CLI が待ち続けてハング**していました（実ログでも release command として Puma が起動していることを確認）。

`4468575「Herokuデプロイを Release Phase 化」` で `container:release web` → `web release` に変更し release プロセスを追加したのが発火点です（それ以前は web のみで release phase が無く問題なし）。

## 修正

release プロセス用に **CMD を `db:migrate` に上書きした別イメージ**をビルドしてから push するようにします（`docker tag` では CMD を変更できないため別ビルドが必要）。ENTRYPOINT (`bin/docker-entrypoint`) は本番で `exec "$@"` するだけなので、release イメージは `rails db:migrate` を実行して**終了**し、release phase が正しく完了します。web は従来どおり `rails server`。

- あわせて誤解を招くコメント（「Procfile の release: rails db:migrate が実行される」）を実態に合わせて修正。
- app 名は best practice に従い `env:` 経由で渡すよう整理。

## 補足（マージ後の初回デプロイ）

このデプロイ経路（main.yml）は main への push で走るため、stg → main へ反映されて初めて有効になります。今回ハングした #306 相当のデプロイは、未適用マイグレーションが無ければ web のみのリリース（`heroku container:release web`）で即時復旧できます（本修正マージ後は release phase も正常動作します）。
