### PR TITLE
Fix: ユーザー作成済み球場のFK違反でアカウント削除が失敗する不具合を修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,8 @@ class User < ActiveRecord::Base
   has_many :pitching_results, dependent: :destroy
   has_many :plate_appearances, dependent: :destroy
   has_many :created_pitchers, class_name: 'Pitcher', foreign_key: 'created_by_user_id', dependent: :destroy, inverse_of: :created_by_user
+  # 球場は match_results から共有参照される共有リソースのため、作成者削除時は破棄せず created_by_user_id を NULL にする
+  has_many :created_stadiums, class_name: 'Stadium', foreign_key: 'created_by_user_id', dependent: :nullify, inverse_of: :created_by_user
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -126,6 +126,20 @@ RSpec.describe 'Api::V1::Users', type: :request do
       end
     end
 
+    # 作成した球場は共有リソースのため、作成者削除時に破棄せず created_by_user_id を NULL 化する回帰テスト
+    context 'when user has created a stadium' do
+      it 'destroys the user and keeps the stadium with a null creator' do
+        stadium = create(:stadium, created_by_user: user)
+
+        delete '/api/v1/user', headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(User.exists?(user.id)).to be(false)
+        expect(Stadium.exists?(stadium.id)).to be(true)
+        expect(stadium.reload.created_by_user_id).to be_nil
+      end
+    end
+
     context 'when destroy! raises an unexpected error' do
       it 'returns 500 with a localized message instead of leaking the exception' do
         # Devise が返す current_api_v1_user を直接掴めないため any_instance を許可


### PR DESCRIPTION
## 概要

球場を作成したことがあるユーザーがアカウント削除を実行すると、`PG::ForeignKeyViolation` で削除に失敗する不具合を修正します。

Sentry で `Api::V1::UsersController#destroy` が本番で発生していました。

## 原因

- `stadiums.created_by_user_id` は `users` への外部キー `fk_rails_6c9b93f78b` を持つが `on_delete` 指定がなく、PostgreSQL のデフォルト RESTRICT 動作になっている
- `Stadium` は `belongs_to :created_by_user, optional: true` を持つが、`User` 側に対応する `has_many ... dependent:` の宣言が漏れていた
- そのため球場を作成したユーザーが `destroy!` すると、参照が残ったまま `DELETE FROM users` が FK 違反で ROLLBACK していた

同じユーザー作成リソースでも `pitchers` は `has_many :created_pitchers, dependent: :destroy` があり問題は起きていなかった。

## 対応

`User` に以下を追加:

```ruby
has_many :created_stadiums, class_name: 'Stadium', foreign_key: 'created_by_user_id',
                            dependent: :nullify, inverse_of: :created_by_user
```

球場は `match_results` から共有参照される共有リソースのため、`destroy`（連鎖削除）ではなく `nullify`（作成者のみ NULL 化）を採用。これにより:

- ユーザーは削除できる
- 球場データは残り、他ユーザーも引き続き利用できる
- その球場を参照する `match_results` は影響を受けない

## テスト

`spec/requests/api/v1/users_spec.rb` に回帰テストを追加。ユーザー削除後も球場が残り `created_by_user_id` が NULL になることを検証。

- `docker compose exec back bundle exec rspec spec/requests/api/v1/users_spec.rb` → 12 examples, 0 failures
- `docker compose exec back bundle exec rubocop` → no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
