### PR TITLE
Add: 練習ログに schedule_id を追加し予定単位で「済」を判定できるようにする

### DIFF
--- a/app/controllers/api/v2/plans_controller.rb
+++ b/app/controllers/api/v2/plans_controller.rb
@@ -12,7 +12,7 @@ module Api
 
         render json: plans_on(date),
                each_serializer: ::V2::PlanSerializer,
-               done_menu_ids: done_practice_menu_ids_on(date),
+               done_menu_ids: done_menu_ids_by_schedule_on(date),
                status: :ok
       end
 
@@ -55,8 +55,19 @@ module Api
           .sort_by { |schedule| schedule.scheduled_time&.strftime('%H:%M') || '99:99' }
       end
 
-      def done_practice_menu_ids_on(date)
-        current_api_v1_user.practice_logs.where(logged_on: date).pluck(:practice_menu_id).compact.to_set
+      # 予定（schedule）単位で「済」を判定するため、当日ログを schedule_id ごとの
+      # practice_menu_id 集合に畳み込む。schedule_id を持たないログ（フル記録・素振り等）は
+      # どの予定にも紐づかないため除外する。
+      # @return [Hash{Integer => Set<Integer>}]
+      def done_menu_ids_by_schedule_on(date)
+        current_api_v1_user.practice_logs
+                           .where(logged_on: date)
+                           .where.not(schedule_id: nil)
+                           .where.not(practice_menu_id: nil)
+                           .pluck(:schedule_id, :practice_menu_id)
+                           .each_with_object(Hash.new { |hash, key| hash[key] = Set.new }) do |(schedule_id, practice_menu_id), acc|
+          acc[schedule_id] << practice_menu_id
+        end
       end
     end
   end

--- a/app/controllers/api/v2/practice_logs_controller.rb
+++ b/app/controllers/api/v2/practice_logs_controller.rb
@@ -15,9 +15,12 @@ module Api
 
       def create
         menu = current_api_v1_user.practice_menus.find(practice_log_params[:practice_menu_id])
+        # schedule_id は「今日のやること」の予定単位で done を判定するために持つ。他人の予定は弾く。
+        schedule = current_api_v1_user.schedules.find(practice_log_params[:schedule_id]) if practice_log_params[:schedule_id].present?
         log = current_api_v1_user.practice_logs.build(
-          practice_log_params.except(:practice_menu_id).merge(
+          practice_log_params.except(:practice_menu_id, :schedule_id).merge(
             practice_menu: menu,
+            schedule:,
             menu_name: menu.name,
             unit_label: menu.unit_label
           )
@@ -38,7 +41,7 @@ module Api
       private
 
       def practice_log_params
-        params.require(:practice_log).permit(:practice_menu_id, :logged_on, :amount, :weight, :memo)
+        params.require(:practice_log).permit(:practice_menu_id, :schedule_id, :logged_on, :amount, :weight, :memo)
       end
     end
   end

--- a/app/models/practice_log.rb
+++ b/app/models/practice_log.rb
@@ -2,6 +2,7 @@ class PracticeLog < ApplicationRecord
   belongs_to :user
   belongs_to :practice_menu, optional: true
   belongs_to :practice_session, optional: true
+  belongs_to :schedule, optional: true
 
   SOURCES = %w[manual shadow_swing].freeze
 

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -6,6 +6,8 @@ class Schedule < ApplicationRecord
   belongs_to :game_result, optional: true
   has_many :schedule_menus, -> { order(:sort_order) }, dependent: :destroy, inverse_of: :schedule
   has_many :practice_menus, through: :schedule_menus
+  # チェック（済トグル）で作られた練習ログは実績のため、予定を消しても残して紐付けだけ外す。
+  has_many :practice_logs, dependent: :nullify
 
   validates :title, length: { maximum: 50 }, allow_blank: true
   validates :title, presence: true, if: -> { menu_set_id.blank? }

--- a/app/serializers/v2/plan_serializer.rb
+++ b/app/serializers/v2/plan_serializer.rb
@@ -1,7 +1,7 @@
 module V2
   # 特定日に展開された予定（schedule）を「今日のやること」形式で返す。
-  # `done_menu_ids`（その日に練習ログ済みの practice_menu_id 集合）を instance_options で受け取り、
-  # メニュー単位・予定単位の「済」判定に使う。
+  # `done_menu_ids`（schedule_id => その日にログ済みの practice_menu_id 集合）を instance_options で受け取り、
+  # 予定単位・メニュー単位の「済」判定に使う。同じメニューが複数の予定にあっても予定ごとに独立して判定する。
   class PlanSerializer < ActiveModel::Serializer
     attributes :id, :title, :event_type, :scheduled_time, :recurring,
                :menu_set_id, :game_result_id, :note, :menus, :done
@@ -19,7 +19,7 @@ module V2
     end
 
     def menus
-      done_ids = instance_options[:done_menu_ids] || Set.new
+      done_ids = (instance_options[:done_menu_ids] || {})[object.id] || Set.new
       object.resolved_menu_items.map do |item|
         item.merge(done: done_ids.include?(item[:practice_menu_id]))
       end

--- a/app/serializers/v2/practice_log_serializer.rb
+++ b/app/serializers/v2/practice_log_serializer.rb
@@ -1,5 +1,5 @@
 module V2
   class PracticeLogSerializer < ActiveModel::Serializer
-    attributes :id, :practice_menu_id, :logged_on, :amount, :weight, :menu_name, :unit_label, :source, :memo, :created_at
+    attributes :id, :practice_menu_id, :schedule_id, :logged_on, :amount, :weight, :menu_name, :unit_label, :source, :memo, :created_at
   end
 end

--- a/db/migrate/20260709010001_add_schedule_to_practice_logs.rb
+++ b/db/migrate/20260709010001_add_schedule_to_practice_logs.rb
@@ -1,0 +1,5 @@
+class AddScheduleToPracticeLogs < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :practice_logs, :schedule, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_07_06_020001) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_09_010001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -625,8 +625,10 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_06_020001) do
     t.datetime "updated_at", null: false
     t.bigint "practice_session_id"
     t.decimal "weight", precision: 10, scale: 2
