### PR TITLE
Add: マイページ個人成績に大会フィルタのparamを配線

### DIFF
--- a/app/controllers/api/v1/batting_averages_controller.rb
+++ b/app/controllers/api/v1/batting_averages_controller.rb
@@ -72,10 +72,15 @@ module Api
         year = params[:year]
         match_type = convert_match_type(params[:match_type])
         season_id = params[:season_id]
+        tournament_id = params[:tournament_id]
         start_month = params[:start_month]
         end_month = params[:end_month]
-        aggregated_data = if year.present? || match_type.present? || season_id.present? || start_month.present? || end_month.present?
-                            BattingAverage.filtered_aggregate_for_user(user_id, year:, match_type:, season_id:, start_month:, end_month:)
+        any_filter = year.present? || match_type.present? || season_id.present? ||
+                     tournament_id.present? || start_month.present? || end_month.present?
+        aggregated_data = if any_filter
+                            BattingAverage.filtered_aggregate_for_user(
+                              user_id, year:, match_type:, season_id:, tournament_id:, start_month:, end_month:
+                            )
                           else
                             BattingAverage.aggregate_for_user(user_id)
                           end
@@ -89,7 +94,7 @@ module Api
         match_type = convert_match_type(params[:match_type])
         season_id = params[:season_id]
         batting_stats = BattingAverage.stats_for_user(
-          user_id, year:, match_type:, season_id:,
+          user_id, year:, match_type:, season_id:, tournament_id: params[:tournament_id],
                    start_month: params[:start_month], end_month: params[:end_month]
         )
         if batting_stats.present?

--- a/app/controllers/api/v1/pitching_results_controller.rb
+++ b/app/controllers/api/v1/pitching_results_controller.rb
@@ -73,12 +73,15 @@ module Api
         year = params[:year]
         match_type = convert_match_type(params[:match_type])
         season_id = params[:season_id]
+        tournament_id = params[:tournament_id]
         start_month = params[:start_month]
         end_month = params[:end_month]
-        any_filter = year.present? || match_type.present? || season_id.present? || start_month.present? || end_month.present?
+        any_filter = year.present? || match_type.present? || season_id.present? ||
+                     tournament_id.present? || start_month.present? || end_month.present?
         pitching_aggregated_data = if any_filter
-                                     PitchingResult.filtered_pitching_aggregate_for_user(user_id, year:, match_type:, season_id:,
-                                                                                                  start_month:, end_month:)
+                                     PitchingResult.filtered_pitching_aggregate_for_user(
+                                       user_id, year:, match_type:, season_id:, tournament_id:, start_month:, end_month:
+                                     )
                                    else
                                      PitchingResult.pitching_aggregate_for_user(user_id)
                                    end
@@ -92,7 +95,7 @@ module Api
         match_type = convert_match_type(params[:match_type])
         season_id = params[:season_id]
         pitching_stats = PitchingResult.pitching_stats_for_user(
-          user_id, year:, match_type:, season_id:,
+          user_id, year:, match_type:, season_id:, tournament_id: params[:tournament_id],
                    start_month: params[:start_month], end_month: params[:end_month]
         )
         if pitching_stats.present?


### PR DESCRIPTION
## 概要

マイページ成績タブ（個人成績）で大会フィルタを効かせるため、v1 の個人成績エンドポイントが `tournament_id` を拾ってモデルへ渡すよう配線する。

フロント側（`ippei-shimizu/buzzbase_front` の `fix/tournament-filter-user-scope`）でマイページ成績タブに大会 FilterChip を追加し、personal 系フックが `tournament_id` を送るようになったが、バックエンドの personal 系アクションだけが未対応だった。

## 変更点

- `batting_averages#personal_batting_average` / `#personal_batting_stats`
- `pitching_results#personal_pitching_result` / `#personal_pitching_stats`

いずれも既存の `season_id` / `start_month` / `end_month` と同じパターンで `params[:tournament_id]` を受け取り、モデルメソッド（`filtered_aggregate_for_user` / `stats_for_user` / `filtered_pitching_aggregate_for_user` / `pitching_stats_for_user`）へ渡す。モデル側は `tournament_id` 対応済みのため変更なし。

## 動作

- 大会未指定時は従来どおり（`any_filter` が false なら非フィルタ集計）。
- 大会候補はフロントが `/api/v1/tournaments/user_tournaments` から取得（記録した大会のみ）。

## テスト

既存の personal 系リクエストスペックで回帰を確認（CI）。ロジックは他フィルタと同一経路。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