+    t.bigint "schedule_id"
     t.index ["practice_menu_id"], name: "index_practice_logs_on_practice_menu_id"
     t.index ["practice_session_id"], name: "index_practice_logs_on_practice_session_id"
+    t.index ["schedule_id"], name: "index_practice_logs_on_schedule_id"
     t.index ["user_id", "logged_on"], name: "index_practice_logs_on_user_id_and_logged_on"
     t.index ["user_id"], name: "index_practice_logs_on_user_id"
   end
@@ -1110,6 +1112,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_06_020001) do
   add_foreign_key "plate_appearances", "users"
   add_foreign_key "practice_logs", "practice_menus", on_delete: :nullify
   add_foreign_key "practice_logs", "practice_sessions"
+  add_foreign_key "practice_logs", "schedules"
   add_foreign_key "practice_logs", "users"
   add_foreign_key "practice_menus", "users"
   add_foreign_key "practice_sessions", "improvement_themes"

--- a/spec/requests/api/v2/plans_spec.rb
+++ b/spec/requests/api/v2/plans_spec.rb
@@ -40,12 +40,12 @@ RSpec.describe 'Api::V2::Plans', type: :request do
       expect(response.parsed_body.pluck('title')).to eq(%w[朝 午後 終日])
     end
 
-    it 'メニューセット由来のメニューを展開し、当日ログ済みは done を立てる' do
+    it 'メニューセット由来のメニューを展開し、その予定に紐づく当日ログ済みは done を立てる' do
       menu = create(:practice_menu, user:, name: '素振り')
       menu_set = create(:menu_set, user:, name: 'オフ日ルーティン')
       create(:menu_set_item, menu_set:, practice_menu: menu, target_value: 200)
-      create(:schedule, user:, title: nil, menu_set:, days_of_week: '1', scheduled_time: '06:00')
-      create(:practice_log, user:, practice_menu: menu, logged_on: '2026-07-06', amount: 200)
+      schedule = create(:schedule, user:, title: nil, menu_set:, days_of_week: '1', scheduled_time: '06:00')
+      create(:practice_log, user:, practice_menu: menu, schedule:, logged_on: '2026-07-06', amount: 200)
 
       get '/api/v2/plans/by_date', params: { date: '2026-07-06' }, headers: auth_headers_for(user)
 
@@ -54,6 +54,23 @@ RSpec.describe 'Api::V2::Plans', type: :request do
       expect(plan['menus'].first['name']).to eq('素振り')
       expect(plan['menus'].first['done']).to be(true)
       expect(plan['done']).to be(true)
+    end
+
+    it '同じメニューを含む別の予定のログでは done を立てない（予定単位で独立）' do
+      menu = create(:practice_menu, user:, name: '素振り')
+      done_set = create(:menu_set, user:, name: '済セット')
+      pending_set = create(:menu_set, user:, name: '未済セット')
+      create(:menu_set_item, menu_set: done_set, practice_menu: menu, target_value: 200)
+      create(:menu_set_item, menu_set: pending_set, practice_menu: menu, target_value: 100)
+      done_schedule = create(:schedule, user:, title: nil, menu_set: done_set, days_of_week: '1', scheduled_time: '06:00')
+      create(:schedule, user:, title: nil, menu_set: pending_set, days_of_week: '1', scheduled_time: '18:00')
+      create(:practice_log, user:, practice_menu: menu, schedule: done_schedule, logged_on: '2026-07-06', amount: 200)
+
+      get '/api/v2/plans/by_date', params: { date: '2026-07-06' }, headers: auth_headers_for(user)
+
+      plans_by_title = response.parsed_body.index_by { |plan| plan['title'] }
+      expect(plans_by_title['済セット']['menus'].first['done']).to be(true)
+      expect(plans_by_title['未済セット']['menus'].first['done']).to be(false)
     end
   end
 

--- a/spec/requests/api/v2/practice_logs_spec.rb
+++ b/spec/requests/api/v2/practice_logs_spec.rb
@@ -29,6 +29,23 @@ RSpec.describe 'Api::V2::PracticeLogs', type: :request do
         post '/api/v2/practice_logs', params:, headers: auth_headers_for(user)
       end.to change { user.activity_logs.where(activity_date: today).count }.from(0).to(1)
     end
+
+    it 'schedule_id を渡すと予定に紐づけて作成する' do
+      schedule = create(:schedule, user:, title: '朝練', days_of_week: '1')
+      post '/api/v2/practice_logs',
+           params: { practice_log: { practice_menu_id: menu.id, schedule_id: schedule.id, logged_on: today } },
+           headers: auth_headers_for(user)
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body['schedule_id']).to eq(schedule.id)
+    end
+
+    it '他人の予定の schedule_id は 404' do
+      other_schedule = create(:schedule, user: create(:user), title: '他人の予定', days_of_week: '1')
+      post '/api/v2/practice_logs',
+           params: { practice_log: { practice_menu_id: menu.id, schedule_id: other_schedule.id, logged_on: today } },
+           headers: auth_headers_for(user)
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe 'GET /api/v2/practice_logs' do

--- a/spec/requests/api/v2/schedules_spec.rb
+++ b/spec/requests/api/v2/schedules_spec.rb
@@ -89,6 +89,17 @@ RSpec.describe 'Api::V2::Schedules', type: :request do
       expect(response).to have_http_status(:ok)
       expect(Schedule.exists?(schedule.id)).to be(false)
     end
+
+    it '紐づく練習ログがあっても削除でき、ログは schedule_id が外れて残る' do
+      menu = create(:practice_menu, user:)
+      log = create(:practice_log, user:, practice_menu: menu, schedule:, logged_on: '2026-07-09')
+
+      delete "/api/v2/schedules/#{schedule.id}", headers: auth_headers_for(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(Schedule.exists?(schedule.id)).to be(false)
+      expect(log.reload.schedule_id).to be_nil
+    end
   end
 
   describe '単発（planned_on）・event_type の割り当て' do


### PR DESCRIPTION
同じメニューを含む複数の予定が存在する場合、これまでは practice_menu_id のみで
done を判定していたため、片方の予定を完了すると他方も誤って完了扱いになっていた。
practice_logs に schedule_id を追加し、当日ログを schedule_id ごとの practice_menu_id 集合に畳み込んで予定単位で独立に判定する。

## 関連Issue

closes #

## 概要

<!-- 変更内容を簡潔に説明 -->

## 変更内容

<!-- 具体的な変更点を箇条書きで記載 -->

-

## マイグレーション

<!-- DBマイグレーションがある場合のみ記載 -->

- [ ] マイグレーションあり → `bundle exec rails db:migrate`
- [ ] マイグレーションなし

## 確認手順

<!-- レビュアーが動作確認するための手順 -->

1.

## チェックリスト

- [ ] テストが通る (`bundle exec rspec`)
- [ ] 動作確認済み
