### PR TITLE
Chore: Pro機能ゲーティング監査（#439）― 無料/Pro境界の追加・修正一式

### DIFF
--- a/app/controllers/api/v1/group_invitations_controller.rb
+++ b/app/controllers/api/v1/group_invitations_controller.rb
@@ -6,11 +6,13 @@ module Api
       def accept_invitation
         group_id = params[:id]
         invitation = GroupInvitation.find_by(group_id:, user_id: current_api_v1_user.id)
-        if invitation
+        if invitation.nil?
+          render json: { error: '招待状況が見つかりません' }, status: :not_found
+        elsif !current_api_v1_user.can_create_or_join_group?
+          render json: { error: 'Pro プランでグループを無制限に作成・参加できます' }, status: :forbidden
+        else
           invitation.accepted!
           render json: { success: true }
-        else
-          render json: { error: '招待状況が見つかりません' }, status: :not_found
         end
       end
 

--- a/app/controllers/api/v1/group_invite_links_controller.rb
+++ b/app/controllers/api/v1/group_invite_links_controller.rb
@@ -35,6 +35,8 @@ module Api
           return render json: { error: '既にこのグループのメンバーです' }, status: :unprocessable_entity
         end
 
+        return render json: { error: 'Pro プランでグループを無制限に作成・参加できます' }, status: :forbidden unless user.can_create_or_join_group?
+
         ActiveRecord::Base.transaction do
           group.group_invitations.create!(user:, state: 'accepted', sent_at: Time.current)
           create_mutual_follow(user, invite_link.inviter)

--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -30,6 +30,8 @@ module Api
       end
 
       def create
+        return render json: { error: 'Pro プランでグループを無制限に作成・参加できます' }, status: :forbidden unless current_api_v1_user.can_create_or_join_group?
+
         group = current_api_v1_user.groups.build(group_params)
         if group.save
           group.users << current_api_v1_user

--- a/app/controllers/api/v2/baseball_notes_controller.rb
+++ b/app/controllers/api/v2/baseball_notes_controller.rb
@@ -39,9 +39,7 @@ module Api
         saved = ActiveRecord::Base.transaction do
           next false unless note.save
 
-          note.note_tag_ids = tag_ids
-          note.game_result_ids = game_result_ids
-          note.improvement_theme_ids = theme_ids
+          apply_links(note, tag_ids, game_result_ids, theme_ids)
           true
         end
         if saved
@@ -62,9 +60,7 @@ module Api
         saved = ActiveRecord::Base.transaction do
           next false unless @note.save
 
-          @note.note_tag_ids = tag_ids unless tag_ids.nil?
-          @note.game_result_ids = game_result_ids
-          @note.improvement_theme_ids = theme_ids
+          apply_links(@note, tag_ids, game_result_ids, theme_ids)
           true
         end
         if saved
@@ -81,6 +77,14 @@ module Api
 
       private
 
+      # 検証済みの ID 群を紐付けへ反映する。nil はキー未送信を表すため反映をスキップし、
+      # 既存紐付けを維持する（[] は明示的な全解除）。create では常に配列が渡る。
+      def apply_links(note, tag_ids, game_result_ids, theme_ids)
+        note.note_tag_ids = tag_ids unless tag_ids.nil?
+        note.game_result_ids = game_result_ids unless game_result_ids.nil?
+        note.improvement_theme_ids = theme_ids unless theme_ids.nil?
+      end
+
       def load_note
         @note = current_api_v1_user.baseball_notes.find(params[:id])
       end
@@ -93,14 +97,22 @@ module Api
 
       # 試合記録は has_many through の即時保存を避けるため mass-assign せず、
       # 所有・Pro 制限検証後に別途 game_result_ids= で反映する。
+      # update 時にキー自体が未送信なら nil を返し反映をスキップする（部分更新で既存紐付けを消さない）。
       def game_result_id_params
-        params.require(:baseball_note).fetch(:game_result_ids, []).map(&:to_i).uniq
+        baseball_note_params = params.require(:baseball_note)
+        return nil if action_name == 'update' && !baseball_note_params.key?(:game_result_ids)
+
+        baseball_note_params.fetch(:game_result_ids, []).map(&:to_i).uniq
       end
 
       # 課題は has_many through の即時保存を避けるため mass-assign せず、
       # 所有・Pro 制限検証後に別途 improvement_theme_ids= で反映する。
+      # update 時にキー自体が未送信なら nil を返し反映をスキップする（部分更新で既存紐付けを消さない）。
       def improvement_theme_id_params
-        params.require(:baseball_note).fetch(:improvement_theme_ids, []).map(&:to_i).uniq
+        baseball_note_params = params.require(:baseball_note)
+        return nil if action_name == 'update' && !baseball_note_params.key?(:improvement_theme_ids)
+
+        baseball_note_params.fetch(:improvement_theme_ids, []).map(&:to_i).uniq
       end
 
       # タグは has_many through の即時保存を避けるため mass-assign せず、

--- a/app/controllers/api/v2/baseball_notes_controller.rb
+++ b/app/controllers/api/v2/baseball_notes_controller.rb
@@ -55,7 +55,8 @@ module Api
         game_result_ids = game_result_id_params
         theme_ids = improvement_theme_id_params
         return unless valid_links?(@note) && valid_note_tags?(tag_ids) &&
-                      valid_game_results?(game_result_ids) && valid_improvement_themes?(theme_ids)
+                      valid_game_results?(game_result_ids, @note.game_result_ids) &&
+                      valid_improvement_themes?(theme_ids, @note.improvement_theme_ids)
 
         saved = ActiveRecord::Base.transaction do
           next false unless @note.save
@@ -169,10 +170,13 @@ module Api
       end
 
       # 他ユーザーの試合には紐付けられない（IDOR 防止）。無料は1件、Pro は複数件紐付け可。
-      def valid_game_results?(game_result_ids)
+      # existing_ids は更新前の既存紐付け。Pro 解約後も既存の複数紐付けを維持・削減できるよう、
+      # 既存件数を超えて新規に増やす場合のみ Pro 判定する（グランドファザリング）。
+      def valid_game_results?(game_result_ids, existing_ids = [])
         return true if game_result_ids.blank?
 
-        if game_result_ids.size > 1 && !current_api_v1_user.has_entitlement?('multi_game_result_notes')
+        if game_result_ids.size > 1 && game_result_ids.size > existing_ids.size &&
+           !current_api_v1_user.has_entitlement?('multi_game_result_notes')
           render json: { error: '複数の試合記録への紐付けは Pro プラン限定です' }, status: :forbidden
           return false
         end
@@ -183,10 +187,13 @@ module Api
       end
 
       # 他ユーザーの課題には紐付けられない（IDOR 防止）。無料は1件、Pro は複数件紐付け可。
-      def valid_improvement_themes?(theme_ids)
+      # existing_ids は更新前の既存紐付け。Pro 解約後も既存の複数紐付けを維持・削減できるよう、
+      # 既存件数を超えて新規に増やす場合のみ Pro 判定する（グランドファザリング）。
+      def valid_improvement_themes?(theme_ids, existing_ids = [])
         return true if theme_ids.blank?
 
-        if theme_ids.size > 1 && !current_api_v1_user.has_entitlement?('multi_improvement_theme_links')
+        if theme_ids.size > 1 && theme_ids.size > existing_ids.size &&
+           !current_api_v1_user.has_entitlement?('multi_improvement_theme_links')
           render json: { error: '複数の課題への紐付けは Pro プラン限定です' }, status: :forbidden
           return false
         end

--- a/app/controllers/api/v2/baseball_notes_controller.rb
+++ b/app/controllers/api/v2/baseball_notes_controller.rb
@@ -6,16 +6,20 @@ module Api
       before_action :authenticate_api_v1_user!
       before_action :load_note, only: %i[show update destroy]
 
-      FILTERABLE_COLUMNS = %i[date practice_log_id practice_session_id improvement_theme_id].freeze
+      FILTERABLE_COLUMNS = %i[date practice_log_id practice_session_id].freeze
 
       def index
-        notes = current_api_v1_user.baseball_notes.includes(:note_tags, :game_results)
+        notes = current_api_v1_user.baseball_notes.includes(:note_tags, :game_results, :improvement_themes)
                                    .order(date: :desc, created_at: :desc)
         FILTERABLE_COLUMNS.each do |column|
           notes = notes.where(column => params[column]) if params[column].present?
         end
         if params[:game_result_id].present?
           notes = notes.joins(:note_game_links).where(note_game_links: { game_result_id: params[:game_result_id] })
+        end
+        if params[:improvement_theme_id].present?
+          notes = notes.joins(:note_theme_links)
+                       .where(note_theme_links: { improvement_theme_id: params[:improvement_theme_id] })
         end
         render json: notes, each_serializer: ::V2::BaseballNoteSerializer, status: :ok
       end
@@ -28,13 +32,16 @@ module Api
         note = current_api_v1_user.baseball_notes.build(note_params)
         tag_ids = tag_id_params
         game_result_ids = game_result_id_params
-        return unless valid_links?(note) && valid_note_tags?(tag_ids) && valid_game_results?(game_result_ids)
+        theme_ids = improvement_theme_id_params
+        return unless valid_links?(note) && valid_note_tags?(tag_ids) &&
+                      valid_game_results?(game_result_ids) && valid_improvement_themes?(theme_ids)
 
         saved = ActiveRecord::Base.transaction do
           next false unless note.save
 
           note.note_tag_ids = tag_ids
           note.game_result_ids = game_result_ids
+          note.improvement_theme_ids = theme_ids
           true
         end
         if saved
@@ -48,13 +55,16 @@ module Api
         @note.assign_attributes(note_params)
         tag_ids = tag_id_params
         game_result_ids = game_result_id_params
-        return unless valid_links?(@note) && valid_note_tags?(tag_ids) && valid_game_results?(game_result_ids)
+        theme_ids = improvement_theme_id_params
+        return unless valid_links?(@note) && valid_note_tags?(tag_ids) &&
+                      valid_game_results?(game_result_ids) && valid_improvement_themes?(theme_ids)
 
         saved = ActiveRecord::Base.transaction do
           next false unless @note.save
 
           @note.note_tag_ids = tag_ids unless tag_ids.nil?
           @note.game_result_ids = game_result_ids
+          @note.improvement_theme_ids = theme_ids
           true
         end
         if saved
@@ -77,7 +87,7 @@ module Api
 
       def note_params
         params.require(:baseball_note).permit(:title, :date, :memo, :practice_log_id,
-                                              :practice_session_id, :improvement_theme_id, :reflection_template_id,
+                                              :practice_session_id, :reflection_template_id,
                                               reflection_answers: %i[question answer])
       end
 
@@ -85,6 +95,12 @@ module Api
       # 所有・Pro 制限検証後に別途 game_result_ids= で反映する。
       def game_result_id_params
         params.require(:baseball_note).fetch(:game_result_ids, []).map(&:to_i).uniq
+      end
+
+      # 課題は has_many through の即時保存を避けるため mass-assign せず、
+      # 所有・Pro 制限検証後に別途 improvement_theme_ids= で反映する。
+      def improvement_theme_id_params
+        params.require(:baseball_note).fetch(:improvement_theme_ids, []).map(&:to_i).uniq
       end
 
       # タグは has_many through の即時保存を避けるため mass-assign せず、
@@ -102,8 +118,7 @@ module Api
       # 紐付け先カラム => { association:, error: } の対応。所有検証（IDOR 防止）に使う。
       LINK_OWNERSHIPS = {
         practice_log_id: { association: :practice_logs, error: '不正な練習の指定です' },
-        practice_session_id: { association: :practice_sessions, error: '不正な練習記録の指定です' },
-        improvement_theme_id: { association: :improvement_themes, error: '不正な課題の指定です' }
+        practice_session_id: { association: :practice_sessions, error: '不正な練習記録の指定です' }
       }.freeze
 
       # 他ユーザーの試合 / 練習 / 課題に紐付けられないよう所有を検証する（IDOR 防止）。
@@ -152,6 +167,20 @@ module Api
         return true if current_api_v1_user.game_results.where(id: game_result_ids).count == game_result_ids.uniq.size
 
         render json: { error: '不正な試合の指定です' }, status: :forbidden
+        false
+      end
+
+      # 他ユーザーの課題には紐付けられない（IDOR 防止）。無料は1件、Pro は複数件紐付け可。
+      def valid_improvement_themes?(theme_ids)
+        return true if theme_ids.blank?
+
+        if theme_ids.size > 1 && !current_api_v1_user.has_entitlement?('multi_improvement_theme_links')
+          render json: { error: '複数の課題への紐付けは Pro プラン限定です' }, status: :forbidden
+          return false
+        end
+        return true if current_api_v1_user.improvement_themes.where(id: theme_ids).count == theme_ids.uniq.size
+
+        render json: { error: '不正な課題の指定です' }, status: :forbidden
         false
       end
     end

--- a/app/controllers/api/v2/baseball_notes_controller.rb
+++ b/app/controllers/api/v2/baseball_notes_controller.rb
@@ -6,12 +6,16 @@ module Api
       before_action :authenticate_api_v1_user!
       before_action :load_note, only: %i[show update destroy]
 
-      FILTERABLE_COLUMNS = %i[date game_result_id practice_log_id practice_session_id improvement_theme_id].freeze
+      FILTERABLE_COLUMNS = %i[date practice_log_id practice_session_id improvement_theme_id].freeze
 
       def index
-        notes = current_api_v1_user.baseball_notes.includes(:note_tags).order(date: :desc, created_at: :desc)
+        notes = current_api_v1_user.baseball_notes.includes(:note_tags, :game_results)
+                                   .order(date: :desc, created_at: :desc)
         FILTERABLE_COLUMNS.each do |column|
           notes = notes.where(column => params[column]) if params[column].present?
+        end
+        if params[:game_result_id].present?
+          notes = notes.joins(:note_game_links).where(note_game_links: { game_result_id: params[:game_result_id] })
         end
         render json: notes, each_serializer: ::V2::BaseballNoteSerializer, status: :ok
       end
@@ -22,12 +26,15 @@ module Api
 
       def create
         note = current_api_v1_user.baseball_notes.build(note_params)
-        return unless valid_links?(note) && valid_note_tags?(tag_id_params)
+        tag_ids = tag_id_params
+        game_result_ids = game_result_id_params
+        return unless valid_links?(note) && valid_note_tags?(tag_ids) && valid_game_results?(game_result_ids)
 
         saved = ActiveRecord::Base.transaction do
           next false unless note.save
 
-          note.note_tag_ids = tag_id_params
+          note.note_tag_ids = tag_ids
+          note.game_result_ids = game_result_ids
           true
         end
         if saved
@@ -39,12 +46,15 @@ module Api
 
       def update
         @note.assign_attributes(note_params)
-        return unless valid_links?(@note) && valid_note_tags?(tag_id_params)
+        tag_ids = tag_id_params
+        game_result_ids = game_result_id_params
+        return unless valid_links?(@note) && valid_note_tags?(tag_ids) && valid_game_results?(game_result_ids)
 
         saved = ActiveRecord::Base.transaction do
           next false unless @note.save
 
-          @note.note_tag_ids = tag_id_params
+          @note.note_tag_ids = tag_ids unless tag_ids.nil?
+          @note.game_result_ids = game_result_ids
           true
         end
         if saved
@@ -66,21 +76,31 @@ module Api
       end
 
       def note_params
-        params.require(:baseball_note).permit(:title, :date, :memo, :game_result_id, :practice_log_id,
+        params.require(:baseball_note).permit(:title, :date, :memo, :practice_log_id,
                                               :practice_session_id, :improvement_theme_id, :reflection_template_id,
                                               reflection_answers: %i[question answer])
       end
 
+      # 試合記録は has_many through の即時保存を避けるため mass-assign せず、
+      # 所有・Pro 制限検証後に別途 game_result_ids= で反映する。
+      def game_result_id_params
+        params.require(:baseball_note).fetch(:game_result_ids, []).map(&:to_i).uniq
+      end
+
       # タグは has_many through の即時保存を避けるため mass-assign せず、
-      # 所有検証後に別途 note_tag_ids= で反映する。
+      # 所有・Pro 制限検証後に別途 note_tag_ids= で反映する。
       # 重複IDのまま渡すと ids_writer が同一レコードを二重 add しようとしうるため uniq する。
+      # update 時に tag_ids キー自体が未送信なら nil を返しタグ処理自体をスキップする（無料ユーザーは
+      # タグ編集UIが非表示になるため、パラメータ省略時に既存タグへ再度Pro判定をかけて消してしまわないようにする）。
       def tag_id_params
-        params.require(:baseball_note).fetch(:tag_ids, []).map(&:to_i).uniq
+        baseball_note_params = params.require(:baseball_note)
+        return nil if action_name == 'update' && !baseball_note_params.key?(:tag_ids)
+
+        baseball_note_params.fetch(:tag_ids, []).map(&:to_i).uniq
       end
 
       # 紐付け先カラム => { association:, error: } の対応。所有検証（IDOR 防止）に使う。
       LINK_OWNERSHIPS = {
-        game_result_id: { association: :game_results, error: '不正な試合の指定です' },
         practice_log_id: { association: :practice_logs, error: '不正な練習の指定です' },
         practice_session_id: { association: :practice_sessions, error: '不正な練習記録の指定です' },
         improvement_theme_id: { association: :improvement_themes, error: '不正な課題の指定です' }
@@ -107,12 +127,31 @@ module Api
         false
       end
 
-      # タグはプリセット or 自作のみ付与可（他ユーザーの自作は不可）。
+      # タグはプリセット or 自作のみ付与可（他ユーザーの自作は不可）。タグ付与自体が Pro 限定機能。
       def valid_note_tags?(tag_ids)
         return true if tag_ids.blank?
+
+        unless current_api_v1_user.has_entitlement?('note_tags')
+          render json: { error: 'タグ機能は Pro プラン限定です' }, status: :forbidden
+          return false
+        end
         return true if ::NoteTag.available_for(current_api_v1_user).where(id: tag_ids).count == tag_ids.uniq.size
 
         render json: { error: '不正なタグの指定です' }, status: :forbidden
+        false
+      end
+
+      # 他ユーザーの試合には紐付けられない（IDOR 防止）。無料は1件、Pro は複数件紐付け可。
+      def valid_game_results?(game_result_ids)
+        return true if game_result_ids.blank?
+
+        if game_result_ids.size > 1 && !current_api_v1_user.has_entitlement?('multi_game_result_notes')
+          render json: { error: '複数の試合記録への紐付けは Pro プラン限定です' }, status: :forbidden
+          return false
+        end
+        return true if current_api_v1_user.game_results.where(id: game_result_ids).count == game_result_ids.uniq.size
+
+        render json: { error: '不正な試合の指定です' }, status: :forbidden
         false
       end
     end

--- a/app/controllers/api/v2/goals_controller.rb
+++ b/app/controllers/api/v2/goals_controller.rb
@@ -47,17 +47,25 @@ module Api
       end
 
       def allowed_to_create?(goal)
+        return false if goal.kind == 'manual' && !current_api_v1_user.can_create_manual_metric_goal?
+
         case goal.period_type
         when 'season' then current_api_v1_user.can_create_season_goal?
         when 'tournament' then current_api_v1_user.can_create_tournament_goal?
+        when 'custom' then current_api_v1_user.can_create_custom_period_goal?
         else current_api_v1_user.can_create_monthly_goal?
         end
       end
 
       def render_limit_error(goal)
+        if goal.kind == 'manual' && !current_api_v1_user.can_create_manual_metric_goal?
+          return render json: { error: '自由指標の目標は Pro プラン限定です' }, status: :forbidden
+        end
+
         message = case goal.period_type
                   when 'season' then 'シーズン目標は Pro プラン限定です'
                   when 'tournament' then '大会目標は Pro プラン限定です'
+                  when 'custom' then 'カスタム期間の目標は Pro プラン限定です'
                   else 'Pro プランで期間目標を無制限に設定できます'
                   end
         render json: { error: message }, status: :forbidden

--- a/app/controllers/api/v2/improvement_themes_controller.rb
+++ b/app/controllers/api/v2/improvement_themes_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V2
     # 課題（テーマ）。選手が一定期間集中的に取り組む上達テーマを管理する。
     # 練習セッション / ノートに緩く紐付き、取組状況を集計する。
-    # 無料は取組中（open）が1つまで、Pro は無制限。
+    # 無料は取組中（open）が2つまで、Pro は無制限。
     class ImprovementThemesController < Api::V2::ApplicationController
       before_action :authenticate_api_v1_user!
       before_action :load_theme, only: %i[update destroy]
@@ -15,7 +15,7 @@ module Api
 
       def create
         unless current_api_v1_user.can_create_improvement_theme?
-          return render json: { error: '取組中の課題は無料プランで1つまでです。Pro で無制限に設定できます' },
+          return render json: { error: '取組中の課題は無料プランで2つまでです。Pro で無制限に設定できます' },
                         status: :forbidden
         end
 

--- a/app/controllers/api/v2/note_tags_controller.rb
+++ b/app/controllers/api/v2/note_tags_controller.rb
@@ -10,6 +10,8 @@ module Api
       end
 
       def create
+        return render json: { error: 'タグ機能は Pro プラン限定です' }, status: :forbidden unless current_api_v1_user.has_entitlement?('note_tags')
+
         tag = current_api_v1_user.note_tags.new(name: tag_params[:name])
         if tag.save
           render json: tag, serializer: ::V2::NoteTagSerializer, status: :created

--- a/app/controllers/api/v2/periodic_reviews_controller.rb
+++ b/app/controllers/api/v2/periodic_reviews_controller.rb
@@ -1,20 +1,22 @@
 module Api
   module V2
-    # 週次 / 月次の振り返りレポート。基本部は全員、詳細部・月次は Pro 限定。
+    # 週次 / 月次の振り返りレポートは Pro 限定機能。無料ユーザーには一件も返さない
+    # （週次はバッチで生成し続けるが、Pro 加入時に過去分をまとめて見せるための蓄積であり、
+    # 加入前の閲覧には使わない）。
     # レポート本体はバッチ（GeneratePeriodicReviewJob）が生成し、ここは閲覧と既読化のみ。
     class PeriodicReviewsController < Api::V2::ApplicationController
       before_action :authenticate_api_v1_user!
 
       def index
         reviews = current_api_v1_user.periodic_reviews.recent_first
-        reviews = reviews.weekly unless pro?
+        reviews = reviews.none unless pro?
         render json: reviews, each_serializer: ::V2::PeriodicReviewSerializer, pro: pro?, status: :ok
       end
 
       def update
-        # index と同様、無料ユーザーは月次レビューへアクセスできない（レスポンス経由の露出防止）。
+        # index と同様、無料ユーザーはレビューへ一切アクセスできない（レスポンス経由の露出防止）。
         reviews = current_api_v1_user.periodic_reviews
-        reviews = reviews.weekly unless pro?
+        reviews = reviews.none unless pro?
         review = reviews.find(params[:id])
         review.update!(read: true)
         render json: review, serializer: ::V2::PeriodicReviewSerializer, pro: pro?, status: :ok

--- a/app/controllers/api/v2/practice_menu_trends_controller.rb
+++ b/app/controllers/api/v2/practice_menu_trends_controller.rb
@@ -1,12 +1,22 @@
 module Api
   module V2
     # 単一メニューの推移・自己ベスト・履歴。:id は practice_menu の id。
+    # 推移の詳細表示は Pro 限定機能のため、entitlement を要求する。
     class PracticeMenuTrendsController < Api::V2::ApplicationController
       before_action :authenticate_api_v1_user!
+      before_action :require_trend_detail_entitlement
 
       def show
         menu = current_api_v1_user.practice_menus.find(params[:id])
         render json: ::Practices::MenuTrend.new(current_api_v1_user, menu).call, status: :ok
+      end
+
+      private
+
+      def require_trend_detail_entitlement
+        return if current_api_v1_user.has_entitlement?('practice_menu_trend_detail')
+
+        render json: { error: 'メニュー推移の詳細表示は Pro プラン限定です' }, status: :forbidden
       end
     end
   end

--- a/app/controllers/api/v2/practice_menus_controller.rb
+++ b/app/controllers/api/v2/practice_menus_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V2
     # 練習メニュー マスターの CRUD。
-    # 無料プランは archived 以外 5 件まで（PlanLimits#can_create_practice_menu?）。
+    # 無料プランは archived 以外 3 件まで（PlanLimits#can_create_practice_menu?）。
     class PracticeMenusController < Api::V2::ApplicationController
       before_action :authenticate_api_v1_user!
       before_action :load_practice_menu, only: %i[update destroy]

--- a/app/controllers/api/v2/practice_sessions_controller.rb
+++ b/app/controllers/api/v2/practice_sessions_controller.rb
@@ -8,24 +8,29 @@ module Api
 
       def index
         sessions = current_api_v1_user.practice_sessions
-                                      .includes(:practice_logs)
+                                      .includes(:practice_logs, :improvement_themes)
                                       .ordered
         sessions = sessions.where(logged_on: params[:from]..) if params[:from].present?
         sessions = sessions.where(logged_on: ..params[:to]) if params[:to].present?
-        sessions = sessions.where(improvement_theme_id: params[:improvement_theme_id]) if params[:improvement_theme_id].present?
+        if params[:improvement_theme_id].present?
+          sessions = sessions.joins(:practice_session_theme_links)
+                             .where(practice_session_theme_links: { improvement_theme_id: params[:improvement_theme_id] })
+        end
         render json: sessions, each_serializer: ::V2::PracticeSessionSerializer, status: :ok,
                condition_logs_by_date: condition_logs_by_date(sessions.map(&:logged_on))
       end
 
       def show
-        session = current_api_v1_user.practice_sessions.includes(:practice_logs).find(params[:id])
+        session = current_api_v1_user.practice_sessions
+                                     .includes(:practice_logs, :improvement_themes)
+                                     .find(params[:id])
         render json: session, serializer: ::V2::PracticeSessionSerializer, status: :ok
       end
 
       # GET /api/v2/practice_sessions/by_date?date=YYYY-MM-DD
       def by_date
         session = current_api_v1_user.practice_sessions
-                                     .includes(:practice_logs)
+                                     .includes(:practice_logs, :improvement_themes)
                                      .find_by(logged_on: params[:date])
         return render json: nil, status: :ok if session.nil?
 
@@ -37,13 +42,15 @@ module Api
           user: current_api_v1_user,
           logged_on: session_params[:logged_on],
           memo: session_params[:memo],
-          improvement_theme_id: session_params[:improvement_theme_id],
+          improvement_theme_ids: session_params[:improvement_theme_ids],
           items: session_params[:items]&.map(&:to_h) || [],
           condition: session_params[:condition]&.to_h
         ).call
         render json: session, serializer: ::V2::PracticeSessionSerializer, status: :created
       rescue PracticeSessions::Upsert::NotEntitled
         render json: { error: 'コンディション記録は Pro プラン限定です' }, status: :forbidden
+      rescue PracticeSessions::Upsert::ThemeLimitExceeded
+        render json: { error: '複数の課題への紐付けは Pro プラン限定です' }, status: :forbidden
       rescue ActiveRecord::RecordInvalid => e
         render json: { errors: e.record.errors.full_messages }, status: :unprocessable_entity
       end
@@ -64,7 +71,8 @@ module Api
 
       def session_params
         params.require(:practice_session).permit(
-          :logged_on, :memo, :improvement_theme_id,
+          :logged_on, :memo,
+          improvement_theme_ids: [],
           items: %i[practice_menu_id amount weight memo],
           condition: [:fatigue_level, :physical_level, :sleep_hours, :mood, :memo, { injuries: %i[part memo] }]
         )

--- a/app/controllers/api/v2/schedules/week_copies_controller.rb
+++ b/app/controllers/api/v2/schedules/week_copies_controller.rb
@@ -1,0 +1,61 @@
+module Api
+  module V2
+    module Schedules
+      # 週の練習プラン（単発予定のみ）を翌週へ一括コピーする。Pro限定機能。
+      class WeekCopiesController < Api::V2::ApplicationController
+        before_action :authenticate_api_v1_user!
+
+        # POST /api/v2/schedules/week_copy
+        # @param week_start [String] コピー元の週の開始日（YYYY-MM-DD）
+        def create
+          unless current_api_v1_user.has_entitlement?('schedule_copy_next_week')
+            return render json: { error: '来週にコピーは Pro プラン限定です' }, status: :forbidden
+          end
+
+          week_start = parse_date(params[:week_start])
+          return render json: { error: 'week_start が不正です' }, status: :unprocessable_entity if week_start.nil?
+
+          copied = ActiveRecord::Base.transaction do
+            source_schedules(week_start).map { |schedule| copy_to_next_week(schedule) }
+          end
+          render json: copied, each_serializer: ::V2::ScheduleSerializer, status: :created
+        end
+
+        private
+
+        def parse_date(value)
+          Date.parse(value.to_s)
+        rescue ArgumentError, TypeError
+          nil
+        end
+
+        def source_schedules(week_start)
+          current_api_v1_user.schedules.active.single
+                             .where(planned_on: week_start..(week_start + 6.days))
+        end
+
+        def copy_to_next_week(schedule)
+          new_schedule = current_api_v1_user.schedules.create!(
+            title: schedule.title,
+            event_type: schedule.event_type,
+            scheduled_time: schedule.scheduled_time,
+            planned_on: schedule.planned_on + 7.days,
+            notification_enabled: schedule.notification_enabled,
+            notification_message: schedule.notification_message,
+            menu_set_id: schedule.menu_set_id
+          )
+          return new_schedule if schedule.menu_set_id
+
+          schedule.schedule_menus.each do |menu|
+            new_schedule.schedule_menus.create!(
+              practice_menu_id: menu.practice_menu_id,
+              target_value: menu.target_value,
+              sort_order: menu.sort_order
+            )
+          end
+          new_schedule
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/schedules/week_copies_controller.rb
+++ b/app/controllers/api/v2/schedules/week_copies_controller.rb
@@ -30,7 +30,7 @@ module Api
         end
 
         def source_schedules(week_start)
-          current_api_v1_user.schedules.active.single
+          current_api_v1_user.schedules.active.single.includes(:schedule_menus)
                              .where(planned_on: week_start..(week_start + 6.days))
         end
 

--- a/app/controllers/api/v2/schedules/week_copies_controller.rb
+++ b/app/controllers/api/v2/schedules/week_copies_controller.rb
@@ -16,7 +16,7 @@ module Api
           return render json: { error: 'week_start が不正です' }, status: :unprocessable_entity if week_start.nil?
 
           copied = ActiveRecord::Base.transaction do
-            source_schedules(week_start).map { |schedule| copy_to_next_week(schedule) }
+            source_schedules(week_start).filter_map { |schedule| copy_to_next_week(schedule) }
           end
           render json: copied, each_serializer: ::V2::ScheduleSerializer, status: :created
         end
@@ -35,11 +35,15 @@ module Api
         end
 
         def copy_to_next_week(schedule)
+          target_date = schedule.planned_on + 7.days
+          # 連続実行での二重コピーを避け、コピー先に同一内容の予定が既にあればスキップする。
+          return nil if already_copied?(schedule, target_date)
+
           new_schedule = current_api_v1_user.schedules.create!(
             title: schedule.title,
             event_type: schedule.event_type,
             scheduled_time: schedule.scheduled_time,
-            planned_on: schedule.planned_on + 7.days,
+            planned_on: target_date,
             notification_enabled: schedule.notification_enabled,
             notification_message: schedule.notification_message,
             menu_set_id: schedule.menu_set_id
@@ -54,6 +58,16 @@ module Api
             )
           end
           new_schedule
+        end
+
+        def already_copied?(schedule, target_date)
+          current_api_v1_user.schedules.active.single.exists?(
+            planned_on: target_date,
+            title: schedule.title,
+            event_type: schedule.event_type,
+            scheduled_time: schedule.scheduled_time,
+            menu_set_id: schedule.menu_set_id
+          )
         end
       end
     end

--- a/app/controllers/api/v2/schedules_controller.rb
+++ b/app/controllers/api/v2/schedules_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V2
-    # 練習プランの割り当て（繰り返し / 単発）。無料は3つまで（PlanLimits）。
+    # 練習プランの割り当て（繰り返し / 単発）。件数上限なし。
     # 通知のリマインド自体は端末側のローカル通知で行う（サーバーは設定の保管のみ）。
     class SchedulesController < Api::V2::ApplicationController
       before_action :authenticate_api_v1_user!
@@ -8,7 +8,7 @@ module Api
 
       def index
         schedules = current_api_v1_user.schedules.active
-                                       .includes(:game_result,
+                                       .includes(:game_result, :practice_logs,
                                                  { menu_set: { menu_set_items: :practice_menu } },
                                                  { schedule_menus: :practice_menu })
                                        .order(:scheduled_time)
@@ -16,8 +16,6 @@ module Api
       end
 
       def create
-        return render json: { error: 'Pro プランでスケジュールを無制限に登録できます' }, status: :forbidden unless current_api_v1_user.can_create_schedule?
-
         schedule = current_api_v1_user.schedules.build(schedule_params)
         assign_menus(schedule)
         if schedule.save
@@ -28,13 +26,16 @@ module Api
       end
 
       def update
-        @schedule.assign_attributes(schedule_params)
-        assign_menus(@schedule) if params[:schedule].key?(:menus)
-        if @schedule.save
-          render json: @schedule, serializer: ::V2::ScheduleSerializer, status: :ok
-        else
-          render json: { errors: @schedule.errors.full_messages }, status: :unprocessable_entity
+        # assign_menus の destroy_all は即時実行されるため、save失敗時に schedule_menus だけ
+        # 消えて残らないよう、属性更新・メニュー再構築・保存を1トランザクションに包む。
+        ActiveRecord::Base.transaction do
+          @schedule.assign_attributes(schedule_params)
+          assign_menus(@schedule) if params[:schedule].key?(:menus)
+          @schedule.save!
         end
+        render json: @schedule, serializer: ::V2::ScheduleSerializer, status: :ok
+      rescue ActiveRecord::RecordInvalid
+        render json: { errors: @schedule.errors.full_messages }, status: :unprocessable_entity
       end
 
       def destroy

--- a/app/models/baseball_note.rb
+++ b/app/models/baseball_note.rb
@@ -3,13 +3,14 @@ class BaseballNote < ApplicationRecord
   # モデルA: 試合 or 練習（日次セッション）に緩く紐付く（どちらも任意）。
   belongs_to :practice_log, optional: true
   belongs_to :practice_session, optional: true
-  belongs_to :improvement_theme, optional: true
   belongs_to :reflection_template, optional: true
   has_many :note_taggings, dependent: :destroy
   has_many :note_tags, through: :note_taggings
-  # 試合記録は複数紐付け可（無料は1件・Proは複数、controller側で制限）。
+  # 試合記録・課題は複数紐付け可（無料は1件・Proは複数、controller側で制限）。
   has_many :note_game_links, dependent: :destroy
   has_many :game_results, through: :note_game_links
+  has_many :note_theme_links, dependent: :destroy
+  has_many :improvement_themes, through: :note_theme_links
 
   def extract_and_truncate_memo
     return '' if memo.blank?

--- a/app/models/baseball_note.rb
+++ b/app/models/baseball_note.rb
@@ -1,13 +1,15 @@
 class BaseballNote < ApplicationRecord
   belongs_to :user
   # モデルA: 試合 or 練習（日次セッション）に緩く紐付く（どちらも任意）。
-  belongs_to :game_result, optional: true
   belongs_to :practice_log, optional: true
   belongs_to :practice_session, optional: true
   belongs_to :improvement_theme, optional: true
   belongs_to :reflection_template, optional: true
   has_many :note_taggings, dependent: :destroy
   has_many :note_tags, through: :note_taggings
+  # 試合記録は複数紐付け可（無料は1件・Proは複数、controller側で制限）。
+  has_many :note_game_links, dependent: :destroy
+  has_many :game_results, through: :note_game_links
 
   def extract_and_truncate_memo
     return '' if memo.blank?

--- a/app/models/concerns/entitlement.rb
+++ b/app/models/concerns/entitlement.rb
@@ -26,7 +26,7 @@ module Entitlement
     'unlimited_media_uploads',      # 動画・画像アップロード無制限(無料は月3件)
     'media_long_term_storage',      # メディア長期保管(31日以上前も閲覧可)
     'schedule_copy_next_week',      # 週の練習プランを来週へ一括コピー
-    'unlimited_menu_sets',          # メニューセット無制限(無料は3件まで)
+    'unlimited_menu_sets',          # メニューセット無制限(無料は2件まで)
     'unlimited_monthly_goals',      # 個人の期間目標無制限(無料は2件まで)
     'season_goals',                 # シーズン目標(無料は利用不可)
     'tournament_goals',             # 大会目標(無料は利用不可)

--- a/app/models/concerns/entitlement.rb
+++ b/app/models/concerns/entitlement.rb
@@ -38,7 +38,8 @@ module Entitlement
     'unlimited_reflection_templates', # 振り返りテンプレの自作無制限(無料は1つまで・プリセットは全員可)
     'advanced_periodic_review', # 週次/月次レポートの詳細(課題別内訳・相関・成績前週比・月次)
     'note_tags', # 野球ノートへのタグ付け(無料は付与不可)
-    'multi_game_result_notes' # 野球ノートへの複数試合記録紐付け(無料は1件まで)
+    'multi_game_result_notes', # 野球ノートへの複数試合記録紐付け(無料は1件まで)
+    'multi_improvement_theme_links' # 練習記録・野球ノートへの複数課題紐付け(無料は1件まで)
   ].freeze
 
   ALL_FEATURES = (FREE_FEATURES + PRO_FEATURES).freeze

--- a/app/models/concerns/entitlement.rb
+++ b/app/models/concerns/entitlement.rb
@@ -42,7 +42,9 @@ module Entitlement
     'multi_improvement_theme_links', # 練習記録・野球ノートへの複数課題紐付け(無料は1件まで)
     'practice_menu_trend_detail', # メニューごとの推移詳細(期間フィルタ・グラフ・数値内訳)
     'custom_period_goals', # カスタム期間の個人目標(無料は利用不可)
-    'manual_metric_goals' # 自由指標(手動更新)の目標設定(無料は利用不可)
+    'manual_metric_goals', # 自由指標(手動更新)の目標設定(無料は利用不可)
+    'shadow_swing_custom_interval', # 素振りカウンターのインターバル自由設定(無料は5〜10秒のみ)
+    'shadow_swing_vibration' # 素振りカウンターのバイブレーション設定(無料は利用不可)
   ].freeze
 
   ALL_FEATURES = (FREE_FEATURES + PRO_FEATURES).freeze

--- a/app/models/concerns/entitlement.rb
+++ b/app/models/concerns/entitlement.rb
@@ -39,7 +39,8 @@ module Entitlement
     'advanced_periodic_review', # 週次/月次レポートの詳細(課題別内訳・相関・成績前週比・月次)
     'note_tags', # 野球ノートへのタグ付け(無料は付与不可)
     'multi_game_result_notes', # 野球ノートへの複数試合記録紐付け(無料は1件まで)
-    'multi_improvement_theme_links' # 練習記録・野球ノートへの複数課題紐付け(無料は1件まで)
+    'multi_improvement_theme_links', # 練習記録・野球ノートへの複数課題紐付け(無料は1件まで)
+    'practice_menu_trend_detail' # メニューごとの推移詳細(期間フィルタ・グラフ・数値内訳)
   ].freeze
 
   ALL_FEATURES = (FREE_FEATURES + PRO_FEATURES).freeze

--- a/app/models/concerns/entitlement.rb
+++ b/app/models/concerns/entitlement.rb
@@ -14,7 +14,7 @@ module Entitlement
     'practice_log_basic',    # 練習記録(基本): 練習内容のログ
     'grass_recent_30days',   # 草機能: 直近30日分のヒートマップ表示
     'monthly_goal_single',   # 個人の期間目標（月次/週次/年間/カスタム）: 2つまで作成可
-    'schedule_single'        # 自主練スケジュール: 3つまで作成可
+    'schedule_single'        # 自主練スケジュール: 無料でも無制限に作成可
   ].freeze
 
   # Pro 加入時のみ利用可能な機能キー。subscription が pro_active? のとき true。
@@ -25,8 +25,8 @@ module Entitlement
     'unlimited_practice_menus',     # 練習メニュー無制限(無料は5件まで)
     'unlimited_media_uploads',      # 動画・画像アップロード無制限(無料は月3件)
     'media_long_term_storage',      # メディア長期保管(31日以上前も閲覧可)
-    'unlimited_schedules',          # 練習プランの割り当て無制限(無料は3件まで)
-    'unlimited_menu_sets',          # メニューセット無制限(無料は2件まで)
+    'schedule_copy_next_week',      # 週の練習プランを来週へ一括コピー
+    'unlimited_menu_sets',          # メニューセット無制限(無料は3件まで)
     'unlimited_monthly_goals',      # 個人の期間目標無制限(無料は2件まで)
     'season_goals',                 # シーズン目標(無料は利用不可)
     'tournament_goals',             # 大会目標(無料は利用不可)

--- a/app/models/concerns/entitlement.rb
+++ b/app/models/concerns/entitlement.rb
@@ -33,14 +33,16 @@ module Entitlement
     'custom_notification_messages', # カスタム通知メッセージの設定
     'advanced_goal_tracking',       # 高度な目標トラッキング(達成率の詳細推移)
     'detailed_condition_log',       # 詳細コンディションログ(体調・気分の詳細記録)
-    'unlimited_improvement_themes', # 課題テーマ無制限(無料は取組中1つまで)
+    'unlimited_improvement_themes', # 課題テーマ無制限(無料は取組中2つまで)
     'correlation_insights',         # 相関インサイト(練習量・コンディション×成績の傾向)
     'unlimited_reflection_templates', # 振り返りテンプレの自作無制限(無料は1つまで・プリセットは全員可)
     'advanced_periodic_review', # 週次/月次レポートの詳細(課題別内訳・相関・成績前週比・月次)
     'note_tags', # 野球ノートへのタグ付け(無料は付与不可)
     'multi_game_result_notes', # 野球ノートへの複数試合記録紐付け(無料は1件まで)
     'multi_improvement_theme_links', # 練習記録・野球ノートへの複数課題紐付け(無料は1件まで)
-    'practice_menu_trend_detail' # メニューごとの推移詳細(期間フィルタ・グラフ・数値内訳)
+    'practice_menu_trend_detail', # メニューごとの推移詳細(期間フィルタ・グラフ・数値内訳)
+    'custom_period_goals', # カスタム期間の個人目標(無料は利用不可)
+    'manual_metric_goals' # 自由指標(手動更新)の目標設定(無料は利用不可)
   ].freeze
 
   ALL_FEATURES = (FREE_FEATURES + PRO_FEATURES).freeze

--- a/app/models/concerns/entitlement.rb
+++ b/app/models/concerns/entitlement.rb
@@ -44,7 +44,8 @@ module Entitlement
     'custom_period_goals', # カスタム期間の個人目標(無料は利用不可)
     'manual_metric_goals', # 自由指標(手動更新)の目標設定(無料は利用不可)
     'shadow_swing_custom_interval', # 素振りカウンターのインターバル自由設定(無料は5〜10秒のみ)
-    'shadow_swing_vibration' # 素振りカウンターのバイブレーション設定(無料は利用不可)
+    'shadow_swing_vibration', # 素振りカウンターのバイブレーション設定(無料は利用不可)
+    'unlimited_groups' # グループ作成・参加を無制限に(無料は所属1件まで)
   ].freeze
 
   ALL_FEATURES = (FREE_FEATURES + PRO_FEATURES).freeze

--- a/app/models/concerns/entitlement.rb
+++ b/app/models/concerns/entitlement.rb
@@ -36,7 +36,9 @@ module Entitlement
     'unlimited_improvement_themes', # 課題テーマ無制限(無料は取組中1つまで)
     'correlation_insights',         # 相関インサイト(練習量・コンディション×成績の傾向)
     'unlimited_reflection_templates', # 振り返りテンプレの自作無制限(無料は1つまで・プリセットは全員可)
-    'advanced_periodic_review' # 週次/月次レポートの詳細(課題別内訳・相関・成績前週比・月次)
+    'advanced_periodic_review', # 週次/月次レポートの詳細(課題別内訳・相関・成績前週比・月次)
+    'note_tags', # 野球ノートへのタグ付け(無料は付与不可)
+    'multi_game_result_notes' # 野球ノートへの複数試合記録紐付け(無料は1件まで)
   ].freeze
 
   ALL_FEATURES = (FREE_FEATURES + PRO_FEATURES).freeze

--- a/app/models/concerns/entitlement.rb
+++ b/app/models/concerns/entitlement.rb
@@ -13,7 +13,7 @@ module Entitlement
     'shadow_swing_basic',    # 素振りカウンター(基本): スイング回数の記録
     'practice_log_basic',    # 練習記録(基本): 練習内容のログ
     'grass_recent_30days',   # 草機能: 直近30日分のヒートマップ表示
-    'monthly_goal_single',   # 個人の期間目標（月次/週次/年間/カスタム）: 2つまで作成可
+    'monthly_goal_single',   # 個人の期間目標（月次/週次/年間）: 2つまで作成可。カスタム期間は Pro 限定（custom_period_goals）
     'schedule_single'        # 自主練スケジュール: 無料でも無制限に作成可
   ].freeze
 

--- a/app/models/concerns/plan_limits.rb
+++ b/app/models/concerns/plan_limits.rb
@@ -7,7 +7,7 @@ module PlanLimits
 
   PRACTICE_MENU_FREE_LIMIT = 5
   MEDIA_UPLOAD_FREE_LIMIT_PER_MONTH = 3
-  MENU_SET_FREE_LIMIT = 3
+  MENU_SET_FREE_LIMIT = 2
   MONTHLY_GOAL_FREE_LIMIT = 2
   IMPROVEMENT_THEME_FREE_LIMIT = 1
   REFLECTION_TEMPLATE_FREE_LIMIT = 1
@@ -30,7 +30,7 @@ module PlanLimits
     media_attachments_count_this_month < MEDIA_UPLOAD_FREE_LIMIT_PER_MONTH
   end
 
-  # メニューセットを新規作成できるか。無料は3つまで。
+  # メニューセットを新規作成できるか。無料は2つまで。
   # @return [Boolean]
   def can_create_menu_set?
     return true if has_entitlement?('unlimited_menu_sets')

--- a/app/models/concerns/plan_limits.rb
+++ b/app/models/concerns/plan_limits.rb
@@ -13,6 +13,7 @@ module PlanLimits
   REFLECTION_TEMPLATE_FREE_LIMIT = 1
   # 「練習と成績のつながり」の自作カード上限（機能自体が Pro 限定のため Pro 内での歯止め）。
   INSIGHT_COMBINATION_LIMIT = 20
+  GROUP_FREE_LIMIT = 1
 
   # 練習メニューを新規作成できるか。無料は archived 以外3つまで。
   # @return [Boolean]
@@ -92,6 +93,16 @@ module PlanLimits
     insight_combinations.count < INSIGHT_COMBINATION_LIMIT
   end
 
+  # グループを新規作成・参加できるか。無料は所属（作成+参加の合算）が1件まで。
+  # 既に上限を超えて所属しているユーザーからグループを剥奪する処理ではないため、
+  # 既存の所属には一切影響しない（新規作成・参加のみをブロックする）。
+  # @return [Boolean]
+  def can_create_or_join_group?
+    return true if has_entitlement?('unlimited_groups')
+
+    accepted_groups_count < GROUP_FREE_LIMIT
+  end
+
   private
 
   # 各 Pro 機能 issue で実関連に差し替える。関連未実装のため現状は 0 を返す。
@@ -119,5 +130,11 @@ module PlanLimits
   def custom_reflection_templates_count
     # 編集で置き換えられた旧版（archived）は上限に数えない。
     reflection_templates.where(archived_at: nil).count
+  end
+
+  # 所属グループ数（作成+参加の合算）。GroupInvitation の accepted が実際の所属を表す
+  # （User#groups は作成したグループのみを返すため使えない）。
+  def accepted_groups_count
+    group_invitations.accepted.count
   end
 end

--- a/app/models/concerns/plan_limits.rb
+++ b/app/models/concerns/plan_limits.rb
@@ -5,7 +5,7 @@
 module PlanLimits
   extend ActiveSupport::Concern
 
-  PRACTICE_MENU_FREE_LIMIT = 5
+  PRACTICE_MENU_FREE_LIMIT = 3
   MEDIA_UPLOAD_FREE_LIMIT_PER_MONTH = 3
   MENU_SET_FREE_LIMIT = 2
   MONTHLY_GOAL_FREE_LIMIT = 2
@@ -14,7 +14,7 @@ module PlanLimits
   # 「練習と成績のつながり」の自作カード上限（機能自体が Pro 限定のため Pro 内での歯止め）。
   INSIGHT_COMBINATION_LIMIT = 20
 
-  # 練習メニューを新規作成できるか。無料は archived 以外5つまで。
+  # 練習メニューを新規作成できるか。無料は archived 以外3つまで。
   # @return [Boolean]
   def can_create_practice_menu?
     return true if has_entitlement?('unlimited_practice_menus')

--- a/app/models/concerns/plan_limits.rb
+++ b/app/models/concerns/plan_limits.rb
@@ -7,8 +7,7 @@ module PlanLimits
 
   PRACTICE_MENU_FREE_LIMIT = 5
   MEDIA_UPLOAD_FREE_LIMIT_PER_MONTH = 3
-  SCHEDULE_FREE_LIMIT = 3
-  MENU_SET_FREE_LIMIT = 2
+  MENU_SET_FREE_LIMIT = 3
   MONTHLY_GOAL_FREE_LIMIT = 2
   IMPROVEMENT_THEME_FREE_LIMIT = 1
   REFLECTION_TEMPLATE_FREE_LIMIT = 1
@@ -31,16 +30,7 @@ module PlanLimits
     media_attachments_count_this_month < MEDIA_UPLOAD_FREE_LIMIT_PER_MONTH
   end
 
-  # 練習プランの割り当て（schedule）を新規作成できるか。
-  # 無料は active なものが単発・繰り返し合算で3つまで。
-  # @return [Boolean]
-  def can_create_schedule?
-    return true if has_entitlement?('unlimited_schedules')
-
-    active_schedules_count < SCHEDULE_FREE_LIMIT
-  end
-
-  # メニューセットを新規作成できるか。無料は2つまで。
+  # メニューセットを新規作成できるか。無料は3つまで。
   # @return [Boolean]
   def can_create_menu_set?
     return true if has_entitlement?('unlimited_menu_sets')
@@ -99,10 +89,6 @@ module PlanLimits
 
   def media_attachments_count_this_month
     0
-  end
-
-  def active_schedules_count
-    schedules.active.count
   end
 
   def menu_sets_count

--- a/app/models/concerns/plan_limits.rb
+++ b/app/models/concerns/plan_limits.rb
@@ -9,7 +9,7 @@ module PlanLimits
   MEDIA_UPLOAD_FREE_LIMIT_PER_MONTH = 3
   MENU_SET_FREE_LIMIT = 2
   MONTHLY_GOAL_FREE_LIMIT = 2
-  IMPROVEMENT_THEME_FREE_LIMIT = 1
+  IMPROVEMENT_THEME_FREE_LIMIT = 2
   REFLECTION_TEMPLATE_FREE_LIMIT = 1
   # 「練習と成績のつながり」の自作カード上限（機能自体が Pro 限定のため Pro 内での歯止め）。
   INSIGHT_COMBINATION_LIMIT = 20
@@ -58,12 +58,24 @@ module PlanLimits
     has_entitlement?('tournament_goals')
   end
 
-  # 課題テーマを新規作成できるか。無料は取組中（open）が1つまで。
+  # 課題テーマを新規作成できるか。無料は取組中（open）が2つまで。
   # @return [Boolean]
   def can_create_improvement_theme?
     return true if has_entitlement?('unlimited_improvement_themes')
 
     open_improvement_themes_count < IMPROVEMENT_THEME_FREE_LIMIT
+  end
+
+  # カスタム期間の個人目標を新規作成できるか。Pro 限定機能。
+  # @return [Boolean]
+  def can_create_custom_period_goal?
+    has_entitlement?('custom_period_goals')
+  end
+
+  # 自由指標（手動更新）の目標を新規作成できるか。Pro 限定機能。
+  # @return [Boolean]
+  def can_create_manual_metric_goal?
+    has_entitlement?('manual_metric_goals')
   end
 
   # 振り返りテンプレを自作できるか。無料は1つまで。プリセット利用は本制限の対象外。

--- a/app/models/game_result.rb
+++ b/app/models/game_result.rb
@@ -7,6 +7,10 @@ class GameResult < ApplicationRecord
   has_many :plate_appearances, dependent: :destroy
   has_one :batting_average, dependent: :destroy
   has_one :pitching_result, dependent: :destroy
+  # 試合削除時にノート紐付け（note_game_links）も消す（ノート本体は独立レコードなので残る）。
+  # match_result 側の ON DELETE CASCADE が game_results 行を先に消すため、
+  # 中間リンクは DB 側の on_delete: :cascade で確実に除去する（本 dependent は直接削除経路の保険）。
+  has_many :note_game_links, dependent: :destroy
 
   def self.all_game_associated_data
     includes(:user, :match_result, :plate_appearances, :pitching_result)

--- a/app/models/improvement_theme.rb
+++ b/app/models/improvement_theme.rb
@@ -1,7 +1,9 @@
 class ImprovementTheme < ApplicationRecord
   belongs_to :user
-  has_many :practice_sessions, dependent: :nullify
-  has_many :baseball_notes, dependent: :nullify
+  has_many :practice_session_theme_links, dependent: :destroy
+  has_many :practice_sessions, through: :practice_session_theme_links
+  has_many :note_theme_links, dependent: :destroy
+  has_many :baseball_notes, through: :note_theme_links
 
   # open: 取組中 / achieved: 克服(達成) / archived: 取りやめ
   enum status: { open: 'open', achieved: 'achieved', archived: 'archived' }, _default: 'open'

--- a/app/models/note_game_link.rb
+++ b/app/models/note_game_link.rb
@@ -1,0 +1,4 @@
+class NoteGameLink < ApplicationRecord
+  belongs_to :baseball_note
+  belongs_to :game_result
+end

--- a/app/models/note_theme_link.rb
+++ b/app/models/note_theme_link.rb
@@ -1,0 +1,4 @@
+class NoteThemeLink < ApplicationRecord
+  belongs_to :baseball_note
+  belongs_to :improvement_theme
+end

--- a/app/models/practice_session.rb
+++ b/app/models/practice_session.rb
@@ -1,10 +1,12 @@
 class PracticeSession < ApplicationRecord
   belongs_to :user
-  belongs_to :improvement_theme, optional: true
   # nullify だと after_commit（草・Streak 再計算）が発火せず集計が古いまま残るため destroy にする。
   has_many :practice_logs, dependent: :destroy
   # ノートは独立した記録なので、セッションを消しても紐付けだけ外して残す。
   has_many :baseball_notes, dependent: :nullify
+  # 課題は複数紐付け可（無料は1件・Proは複数、controller/service側で制限）。
+  has_many :practice_session_theme_links, dependent: :destroy
+  has_many :improvement_themes, through: :practice_session_theme_links
 
   validates :logged_on, presence: true
   validates :user_id, uniqueness: { scope: :logged_on }

--- a/app/models/practice_session_theme_link.rb
+++ b/app/models/practice_session_theme_link.rb
@@ -1,0 +1,4 @@
+class PracticeSessionThemeLink < ApplicationRecord
+  belongs_to :practice_session
+  belongs_to :improvement_theme
+end

--- a/app/serializers/v2/baseball_note_serializer.rb
+++ b/app/serializers/v2/baseball_note_serializer.rb
@@ -1,7 +1,7 @@
 module V2
   class BaseballNoteSerializer < ActiveModel::Serializer
     attributes :id, :title, :date, :memo, :memo_preview, :game_result_ids, :practice_log_id, :practice_session_id,
-               :improvement_theme_id, :reflection_template_id, :reflection_answers, :tags
+               :improvement_theme_ids, :reflection_template_id, :reflection_answers, :tags
 
     def memo_preview
       object.extract_and_truncate_memo
@@ -10,6 +10,11 @@ module V2
     def game_result_ids
       # includes(:game_results) 済みの前提で N+1 を避ける。
       object.game_results.map(&:id)
+    end
+
+    def improvement_theme_ids
+      # includes(:improvement_themes) 済みの前提で N+1 を避ける。
+      object.improvement_themes.map(&:id)
     end
 
     def tags

--- a/app/serializers/v2/baseball_note_serializer.rb
+++ b/app/serializers/v2/baseball_note_serializer.rb
@@ -1,10 +1,15 @@
 module V2
   class BaseballNoteSerializer < ActiveModel::Serializer
-    attributes :id, :title, :date, :memo, :memo_preview, :game_result_id, :practice_log_id, :practice_session_id,
+    attributes :id, :title, :date, :memo, :memo_preview, :game_result_ids, :practice_log_id, :practice_session_id,
                :improvement_theme_id, :reflection_template_id, :reflection_answers, :tags
 
     def memo_preview
       object.extract_and_truncate_memo
+    end
+
+    def game_result_ids
+      # includes(:game_results) 済みの前提で N+1 を避ける。
+      object.game_results.map(&:id)
     end
 
     def tags

--- a/app/serializers/v2/periodic_review_serializer.rb
+++ b/app/serializers/v2/periodic_review_serializer.rb
@@ -1,6 +1,7 @@
 module V2
-  # 週次 / 月次レポート。基本部（練習量・Streak）は全員に、詳細部（課題別内訳・
-  # コンディション・成績前週比・相関）は Pro のみに返す。出し分けは instance_options[:pro]。
+  # 週次 / 月次レポート。振り返りレポート自体が Pro 限定機能で、コントローラー側で
+  # 無料ユーザーには対象レコードを渡さない。詳細部（課題別内訳・コンディション・相関）の
+  # 除外は Pro ユーザー内での区分けが将来入る場合に備えた防御的な出し分け。
   class PeriodicReviewSerializer < ActiveModel::Serializer
     attributes :id, :period_type, :period_start, :period_end, :read, :summary
 

--- a/app/serializers/v2/practice_session_serializer.rb
+++ b/app/serializers/v2/practice_session_serializer.rb
@@ -3,13 +3,18 @@ module V2
   # `condition_logs_by_date`（logged_on => ConditionLog）を instance_options で受け取ると
   # それを使う（一覧表示での N+1 防止）。無ければ個別に 1 件取得する（show 等の単発表示用）。
   class PracticeSessionSerializer < ActiveModel::Serializer
-    attributes :id, :logged_on, :memo, :improvement_theme_id, :created_at
+    attributes :id, :logged_on, :memo, :improvement_theme_ids, :created_at
 
     has_many :practice_logs, serializer: V2::PracticeLogSerializer
 
     attribute :condition do
       log = preloaded_condition_logs? ? instance_options[:condition_logs_by_date][object.logged_on] : object.condition_log
       log && V2::ConditionLogSerializer.new(log).as_json
+    end
+
+    def improvement_theme_ids
+      # includes(:improvement_themes) 済みの前提で N+1 を避ける。
+      object.improvement_themes.map(&:id)
     end
 
     private

--- a/app/serializers/v2/schedule_serializer.rb
+++ b/app/serializers/v2/schedule_serializer.rb
@@ -2,7 +2,8 @@ module V2
   class ScheduleSerializer < ActiveModel::Serializer
     attributes :id, :title, :days_of_week, :planned_on, :scheduled_time, :event_type,
                :recurring, :menu_set_id, :game_result_id, :note,
-               :notification_enabled, :active, :notification_message, :menus
+               :notification_enabled, :active, :notification_message, :menus,
+               :logged_practice_menu_ids
 
     def title
       object.display_title
@@ -22,6 +23,13 @@ module V2
       object.resolved_menu_items.map do |item|
         item.slice(:practice_menu_id, :name, :unit_label, :target_value)
       end
+    end
+
+    # この予定に対して過去に練習ログが記録済みの practice_menu_id 一覧。
+    # 編集画面でこの予定のメニューを変更してしまうと済判定が壊れるため、
+    # 該当メニューを編集不可にする目印としてクライアントへ返す。
+    def logged_practice_menu_ids
+      object.practice_logs.filter_map(&:practice_menu_id).uniq
     end
   end
 end

--- a/app/services/practice_sessions/upsert.rb
+++ b/app/services/practice_sessions/upsert.rb
@@ -10,17 +10,20 @@ module PracticeSessions
     # コンディション記録は Pro 限定のため、未加入時に投げる。
     class NotEntitled < StandardError; end
 
+    # 複数課題への紐付けは Pro 限定のため、無料ユーザーが2件以上指定したときに投げる。
+    class ThemeLimitExceeded < StandardError; end
+
     # @param user [User]
     # @param logged_on [Date, String]
     # @param memo [String, nil] その日の振り返りメモ
-    # @param improvement_theme_id [Integer, String, nil] 紐付ける課題テーマ（空文字は紐付け解除）
+    # @param improvement_theme_ids [Array<Integer, String>, nil] 紐付ける課題テーマ群（nilならテーマ紐付けを更新しない）
     # @param items [Array<Hash>] [{ practice_menu_id:, amount:, memo: }]
     # @param condition [Hash, nil] コンディション入力（nil なら更新しない）
-    def initialize(user:, logged_on:, memo: nil, improvement_theme_id: nil, items: [], condition: nil) # rubocop:disable Metrics/ParameterLists
+    def initialize(user:, logged_on:, memo: nil, improvement_theme_ids: nil, items: [], condition: nil) # rubocop:disable Metrics/ParameterLists
       @user = user
       @logged_on = logged_on
       @memo = memo
-      @improvement_theme_id = improvement_theme_id
+      @improvement_theme_ids = improvement_theme_ids
       @items = items || []
       @condition = condition
     end
@@ -31,7 +34,7 @@ module PracticeSessions
       ActiveRecord::Base.transaction do
         session = PracticeSession.for(@user, @logged_on)
         session.update!(memo: @memo) unless @memo.nil?
-        assign_theme(session) unless @improvement_theme_id.nil?
+        assign_themes(session) unless @improvement_theme_ids.nil?
         sync_items(session)
         upsert_condition if @condition.present?
       end
@@ -40,11 +43,12 @@ module PracticeSessions
 
     private
 
-    # 自分の課題テーマのみ紐付ける（他ユーザーの課題は無視）。空文字なら紐付け解除。
-    def assign_theme(session)
-      theme_id = @improvement_theme_id.presence
-      owned = theme_id && @user.improvement_themes.exists?(theme_id)
-      session.update!(improvement_theme_id: owned ? theme_id : nil)
+    # 自分の課題テーマのみ紐付ける（他ユーザーの課題は無視）。無料は1件まで、Proは複数件可。
+    def assign_themes(session)
+      owned_ids = @user.improvement_themes.where(id: @improvement_theme_ids).pluck(:id)
+      raise ThemeLimitExceeded if owned_ids.size > 1 && !@user.has_entitlement?('multi_improvement_theme_links')
+
+      session.improvement_theme_ids = owned_ids
     end
 
     # メニュー量ログを practice_menu_id ベースで差分同期する。

--- a/app/services/practice_sessions/upsert.rb
+++ b/app/services/practice_sessions/upsert.rb
@@ -44,9 +44,16 @@ module PracticeSessions
     private
 
     # 自分の課題テーマのみ紐付ける（他ユーザーの課題は無視）。無料は1件まで、Proは複数件可。
+    # Pro 解約後も既存の複数紐付けを維持・削減できるよう、既存件数を超えて新規に増やす場合のみ
+    # Pro 判定する（グランドファザリング）。session は find_or_create 済みで、
+    # ここでの session.improvement_theme_ids は更新前の既存値を表す。
     def assign_themes(session)
       owned_ids = @user.improvement_themes.where(id: @improvement_theme_ids).pluck(:id)
-      raise ThemeLimitExceeded if owned_ids.size > 1 && !@user.has_entitlement?('multi_improvement_theme_links')
+      existing_ids = session.improvement_theme_ids
+      if owned_ids.size > 1 && owned_ids.size > existing_ids.size &&
+         !@user.has_entitlement?('multi_improvement_theme_links')
+        raise ThemeLimitExceeded
+      end
 
       session.improvement_theme_ids = owned_ids
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -281,6 +281,7 @@ Rails.application.routes.draw do
         collection { get :streak }
       end
       resources :schedules, only: %i[index create update destroy]
+      post 'schedules/week_copy', to: 'schedules/week_copies#create'
       resources :menu_sets, only: %i[index show create update destroy]
       get 'plans/by_date', to: 'plans#by_date'
       get 'plans/calendar', to: 'plans#calendar'

--- a/db/migrate/20260713010001_create_note_game_links.rb
+++ b/db/migrate/20260713010001_create_note_game_links.rb
@@ -1,0 +1,11 @@
+class CreateNoteGameLinks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :note_game_links do |t|
+      t.references :baseball_note, null: false, foreign_key: true
+      t.references :game_result, null: false, foreign_key: true
+      t.timestamps
+    end
+
+    add_index :note_game_links, %i[baseball_note_id game_result_id], unique: true
+  end
+end

--- a/db/migrate/20260713010002_backfill_note_game_links.rb
+++ b/db/migrate/20260713010002_backfill_note_game_links.rb
@@ -1,0 +1,24 @@
+class BackfillNoteGameLinks < ActiveRecord::Migration[7.1]
+  # マイグレーション内では将来カラム削除・型変更されるアプリのモデルに依存しないよう、
+  # このマイグレーション実行時点のテーブル構造だけを見る匿名モデルを使う。
+  # rubocop:disable Rails/ApplicationRecord
+  class MigrationBaseballNote < ActiveRecord::Base
+    self.table_name = 'baseball_notes'
+  end
+
+  class MigrationNoteGameLink < ActiveRecord::Base
+    self.table_name = 'note_game_links'
+  end
+  # rubocop:enable Rails/ApplicationRecord
+
+  def up
+    MigrationBaseballNote.where.not(game_result_id: nil).find_each do |note|
+      MigrationNoteGameLink.find_or_create_by!(baseball_note_id: note.id, game_result_id: note.game_result_id)
+    end
+  end
+
+  def down
+    # note_game_links から baseball_notes.game_result_id への書き戻しは、複数紐付けがある場合に
+    # 非可逆（1件しか書き戻せない）ため何もしない。ロールバックは本マイグレーションの前段で止める運用とする。
+  end
+end

--- a/db/migrate/20260713010003_remove_game_result_id_from_baseball_notes.rb
+++ b/db/migrate/20260713010003_remove_game_result_id_from_baseball_notes.rb
@@ -1,0 +1,5 @@
+class RemoveGameResultIdFromBaseballNotes < ActiveRecord::Migration[7.1]
+  def change
+    remove_reference :baseball_notes, :game_result, foreign_key: { on_delete: :nullify }, index: true
+  end
+end

--- a/db/migrate/20260714010001_create_practice_session_theme_links.rb
+++ b/db/migrate/20260714010001_create_practice_session_theme_links.rb
@@ -1,0 +1,12 @@
+class CreatePracticeSessionThemeLinks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :practice_session_theme_links do |t|
+      t.references :practice_session, null: false, foreign_key: true
+      t.references :improvement_theme, null: false, foreign_key: true
+      t.timestamps
+    end
+
+    add_index :practice_session_theme_links, %i[practice_session_id improvement_theme_id], unique: true,
+                                                                                           name: 'index_theme_links_on_session_and_theme'
+  end
+end

--- a/db/migrate/20260714010002_backfill_practice_session_theme_links.rb
+++ b/db/migrate/20260714010002_backfill_practice_session_theme_links.rb
@@ -1,0 +1,26 @@
+class BackfillPracticeSessionThemeLinks < ActiveRecord::Migration[7.1]
+  # マイグレーション内では将来カラム削除・型変更されるアプリのモデルに依存しないよう、
+  # このマイグレーション実行時点のテーブル構造だけを見る匿名モデルを使う。
+  # rubocop:disable Rails/ApplicationRecord
+  class MigrationPracticeSession < ActiveRecord::Base
+    self.table_name = 'practice_sessions'
+  end
+
+  class MigrationPracticeSessionThemeLink < ActiveRecord::Base
+    self.table_name = 'practice_session_theme_links'
+  end
+  # rubocop:enable Rails/ApplicationRecord
+
+  def up
+    MigrationPracticeSession.where.not(improvement_theme_id: nil).find_each do |session|
+      MigrationPracticeSessionThemeLink.find_or_create_by!(
+        practice_session_id: session.id, improvement_theme_id: session.improvement_theme_id
+      )
+    end
+  end
+
+  def down
+    # 複数紐付けがある場合、単一カラムへの書き戻しは情報損失があるため何もしない。
+    # ロールバックは本マイグレーションの前段で止める運用とする。
+  end
+end

--- a/db/migrate/20260714010003_remove_improvement_theme_id_from_practice_sessions.rb
+++ b/db/migrate/20260714010003_remove_improvement_theme_id_from_practice_sessions.rb
@@ -1,0 +1,5 @@
+class RemoveImprovementThemeIdFromPracticeSessions < ActiveRecord::Migration[7.1]
+  def change
+    remove_reference :practice_sessions, :improvement_theme, foreign_key: true, index: true
+  end
+end

--- a/db/migrate/20260714010004_create_note_theme_links.rb
+++ b/db/migrate/20260714010004_create_note_theme_links.rb
@@ -1,0 +1,12 @@
+class CreateNoteThemeLinks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :note_theme_links do |t|
+      t.references :baseball_note, null: false, foreign_key: true
+      t.references :improvement_theme, null: false, foreign_key: true
+      t.timestamps
+    end
+
+    add_index :note_theme_links, %i[baseball_note_id improvement_theme_id], unique: true,
+                                                                            name: 'index_theme_links_on_note_and_theme'
+  end
+end

--- a/db/migrate/20260714010005_backfill_note_theme_links.rb
+++ b/db/migrate/20260714010005_backfill_note_theme_links.rb
@@ -1,0 +1,24 @@
+class BackfillNoteThemeLinks < ActiveRecord::Migration[7.1]
+  # rubocop:disable Rails/ApplicationRecord
+  class MigrationBaseballNote < ActiveRecord::Base
+    self.table_name = 'baseball_notes'
+  end
+
+  class MigrationNoteThemeLink < ActiveRecord::Base
+    self.table_name = 'note_theme_links'
+  end
+  # rubocop:enable Rails/ApplicationRecord
+
+  def up
+    MigrationBaseballNote.where.not(improvement_theme_id: nil).find_each do |note|
+      MigrationNoteThemeLink.find_or_create_by!(
+        baseball_note_id: note.id, improvement_theme_id: note.improvement_theme_id
+      )
+    end
+  end
+
+  def down
+    # 複数紐付けがある場合、単一カラムへの書き戻しは情報損失があるため何もしない。
+    # ロールバックは本マイグレーションの前段で止める運用とする。
+  end
+end

--- a/db/migrate/20260714010006_remove_improvement_theme_id_from_baseball_notes.rb
+++ b/db/migrate/20260714010006_remove_improvement_theme_id_from_baseball_notes.rb
@@ -1,0 +1,5 @@
+class RemoveImprovementThemeIdFromBaseballNotes < ActiveRecord::Migration[7.1]
+  def change
+    remove_reference :baseball_notes, :improvement_theme, foreign_key: true, index: true
+  end
+end

--- a/db/migrate/20260720010001_change_note_game_links_game_result_fk_to_cascade.rb
+++ b/db/migrate/20260720010001_change_note_game_links_game_result_fk_to_cascade.rb
@@ -1,0 +1,15 @@
+class ChangeNoteGameLinksGameResultFkToCascade < ActiveRecord::Migration[7.1]
+  # game_results.match_result_id が ON DELETE CASCADE のため、has_one match_result の
+  # dependent: :destroy で match_result を消すと DB カスケードで game_results 行が先に消える。
+  # このとき note_game_links.game_result_id が NO ACTION だと FK 違反で試合削除が失敗するため、
+  # 中間リンク側も ON DELETE CASCADE にして親削除に追随させる。
+  def up
+    remove_foreign_key :note_game_links, :game_results
+    add_foreign_key :note_game_links, :game_results, on_delete: :cascade
+  end
+
+  def down
+    remove_foreign_key :note_game_links, :game_results
+    add_foreign_key :note_game_links, :game_results
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_07_14_010006) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_20_010001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -1115,7 +1115,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_14_010006) do
   add_foreign_key "menu_set_items", "practice_menus"
   add_foreign_key "menu_sets", "users"
   add_foreign_key "note_game_links", "baseball_notes"
-  add_foreign_key "note_game_links", "game_results"
+  add_foreign_key "note_game_links", "game_results", on_delete: :cascade
   add_foreign_key "note_taggings", "baseball_notes"
   add_foreign_key "note_taggings", "note_tags"
   add_foreign_key "note_tags", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_07_09_010001) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_13_010003) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -145,13 +145,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_09_010001) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "game_result_id"
     t.bigint "practice_log_id"
     t.bigint "practice_session_id"
     t.bigint "improvement_theme_id"
     t.jsonb "reflection_answers", default: [], null: false
     t.bigint "reflection_template_id"
-    t.index ["game_result_id"], name: "index_baseball_notes_on_game_result_id"
     t.index ["improvement_theme_id"], name: "index_baseball_notes_on_improvement_theme_id"
     t.index ["practice_log_id"], name: "index_baseball_notes_on_practice_log_id"
     t.index ["practice_session_id"], name: "index_baseball_notes_on_practice_session_id"
@@ -443,6 +441,16 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_09_010001) do
     t.datetime "updated_at", null: false
     t.index ["user_id", "sort_order"], name: "index_menu_sets_on_user_id_and_sort_order"
     t.index ["user_id"], name: "index_menu_sets_on_user_id"
+  end
+
+  create_table "note_game_links", force: :cascade do |t|
+    t.bigint "baseball_note_id", null: false
+    t.bigint "game_result_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["baseball_note_id", "game_result_id"], name: "index_note_game_links_on_baseball_note_id_and_game_result_id", unique: true
+    t.index ["baseball_note_id"], name: "index_note_game_links_on_baseball_note_id"
+    t.index ["game_result_id"], name: "index_note_game_links_on_game_result_id"
   end
 
   create_table "note_taggings", force: :cascade do |t|
@@ -1051,7 +1059,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_09_010001) do
 
   add_foreign_key "activity_logs", "users"
   add_foreign_key "admin_refresh_tokens", "admin_users"
-  add_foreign_key "baseball_notes", "game_results", on_delete: :nullify
   add_foreign_key "baseball_notes", "improvement_themes"
   add_foreign_key "baseball_notes", "practice_logs", on_delete: :nullify
   add_foreign_key "baseball_notes", "practice_sessions"
@@ -1092,6 +1099,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_09_010001) do
   add_foreign_key "menu_set_items", "menu_sets"
   add_foreign_key "menu_set_items", "practice_menus"
   add_foreign_key "menu_sets", "users"
+  add_foreign_key "note_game_links", "baseball_notes"
+  add_foreign_key "note_game_links", "game_results"
   add_foreign_key "note_taggings", "baseball_notes"
   add_foreign_key "note_taggings", "note_tags"
   add_foreign_key "note_tags", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_07_13_010003) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_14_010006) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -147,10 +147,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_13_010003) do
     t.datetime "updated_at", null: false
     t.bigint "practice_log_id"
     t.bigint "practice_session_id"
-    t.bigint "improvement_theme_id"
     t.jsonb "reflection_answers", default: [], null: false
     t.bigint "reflection_template_id"
-    t.index ["improvement_theme_id"], name: "index_baseball_notes_on_improvement_theme_id"
     t.index ["practice_log_id"], name: "index_baseball_notes_on_practice_log_id"
     t.index ["practice_session_id"], name: "index_baseball_notes_on_practice_session_id"
     t.index ["reflection_template_id"], name: "index_baseball_notes_on_reflection_template_id"
@@ -474,6 +472,16 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_13_010003) do
     t.index ["user_id"], name: "index_note_tags_on_user_id"
   end
 
+  create_table "note_theme_links", force: :cascade do |t|
+    t.bigint "baseball_note_id", null: false
+    t.bigint "improvement_theme_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["baseball_note_id", "improvement_theme_id"], name: "index_theme_links_on_note_and_theme", unique: true
+    t.index ["baseball_note_id"], name: "index_note_theme_links_on_baseball_note_id"
+    t.index ["improvement_theme_id"], name: "index_note_theme_links_on_improvement_theme_id"
+  end
+
   create_table "notifications", force: :cascade do |t|
     t.bigint "actor_id", null: false
     t.string "event_type", null: false
@@ -657,14 +665,22 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_13_010003) do
     t.index ["user_id"], name: "index_practice_menus_on_user_id"
   end
 
+  create_table "practice_session_theme_links", force: :cascade do |t|
+    t.bigint "practice_session_id", null: false
+    t.bigint "improvement_theme_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["improvement_theme_id"], name: "index_practice_session_theme_links_on_improvement_theme_id"
+    t.index ["practice_session_id", "improvement_theme_id"], name: "index_theme_links_on_session_and_theme", unique: true
+    t.index ["practice_session_id"], name: "index_practice_session_theme_links_on_practice_session_id"
+  end
+
   create_table "practice_sessions", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.date "logged_on", null: false
     t.text "memo"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "improvement_theme_id"
-    t.index ["improvement_theme_id"], name: "index_practice_sessions_on_improvement_theme_id"
     t.index ["user_id", "logged_on"], name: "index_practice_sessions_on_user_id_and_logged_on", unique: true
     t.index ["user_id"], name: "index_practice_sessions_on_user_id"
   end
@@ -1059,7 +1075,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_13_010003) do
 
   add_foreign_key "activity_logs", "users"
   add_foreign_key "admin_refresh_tokens", "admin_users"
-  add_foreign_key "baseball_notes", "improvement_themes"
   add_foreign_key "baseball_notes", "practice_logs", on_delete: :nullify
   add_foreign_key "baseball_notes", "practice_sessions"
   add_foreign_key "baseball_notes", "reflection_templates"
@@ -1104,6 +1119,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_13_010003) do
   add_foreign_key "note_taggings", "baseball_notes"
   add_foreign_key "note_taggings", "note_tags"
   add_foreign_key "note_tags", "users"
+  add_foreign_key "note_theme_links", "baseball_notes"
+  add_foreign_key "note_theme_links", "improvement_themes"
   add_foreign_key "notifications", "users", column: "actor_id"
   add_foreign_key "periodic_reviews", "users"
   add_foreign_key "pitchers", "arm_angles"
@@ -1124,7 +1141,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_13_010003) do
   add_foreign_key "practice_logs", "schedules"
   add_foreign_key "practice_logs", "users"
   add_foreign_key "practice_menus", "users"
-  add_foreign_key "practice_sessions", "improvement_themes"
+  add_foreign_key "practice_session_theme_links", "improvement_themes"
+  add_foreign_key "practice_session_theme_links", "practice_sessions"
   add_foreign_key "practice_sessions", "users"
   add_foreign_key "reflection_templates", "users"
   add_foreign_key "schedule_menus", "practice_menus"

--- a/spec/factories/baseball_notes.rb
+++ b/spec/factories/baseball_notes.rb
@@ -2,5 +2,13 @@ FactoryBot.define do
   factory :baseball_note do
     user
     memo { nil }
+
+    transient do
+      improvement_theme { nil }
+    end
+
+    after(:create) do |note, evaluator|
+      note.improvement_themes << evaluator.improvement_theme if evaluator.improvement_theme
+    end
   end
 end

--- a/spec/factories/note_game_links.rb
+++ b/spec/factories/note_game_links.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :note_game_link do
+    baseball_note
+    game_result
+  end
+end

--- a/spec/factories/note_theme_links.rb
+++ b/spec/factories/note_theme_links.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :note_theme_link do
+    baseball_note
+    improvement_theme
+  end
+end

--- a/spec/factories/practice_session_theme_links.rb
+++ b/spec/factories/practice_session_theme_links.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :practice_session_theme_link do
+    practice_session
+    improvement_theme
+  end
+end

--- a/spec/factories/practice_sessions.rb
+++ b/spec/factories/practice_sessions.rb
@@ -3,5 +3,13 @@ FactoryBot.define do
     user
     logged_on { Time.find_zone('Asia/Tokyo').today }
     memo { nil }
+
+    transient do
+      improvement_theme { nil }
+    end
+
+    after(:create) do |session, evaluator|
+      session.improvement_themes << evaluator.improvement_theme if evaluator.improvement_theme
+    end
   end
 end

--- a/spec/models/concerns/entitlement_spec.rb
+++ b/spec/models/concerns/entitlement_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe Entitlement, type: :model do
   let(:user) { create(:user) }
 
   describe 'feature key constants' do
-    it 'defines exactly 10 free features and 26 pro features' do
+    it 'defines exactly 10 free features and 27 pro features' do
       # %w[] とインラインコメントの混在で feature key が壊れる回帰を防ぐ
       expect(described_class::FREE_FEATURES.size).to eq 10
-      expect(described_class::PRO_FEATURES.size).to eq 26
-      expect(described_class::ALL_FEATURES.size).to eq 36
+      expect(described_class::PRO_FEATURES.size).to eq 27
+      expect(described_class::ALL_FEATURES.size).to eq 37
     end
 
     it 'contains only valid feature key strings (no stray symbols)' do
@@ -82,6 +82,29 @@ RSpec.describe Entitlement, type: :model do
     it 'returns true for a Pro user' do
       user.subscription.update!(status: 'active', expires_at: 30.days.from_now)
       expect(user.can_create_season_goal?).to be true
+    end
+  end
+
+  describe '#can_create_or_join_group?' do
+    it 'returns true for a free user with no groups' do
+      expect(user.can_create_or_join_group?).to be true
+    end
+
+    it 'returns false for a free user already belonging to 1 group' do
+      GroupInvitation.create!(user:, group: create(:group), state: 'accepted', sent_at: Time.current)
+      expect(user.can_create_or_join_group?).to be false
+    end
+
+    it 'returns true for a Pro user regardless of existing groups' do
+      user.subscription.update!(status: 'active', expires_at: 30.days.from_now)
+      2.times { GroupInvitation.create!(user:, group: create(:group), state: 'accepted', sent_at: Time.current) }
+      expect(user.can_create_or_join_group?).to be true
+    end
+
+    it 'does not modify existing accepted group invitations (grandfathering)' do
+      2.times { GroupInvitation.create!(user:, group: create(:group), state: 'accepted', sent_at: Time.current) }
+      expect { user.can_create_or_join_group? }.not_to(change { user.group_invitations.accepted.count })
+      expect(user.group_invitations.accepted.count).to eq 2
     end
   end
 end

--- a/spec/models/concerns/entitlement_spec.rb
+++ b/spec/models/concerns/entitlement_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe Entitlement, type: :model do
   let(:user) { create(:user) }
 
   describe 'feature key constants' do
-    it 'defines exactly 10 free features and 22 pro features' do
+    it 'defines exactly 10 free features and 24 pro features' do
       # %w[] とインラインコメントの混在で feature key が壊れる回帰を防ぐ
       expect(described_class::FREE_FEATURES.size).to eq 10
-      expect(described_class::PRO_FEATURES.size).to eq 22
-      expect(described_class::ALL_FEATURES.size).to eq 32
+      expect(described_class::PRO_FEATURES.size).to eq 24
+      expect(described_class::ALL_FEATURES.size).to eq 34
     end
 
     it 'contains only valid feature key strings (no stray symbols)' do

--- a/spec/models/concerns/entitlement_spec.rb
+++ b/spec/models/concerns/entitlement_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe Entitlement, type: :model do
   let(:user) { create(:user) }
 
   describe 'feature key constants' do
-    it 'defines exactly 10 free features and 18 pro features' do
+    it 'defines exactly 10 free features and 20 pro features' do
       # %w[] とインラインコメントの混在で feature key が壊れる回帰を防ぐ
       expect(described_class::FREE_FEATURES.size).to eq 10
-      expect(described_class::PRO_FEATURES.size).to eq 18
-      expect(described_class::ALL_FEATURES.size).to eq 28
+      expect(described_class::PRO_FEATURES.size).to eq 20
+      expect(described_class::ALL_FEATURES.size).to eq 30
     end
 
     it 'contains only valid feature key strings (no stray symbols)' do

--- a/spec/models/concerns/entitlement_spec.rb
+++ b/spec/models/concerns/entitlement_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe Entitlement, type: :model do
   let(:user) { create(:user) }
 
   describe 'feature key constants' do
-    it 'defines exactly 10 free features and 24 pro features' do
+    it 'defines exactly 10 free features and 26 pro features' do
       # %w[] とインラインコメントの混在で feature key が壊れる回帰を防ぐ
       expect(described_class::FREE_FEATURES.size).to eq 10
-      expect(described_class::PRO_FEATURES.size).to eq 24
-      expect(described_class::ALL_FEATURES.size).to eq 34
+      expect(described_class::PRO_FEATURES.size).to eq 26
+      expect(described_class::ALL_FEATURES.size).to eq 36
     end
 
     it 'contains only valid feature key strings (no stray symbols)' do

--- a/spec/models/concerns/entitlement_spec.rb
+++ b/spec/models/concerns/entitlement_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe Entitlement, type: :model do
   let(:user) { create(:user) }
 
   describe 'feature key constants' do
-    it 'defines exactly 10 free features and 21 pro features' do
+    it 'defines exactly 10 free features and 22 pro features' do
       # %w[] とインラインコメントの混在で feature key が壊れる回帰を防ぐ
       expect(described_class::FREE_FEATURES.size).to eq 10
-      expect(described_class::PRO_FEATURES.size).to eq 21
-      expect(described_class::ALL_FEATURES.size).to eq 31
+      expect(described_class::PRO_FEATURES.size).to eq 22
+      expect(described_class::ALL_FEATURES.size).to eq 32
     end
 
     it 'contains only valid feature key strings (no stray symbols)' do

--- a/spec/models/concerns/entitlement_spec.rb
+++ b/spec/models/concerns/entitlement_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe Entitlement, type: :model do
   let(:user) { create(:user) }
 
   describe 'feature key constants' do
-    it 'defines exactly 10 free features and 20 pro features' do
+    it 'defines exactly 10 free features and 21 pro features' do
       # %w[] とインラインコメントの混在で feature key が壊れる回帰を防ぐ
       expect(described_class::FREE_FEATURES.size).to eq 10
-      expect(described_class::PRO_FEATURES.size).to eq 20
-      expect(described_class::ALL_FEATURES.size).to eq 30
+      expect(described_class::PRO_FEATURES.size).to eq 21
+      expect(described_class::ALL_FEATURES.size).to eq 31
     end
 
     it 'contains only valid feature key strings (no stray symbols)' do

--- a/spec/requests/api/v1/game_results_spec.rb
+++ b/spec/requests/api/v1/game_results_spec.rb
@@ -260,6 +260,20 @@ RSpec.describe 'Api::V1::GameResults', type: :request do
         expect(GameResult.exists?(other_user_game_result.id)).to be true
       end
     end
+
+    context 'when a baseball note is linked to the game result' do
+      it 'destroys the game result and its note links, leaving the note intact' do
+        note = create(:baseball_note, user:)
+        note.game_result_ids = [game_result.id]
+
+        delete "/api/v1/game_results/#{game_result.id}", headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(GameResult.exists?(game_result.id)).to be false
+        expect(NoteGameLink.where(game_result_id: game_result.id)).to be_empty
+        expect(BaseballNote.exists?(note.id)).to be true
+      end
+    end
   end
 
   describe 'GET /api/v1/game_results/filtered_game_associated_data' do

--- a/spec/requests/api/v1/group_invitations_spec.rb
+++ b/spec/requests/api/v1/group_invitations_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::GroupInvitations', type: :request do
+  let(:user) { create(:user) }
+  let(:group) { create(:group) }
+
+  describe 'POST /api/v1/group_invitations/:id/accept_invitation' do
+    context 'when a pending invitation exists' do
+      let!(:invitation) { create(:group_invitation, user:, group:, state: 'pending') }
+
+      it 'accepts the invitation' do
+        post "/api/v1/group_invitations/#{group.id}/accept_invitation", headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(invitation.reload.state).to eq('accepted')
+      end
+    end
+
+    context 'when no invitation exists' do
+      it 'returns 404' do
+        post "/api/v1/group_invitations/#{group.id}/accept_invitation", headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when the free user already belongs to the free limit of groups' do
+      let!(:invitation) { create(:group_invitation, user:, group:, state: 'pending') }
+
+      before do
+        GroupInvitation.create!(user:, group: create(:group), state: 'accepted', sent_at: Time.current)
+      end
+
+      it 'returns 403 and does not accept the invitation' do
+        post "/api/v1/group_invitations/#{group.id}/accept_invitation", headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response.parsed_body['error']).to eq('Pro プランでグループを無制限に作成・参加できます')
+        expect(invitation.reload.state).to eq('pending')
+      end
+    end
+
+    context 'when a Pro user already belongs to a group' do
+      let!(:invitation) { create(:group_invitation, user:, group:, state: 'pending') }
+
+      before do
+        user.subscription.update!(status: 'active', expires_at: 30.days.from_now)
+        GroupInvitation.create!(user:, group: create(:group), state: 'accepted', sent_at: Time.current)
+      end
+
+      it 'accepts the invitation' do
+        post "/api/v1/group_invitations/#{group.id}/accept_invitation", headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(invitation.reload.state).to eq('accepted')
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/group_invite_links_spec.rb
+++ b/spec/requests/api/v1/group_invite_links_spec.rb
@@ -140,5 +140,20 @@ RSpec.describe 'Api::V1::GroupInviteLinks', type: :request do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context 'when the free user already belongs to the free limit of groups' do
+      before do
+        GroupInvitation.create!(user:, group: create(:group), state: 'accepted', sent_at: Time.current)
+      end
+
+      it 'returns 403 and does not create a new invitation' do
+        expect do
+          post "/api/v1/invite_links/#{invite_link.code}/accept", headers: auth_headers_for(user)
+        end.not_to change(GroupInvitation, :count)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response.parsed_body['error']).to eq('Pro プランでグループを無制限に作成・参加できます')
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/groups_spec.rb
+++ b/spec/requests/api/v1/groups_spec.rb
@@ -102,6 +102,38 @@ RSpec.describe 'Api::V1::Groups', type: :request do
         expect(response).to have_http_status(:unauthorized)
       end
     end
+
+    context 'when the free user already belongs to the free limit of groups' do
+      before do
+        GroupInvitation.create!(user:, group: Group.create!(name: '既存グループ'), state: 'accepted', sent_at: Time.current)
+      end
+
+      it 'returns 403 and does not create the group' do
+        expect do
+          post '/api/v1/groups',
+               params: { group: { name: '2つ目のグループ' } },
+               headers: auth_headers_for(user)
+        end.not_to change(Group, :count)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response.parsed_body['error']).to eq('Pro プランでグループを無制限に作成・参加できます')
+      end
+    end
+
+    context 'when a Pro user already belongs to a group' do
+      before do
+        user.subscription.update!(status: 'active', expires_at: 30.days.from_now)
+        GroupInvitation.create!(user:, group: Group.create!(name: '既存グループ'), state: 'accepted', sent_at: Time.current)
+      end
+
+      it 'creates the group and returns 201' do
+        post '/api/v1/groups',
+             params: { group: { name: '2つ目のグループ' } },
+             headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:created)
+      end
+    end
   end
 
   describe 'PUT /api/v1/groups/:id' do

--- a/spec/requests/api/v2/baseball_notes_spec.rb
+++ b/spec/requests/api/v2/baseball_notes_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe 'Api::V2::BaseballNotes', type: :request do
   let(:user) { create(:user) }
   let(:memo) { [{ 'children' => [{ 'text' => '外角が体の開きで詰まる' }] }].to_json }
 
+  def make_pro(target)
+    target.subscription.update!(status: 'active', expires_at: 1.month.from_now)
+  end
+
   describe 'GET /api/v2/baseball_notes' do
     context '未認証' do
       it '401' do
@@ -82,7 +86,16 @@ RSpec.describe 'Api::V2::BaseballNotes', type: :request do
   end
 
   describe 'POST /api/v2/baseball_notes（タグ）' do
-    it 'プリセット・自作タグを付与して作成し tags を返す' do
+    it '無料ユーザーはタグ付与できない（403）' do
+      mine = create(:note_tag, user:, name: '自主練')
+      post '/api/v2/baseball_notes',
+           params: { baseball_note: { title: 'x', date: Date.current, memo:, tag_ids: [mine.id] } },
+           headers: auth_headers_for(user)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'Proユーザーはプリセット・自作タグを付与して作成し tags を返す' do
+      make_pro(user)
       preset = create(:note_tag, :preset, name: '打撃')
       mine = create(:note_tag, user:, name: '自主練')
       post '/api/v2/baseball_notes',
@@ -93,7 +106,8 @@ RSpec.describe 'Api::V2::BaseballNotes', type: :request do
       expect(names).to contain_exactly('打撃', '自主練')
     end
 
-    it '他ユーザーのタグは付与できない（IDOR防止）' do
+    it 'Proユーザーでも他ユーザーのタグは付与できない（IDOR防止）' do
+      make_pro(user)
       others = create(:note_tag, user: create(:user), name: '他人')
       post '/api/v2/baseball_notes',
            params: { baseball_note: { title: 'x', date: Date.current, memo:, tag_ids: [others.id] } },
@@ -101,7 +115,8 @@ RSpec.describe 'Api::V2::BaseballNotes', type: :request do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it '同じタグIDが重複しても500にならず1件だけ付与される' do
+    it 'Proユーザーは同じタグIDが重複しても500にならず1件だけ付与される' do
+      make_pro(user)
       mine = create(:note_tag, user:, name: '自主練')
       post '/api/v2/baseball_notes',
            params: { baseball_note: { title: 'x', date: Date.current, memo:, tag_ids: [mine.id, mine.id] } },
@@ -112,7 +127,8 @@ RSpec.describe 'Api::V2::BaseballNotes', type: :request do
   end
 
   describe 'PATCH /api/v2/baseball_notes/:id（タグ）' do
-    it 'タグを差し替えられる' do
+    it 'Proユーザーはタグを差し替えられる' do
+      make_pro(user)
       note = create(:baseball_note, user:, memo:, date: Date.current)
       old_tag = create(:note_tag, user:, name: '旧')
       note.note_tag_ids = [old_tag.id]
@@ -121,6 +137,70 @@ RSpec.describe 'Api::V2::BaseballNotes', type: :request do
             params: { baseball_note: { tag_ids: [new_tag.id] } }, headers: auth_headers_for(user)
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body['tags'].pluck('name')).to eq(['新'])
+    end
+
+    it 'tag_ids キー省略時は既存タグを維持する（無料ユーザーのタグUI非表示による意図しない全消去を防止）' do
+      note = create(:baseball_note, user:, memo:, date: Date.current)
+      tag = create(:note_tag, :preset, name: '打撃')
+      note.note_tag_ids = [tag.id]
+      patch "/api/v2/baseball_notes/#{note.id}",
+            params: { baseball_note: { title: '更新後タイトル' } }, headers: auth_headers_for(user)
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['tags'].pluck('name')).to eq(['打撃'])
+    end
+  end
+
+  describe 'POST /api/v2/baseball_notes（試合記録の紐付け）' do
+    it '1件だけなら無料ユーザーでも紐付けられる' do
+      game_result = create(:game_result, user:)
+      post '/api/v2/baseball_notes',
+           params: { baseball_note: { title: 'x', date: Date.current, memo:, game_result_ids: [game_result.id] } },
+           headers: auth_headers_for(user)
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body['game_result_ids']).to eq([game_result.id])
+    end
+
+    it '無料ユーザーが2件以上紐付けようとすると403' do
+      game_results = create_list(:game_result, 2, user:)
+      post '/api/v2/baseball_notes',
+           params: { baseball_note: { title: 'x', date: Date.current, memo:,
+                                      game_result_ids: game_results.map(&:id) } },
+           headers: auth_headers_for(user)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'Proユーザーは複数の試合記録を紐付けられる' do
+      make_pro(user)
+      game_results = create_list(:game_result, 2, user:)
+      post '/api/v2/baseball_notes',
+           params: { baseball_note: { title: 'x', date: Date.current, memo:,
+                                      game_result_ids: game_results.map(&:id) } },
+           headers: auth_headers_for(user)
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body['game_result_ids']).to match_array(game_results.map(&:id))
+    end
+
+    it '他ユーザーの試合には紐付けられない（IDOR防止）' do
+      other_game_result = create(:game_result, user: create(:user))
+      post '/api/v2/baseball_notes',
+           params: { baseball_note: { title: 'x', date: Date.current, memo:,
+                                      game_result_ids: [other_game_result.id] } },
+           headers: auth_headers_for(user)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'PATCH /api/v2/baseball_notes/:id（試合記録の紐付け）' do
+    it 'Proユーザーは紐付けを差し替えられる' do
+      make_pro(user)
+      note = create(:baseball_note, user:, memo:, date: Date.current)
+      old_game_result = create(:game_result, user:)
+      note.game_result_ids = [old_game_result.id]
+      new_game_result = create(:game_result, user:)
+      patch "/api/v2/baseball_notes/#{note.id}",
+            params: { baseball_note: { game_result_ids: [new_game_result.id] } }, headers: auth_headers_for(user)
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['game_result_ids']).to eq([new_game_result.id])
     end
   end
 

--- a/spec/requests/api/v2/baseball_notes_spec.rb
+++ b/spec/requests/api/v2/baseball_notes_spec.rb
@@ -213,6 +213,36 @@ RSpec.describe 'Api::V2::BaseballNotes', type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body['game_result_ids']).to eq([game_result.id])
     end
+
+    context 'Pro 解約後の既存複数紐付け（グランドファザリング）' do
+      let(:note) { create(:baseball_note, user:, memo:, date: Date.current) }
+      let(:game_results) { create_list(:game_result, 3, user:) }
+
+      before { note.game_result_ids = game_results.map(&:id) }
+
+      it '無料ユーザーでも既存の3件をそのまま維持して更新できる' do
+        patch "/api/v2/baseball_notes/#{note.id}",
+              params: { baseball_note: { game_result_ids: game_results.map(&:id) } }, headers: auth_headers_for(user)
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['game_result_ids']).to match_array(game_results.map(&:id))
+      end
+
+      it '無料ユーザーでも既存の3件から減らして更新できる' do
+        patch "/api/v2/baseball_notes/#{note.id}",
+              params: { baseball_note: { game_result_ids: game_results.first(2).map(&:id) } },
+              headers: auth_headers_for(user)
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['game_result_ids']).to match_array(game_results.first(2).map(&:id))
+      end
+
+      it '無料ユーザーが既存件数を超えて増やそうとすると403' do
+        added = create(:game_result, user:)
+        patch "/api/v2/baseball_notes/#{note.id}",
+              params: { baseball_note: { game_result_ids: (game_results.map(&:id) + [added.id]) } },
+              headers: auth_headers_for(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
   end
 
   describe 'GET /api/v2/baseball_notes（練習記録で絞り込み）' do
@@ -287,6 +317,28 @@ RSpec.describe 'Api::V2::BaseballNotes', type: :request do
             params: { baseball_note: { title: '更新後タイトル' } }, headers: auth_headers_for(user)
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body['improvement_theme_ids']).to eq([theme.id])
+    end
+
+    context 'Pro 解約後の既存複数紐付け（グランドファザリング）' do
+      let(:note) { create(:baseball_note, user:, memo:, date: Date.current) }
+      let(:themes) { create_list(:improvement_theme, 3, user:) }
+
+      before { note.improvement_theme_ids = themes.map(&:id) }
+
+      it '無料ユーザーでも既存の3件をそのまま維持して更新できる' do
+        patch "/api/v2/baseball_notes/#{note.id}",
+              params: { baseball_note: { improvement_theme_ids: themes.map(&:id) } }, headers: auth_headers_for(user)
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['improvement_theme_ids']).to match_array(themes.map(&:id))
+      end
+
+      it '無料ユーザーが既存件数を超えて増やそうとすると403' do
+        added = create(:improvement_theme, user:)
+        patch "/api/v2/baseball_notes/#{note.id}",
+              params: { baseball_note: { improvement_theme_ids: (themes.map(&:id) + [added.id]) } },
+              headers: auth_headers_for(user)
+        expect(response).to have_http_status(:forbidden)
+      end
     end
   end
 end

--- a/spec/requests/api/v2/baseball_notes_spec.rb
+++ b/spec/requests/api/v2/baseball_notes_spec.rb
@@ -214,4 +214,58 @@ RSpec.describe 'Api::V2::BaseballNotes', type: :request do
       expect(response.parsed_body.size).to eq(1)
     end
   end
+
+  describe 'POST /api/v2/baseball_notes（課題の紐付け）' do
+    it '1件だけなら無料ユーザーでも紐付けられる' do
+      theme = create(:improvement_theme, user:)
+      post '/api/v2/baseball_notes',
+           params: { baseball_note: { title: 'x', date: Date.current, memo:, improvement_theme_ids: [theme.id] } },
+           headers: auth_headers_for(user)
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body['improvement_theme_ids']).to eq([theme.id])
+    end
+
+    it '無料ユーザーが2件以上紐付けようとすると403' do
+      themes = create_list(:improvement_theme, 2, user:)
+      post '/api/v2/baseball_notes',
+           params: { baseball_note: { title: 'x', date: Date.current, memo:,
+                                      improvement_theme_ids: themes.map(&:id) } },
+           headers: auth_headers_for(user)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'Proユーザーは複数の課題を紐付けられる' do
+      make_pro(user)
+      themes = create_list(:improvement_theme, 2, user:)
+      post '/api/v2/baseball_notes',
+           params: { baseball_note: { title: 'x', date: Date.current, memo:,
+                                      improvement_theme_ids: themes.map(&:id) } },
+           headers: auth_headers_for(user)
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body['improvement_theme_ids']).to match_array(themes.map(&:id))
+    end
+
+    it '他ユーザーの課題には紐付けられない（IDOR防止）' do
+      other_theme = create(:improvement_theme, user: create(:user))
+      post '/api/v2/baseball_notes',
+           params: { baseball_note: { title: 'x', date: Date.current, memo:,
+                                      improvement_theme_ids: [other_theme.id] } },
+           headers: auth_headers_for(user)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'PATCH /api/v2/baseball_notes/:id（課題の紐付け）' do
+    it 'Proユーザーは紐付けを差し替えられる' do
+      make_pro(user)
+      note = create(:baseball_note, user:, memo:, date: Date.current)
+      old_theme = create(:improvement_theme, user:)
+      note.improvement_theme_ids = [old_theme.id]
+      new_theme = create(:improvement_theme, user:)
+      patch "/api/v2/baseball_notes/#{note.id}",
+            params: { baseball_note: { improvement_theme_ids: [new_theme.id] } }, headers: auth_headers_for(user)
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['improvement_theme_ids']).to eq([new_theme.id])
+    end
+  end
 end

--- a/spec/requests/api/v2/baseball_notes_spec.rb
+++ b/spec/requests/api/v2/baseball_notes_spec.rb
@@ -202,6 +202,17 @@ RSpec.describe 'Api::V2::BaseballNotes', type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body['game_result_ids']).to eq([new_game_result.id])
     end
+
+    it 'game_result_ids キー省略時は既存紐付けを維持する（部分更新での意図しない全消去を防止）' do
+      make_pro(user)
+      note = create(:baseball_note, user:, memo:, date: Date.current)
+      game_result = create(:game_result, user:)
+      note.game_result_ids = [game_result.id]
+      patch "/api/v2/baseball_notes/#{note.id}",
+            params: { baseball_note: { title: '更新後タイトル' } }, headers: auth_headers_for(user)
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['game_result_ids']).to eq([game_result.id])
+    end
   end
 
   describe 'GET /api/v2/baseball_notes（練習記録で絞り込み）' do
@@ -266,6 +277,16 @@ RSpec.describe 'Api::V2::BaseballNotes', type: :request do
             params: { baseball_note: { improvement_theme_ids: [new_theme.id] } }, headers: auth_headers_for(user)
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body['improvement_theme_ids']).to eq([new_theme.id])
+    end
+
+    it 'improvement_theme_ids キー省略時は既存紐付けを維持する（部分更新での意図しない全消去を防止）' do
+      note = create(:baseball_note, user:, memo:, date: Date.current)
+      theme = create(:improvement_theme, user:)
+      note.improvement_theme_ids = [theme.id]
+      patch "/api/v2/baseball_notes/#{note.id}",
+            params: { baseball_note: { title: '更新後タイトル' } }, headers: auth_headers_for(user)
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['improvement_theme_ids']).to eq([theme.id])
     end
   end
 end

--- a/spec/requests/api/v2/goals_spec.rb
+++ b/spec/requests/api/v2/goals_spec.rb
@@ -121,7 +121,16 @@ RSpec.describe 'Api::V2::Goals', type: :request do
         expect(response).to have_http_status(:created)
       end
 
-      it 'カスタム期間目標を作成できる' do
+      it 'カスタム期間目標は無料は403' do
+        params = { goal: { title: '大会前3週間', period_type: 'custom',
+                           month_start: today, deadline: today + 21,
+                           metric_key: 'total_swing_count', target_value: 2000 } }
+        post '/api/v2/goals', params:, headers: auth_headers_for(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'カスタム期間目標は Pro なら作成できる' do
+        make_pro(user)
         params = { goal: { title: '大会前3週間', period_type: 'custom',
                            month_start: today, deadline: today + 21,
                            metric_key: 'total_swing_count', target_value: 2000 } }
@@ -130,6 +139,7 @@ RSpec.describe 'Api::V2::Goals', type: :request do
       end
 
       it 'カスタムで終了日が開始日より前だと作成できない' do
+        make_pro(user)
         params = { goal: { title: '逆転', period_type: 'custom',
                            month_start: today, deadline: today - 1,
                            metric_key: 'practice_days', target_value: 5 } }
@@ -217,12 +227,21 @@ RSpec.describe 'Api::V2::Goals', type: :request do
   end
 
   describe '自由指標（manual）' do
-    it '指標名・現在値を持つ自由指標目標を作成し、手入力の現在値が進捗に反映される' do
-      params = { goal: { title: '球速アップ', kind: 'manual', period_type: 'monthly',
-                         month_start: today.beginning_of_month, deadline: today.end_of_month,
-                         custom_metric_label: '球速', custom_unit: 'km/h',
-                         target_value: 130, manual_current_value: 125, comparison_type: 'greater_than' } }
-      post '/api/v2/goals', params:, headers: auth_headers_for(user)
+    let(:manual_params) do
+      { goal: { title: '球速アップ', kind: 'manual', period_type: 'monthly',
+                month_start: today.beginning_of_month, deadline: today.end_of_month,
+                custom_metric_label: '球速', custom_unit: 'km/h',
+                target_value: 130, manual_current_value: 125, comparison_type: 'greater_than' } }
+    end
+
+    it '無料は403' do
+      post '/api/v2/goals', params: manual_params, headers: auth_headers_for(user)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'Pro は指標名・現在値を持つ自由指標目標を作成でき、手入力の現在値が進捗に反映される' do
+      make_pro(user)
+      post '/api/v2/goals', params: manual_params, headers: auth_headers_for(user)
 
       aggregate_failures do
         expect(response).to have_http_status(:created)
@@ -235,6 +254,7 @@ RSpec.describe 'Api::V2::Goals', type: :request do
     end
 
     it '指標名が無いと作成できない（422）' do
+      make_pro(user)
       params = { goal: { title: '球速', kind: 'manual', period_type: 'monthly',
                          month_start: today.beginning_of_month, deadline: today.end_of_month, target_value: 130 } }
       post '/api/v2/goals', params:, headers: auth_headers_for(user)

--- a/spec/requests/api/v2/improvement_themes_spec.rb
+++ b/spec/requests/api/v2/improvement_themes_spec.rb
@@ -40,17 +40,17 @@ RSpec.describe 'Api::V2::ImprovementThemes', type: :request do
       expect(response.parsed_body['status']).to eq('open')
     end
 
-    it '無料は取組中2つ目が 403' do
-      create(:improvement_theme, user:, status: 'open')
-      post '/api/v2/improvement_themes', params: { improvement_theme: { title: '2つ目' } },
+    it '無料は取組中3つ目が 403' do
+      create_list(:improvement_theme, 2, user:, status: 'open')
+      post '/api/v2/improvement_themes', params: { improvement_theme: { title: '3つ目' } },
                                          headers: auth_headers_for(user)
       expect(response).to have_http_status(:forbidden)
     end
 
     it 'Pro は取組中を複数作成できる' do
       make_pro(user)
-      create(:improvement_theme, user:, status: 'open')
-      post '/api/v2/improvement_themes', params: { improvement_theme: { title: '2つ目' } },
+      create_list(:improvement_theme, 2, user:, status: 'open')
+      post '/api/v2/improvement_themes', params: { improvement_theme: { title: '3つ目' } },
                                          headers: auth_headers_for(user)
       expect(response).to have_http_status(:created)
     end

--- a/spec/requests/api/v2/menu_sets_spec.rb
+++ b/spec/requests/api/v2/menu_sets_spec.rb
@@ -52,16 +52,16 @@ RSpec.describe 'Api::V2::MenuSets', type: :request do
       expect(response.parsed_body['items']).to be_empty
     end
 
-    it '無料は3つまで。4つ目は403で拒否する' do
-      create_list(:menu_set, 3, user:)
-      post '/api/v2/menu_sets', params: { menu_set: { name: '4つ目' } }, headers: auth_headers_for(user)
+    it '無料は2つまで。3つ目は403で拒否する' do
+      create_list(:menu_set, 2, user:)
+      post '/api/v2/menu_sets', params: { menu_set: { name: '3つ目' } }, headers: auth_headers_for(user)
       expect(response).to have_http_status(:forbidden)
     end
 
-    it 'Pro は4つ目以降も作成できる' do
-      create_list(:menu_set, 3, user:)
+    it 'Pro は3つ目以降も作成できる' do
+      create_list(:menu_set, 2, user:)
       make_pro(user)
-      post '/api/v2/menu_sets', params: { menu_set: { name: '4つ目' } }, headers: auth_headers_for(user)
+      post '/api/v2/menu_sets', params: { menu_set: { name: '3つ目' } }, headers: auth_headers_for(user)
       expect(response).to have_http_status(:created)
     end
   end

--- a/spec/requests/api/v2/menu_sets_spec.rb
+++ b/spec/requests/api/v2/menu_sets_spec.rb
@@ -52,16 +52,16 @@ RSpec.describe 'Api::V2::MenuSets', type: :request do
       expect(response.parsed_body['items']).to be_empty
     end
 
-    it '無料は2つまで。3つ目は403で拒否する' do
-      create_list(:menu_set, 2, user:)
-      post '/api/v2/menu_sets', params: { menu_set: { name: '3つ目' } }, headers: auth_headers_for(user)
+    it '無料は3つまで。4つ目は403で拒否する' do
+      create_list(:menu_set, 3, user:)
+      post '/api/v2/menu_sets', params: { menu_set: { name: '4つ目' } }, headers: auth_headers_for(user)
       expect(response).to have_http_status(:forbidden)
     end
 
-    it 'Pro は3つ目以降も作成できる' do
-      create_list(:menu_set, 2, user:)
+    it 'Pro は4つ目以降も作成できる' do
+      create_list(:menu_set, 3, user:)
       make_pro(user)
-      post '/api/v2/menu_sets', params: { menu_set: { name: '3つ目' } }, headers: auth_headers_for(user)
+      post '/api/v2/menu_sets', params: { menu_set: { name: '4つ目' } }, headers: auth_headers_for(user)
       expect(response).to have_http_status(:created)
     end
   end

--- a/spec/requests/api/v2/note_tags_spec.rb
+++ b/spec/requests/api/v2/note_tags_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe 'Api::V2::NoteTags', type: :request do
   let(:user) { create(:user) }
 
+  def make_pro(target)
+    target.subscription.update!(status: 'active', expires_at: 1.month.from_now)
+  end
+
   describe 'GET /api/v2/note_tags' do
     before do
       create(:note_tag, :preset, name: '打撃')
@@ -25,13 +29,20 @@ RSpec.describe 'Api::V2::NoteTags', type: :request do
   end
 
   describe 'POST /api/v2/note_tags' do
-    it '自作タグを作成する' do
+    it '無料ユーザーは403' do
+      post '/api/v2/note_tags', params: { note_tag: { name: 'メンタル' } }, headers: auth_headers_for(user)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'Proユーザーは自作タグを作成する' do
+      make_pro(user)
       post '/api/v2/note_tags', params: { note_tag: { name: 'メンタル' } }, headers: auth_headers_for(user)
       expect(response).to have_http_status(:created)
       expect(response.parsed_body['name']).to eq('メンタル')
     end
 
-    it '同名は422' do
+    it 'Proユーザーでも同名は422' do
+      make_pro(user)
       create(:note_tag, user:, name: 'メンタル')
       post '/api/v2/note_tags', params: { note_tag: { name: 'メンタル' } }, headers: auth_headers_for(user)
       expect(response).to have_http_status(:unprocessable_entity)

--- a/spec/requests/api/v2/periodic_reviews_spec.rb
+++ b/spec/requests/api/v2/periodic_reviews_spec.rb
@@ -26,14 +26,10 @@ RSpec.describe 'Api::V2::PeriodicReviews', type: :request do
     end
 
     context '無料ユーザー' do
-      it '週次のみ返し、成績（打撃）は見せるが Pro 詳細部は除外される' do
+      it '振り返りレポート機能自体が Pro 限定のため一件も返さない' do
         get '/api/v2/periodic_reviews', headers: auth_headers_for(user)
         expect(response).to have_http_status(:ok)
-        body = response.parsed_body
-        expect(body.pluck('period_type')).to eq(['weekly'])
-        expect(body.first['summary']).to include('practice_days')
-        expect(body.first['summary']).to have_key('batting')
-        expect(body.first['summary']).not_to have_key('theme_breakdown')
+        expect(response.parsed_body).to eq([])
       end
     end
 
@@ -51,25 +47,25 @@ RSpec.describe 'Api::V2::PeriodicReviews', type: :request do
   describe 'PATCH /api/v2/periodic_reviews/:id' do
     let!(:review) { create(:periodic_review, user:, read: false) }
 
-    it '既読にできる' do
+    it 'Pro ユーザーは既読にできる' do
+      make_pro(user)
       patch "/api/v2/periodic_reviews/#{review.id}", headers: auth_headers_for(user)
       expect(response).to have_http_status(:ok)
       expect(review.reload.read).to be true
     end
 
-    context '無料ユーザーが月次レビューを指定' do
-      it 'index と同様にアクセスできない（404）' do
-        monthly = create(:periodic_review, :monthly, user:, read: false)
-        patch "/api/v2/periodic_reviews/#{monthly.id}", headers: auth_headers_for(user)
+    context '無料ユーザー' do
+      it '振り返りレポート機能自体が Pro 限定のため週次でもアクセスできない（404）' do
+        patch "/api/v2/periodic_reviews/#{review.id}", headers: auth_headers_for(user)
         aggregate_failures do
           expect(response).to have_http_status(:not_found)
-          expect(monthly.reload.read).to be false
+          expect(review.reload.read).to be false
         end
       end
 
       it 'Pro なら月次も既読にできる' do
-        make_pro(user)
         monthly = create(:periodic_review, :monthly, user:, read: false)
+        make_pro(user)
         patch "/api/v2/periodic_reviews/#{monthly.id}", headers: auth_headers_for(user)
         expect(monthly.reload.read).to be true
       end

--- a/spec/requests/api/v2/practice_menu_trends_spec.rb
+++ b/spec/requests/api/v2/practice_menu_trends_spec.rb
@@ -4,8 +4,19 @@ RSpec.describe 'Api::V2::PracticeMenuTrends', type: :request do
   let(:user) { create(:user) }
   let(:today) { Time.find_zone('Asia/Tokyo').today }
 
+  def make_pro(target)
+    target.subscription.update!(status: 'active', expires_at: 1.month.from_now)
+  end
+
   describe 'GET /api/v2/practice_menu_trends/:id' do
-    it 'メニューの年別・月別・日別の集計を返す' do
+    it '無料ユーザーは403（推移詳細は Pro 限定）' do
+      menu = create(:practice_menu, user:)
+      get "/api/v2/practice_menu_trends/#{menu.id}", headers: auth_headers_for(user)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'Proユーザーはメニューの年別・月別・日別の集計を返す' do
+      make_pro(user)
       menu = create(:practice_menu, user:, name: 'ベンチプレス', unit: 'weight_reps', category: 'strength')
       create(:practice_log, user:, practice_menu: menu, logged_on: today, amount: 10, weight: 60)
       create(:practice_log, user:, practice_menu: menu, logged_on: today, amount: 8, weight: 70)
@@ -21,6 +32,7 @@ RSpec.describe 'Api::V2::PracticeMenuTrends', type: :request do
     end
 
     it '他ユーザーのメニューは 404' do
+      make_pro(user)
       other = create(:practice_menu, user: create(:user))
       get "/api/v2/practice_menu_trends/#{other.id}", headers: auth_headers_for(user)
       expect(response).to have_http_status(:not_found)

--- a/spec/requests/api/v2/practice_menus_spec.rb
+++ b/spec/requests/api/v2/practice_menus_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe 'Api::V2::PracticeMenus', type: :request do
       expect(response.parsed_body['name']).to eq('ティー')
     end
 
-    context '無料ユーザーが上限(5)を超える' do
-      before { create_list(:practice_menu, 5, user:) }
+    context '無料ユーザーが上限(3)を超える' do
+      before { create_list(:practice_menu, 3, user:) }
 
       it '403 を返す' do
         post '/api/v2/practice_menus', params:, headers: auth_headers_for(user)

--- a/spec/requests/api/v2/practice_sessions_spec.rb
+++ b/spec/requests/api/v2/practice_sessions_spec.rb
@@ -87,6 +87,44 @@ RSpec.describe 'Api::V2::PracticeSessions', type: :request do
         expect(user.condition_logs.find_by(logged_on: today)).to be_present
       end
     end
+
+    context '課題の紐付け' do
+      it '1件だけなら無料ユーザーでも紐付けられる' do
+        theme = create(:improvement_theme, user:)
+        post '/api/v2/practice_sessions',
+             params: { practice_session: { logged_on: today, items:, improvement_theme_ids: [theme.id] } },
+             headers: auth_headers_for(user)
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body['improvement_theme_ids']).to eq([theme.id])
+      end
+
+      it '無料ユーザーが2件以上紐付けようとすると403' do
+        themes = create_list(:improvement_theme, 2, user:)
+        post '/api/v2/practice_sessions',
+             params: { practice_session: { logged_on: today, items:, improvement_theme_ids: themes.map(&:id) } },
+             headers: auth_headers_for(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'Proユーザーは複数の課題を紐付けられる' do
+        make_pro(user)
+        themes = create_list(:improvement_theme, 2, user:)
+        post '/api/v2/practice_sessions',
+             params: { practice_session: { logged_on: today, items:, improvement_theme_ids: themes.map(&:id) } },
+             headers: auth_headers_for(user)
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body['improvement_theme_ids']).to match_array(themes.map(&:id))
+      end
+
+      it '他ユーザーの課題は無視される' do
+        other_theme = create(:improvement_theme, user: create(:user))
+        post '/api/v2/practice_sessions',
+             params: { practice_session: { logged_on: today, items:, improvement_theme_ids: [other_theme.id] } },
+             headers: auth_headers_for(user)
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body['improvement_theme_ids']).to eq([])
+      end
+    end
   end
 
   describe 'GET /api/v2/practice_sessions/:id' do

--- a/spec/requests/api/v2/practice_sessions_spec.rb
+++ b/spec/requests/api/v2/practice_sessions_spec.rb
@@ -124,6 +124,42 @@ RSpec.describe 'Api::V2::PracticeSessions', type: :request do
         expect(response).to have_http_status(:created)
         expect(response.parsed_body['improvement_theme_ids']).to eq([])
       end
+
+      context 'Pro 解約後の既存複数紐付け（グランドファザリング）' do
+        let(:themes) { create_list(:improvement_theme, 2, user:) }
+        let!(:session) do
+          session = create(:practice_session, user:, logged_on: today)
+          session.improvement_theme_ids = themes.map(&:id)
+          session
+        end
+
+        it '無料ユーザーでも既存の2件をそのまま維持して更新できる' do
+          post '/api/v2/practice_sessions',
+               params: { practice_session: { logged_on: today, items:, improvement_theme_ids: themes.map(&:id) } },
+               headers: auth_headers_for(user)
+          expect(response).to have_http_status(:created)
+          expect(response.parsed_body['improvement_theme_ids']).to match_array(themes.map(&:id))
+        end
+
+        it '無料ユーザーでも既存の2件から減らして更新できる' do
+          post '/api/v2/practice_sessions',
+               params: { practice_session: { logged_on: today, items:, improvement_theme_ids: [themes.first.id] } },
+               headers: auth_headers_for(user)
+          expect(response).to have_http_status(:created)
+          expect(response.parsed_body['improvement_theme_ids']).to eq([themes.first.id])
+        end
+
+        it '無料ユーザーが既存件数を超えて増やそうとすると403で更新全体がロールバックされる' do
+          added = create(:improvement_theme, user:)
+          post '/api/v2/practice_sessions',
+               params: { practice_session: { logged_on: today, memo: '書き換え', items:,
+                                             improvement_theme_ids: (themes.map(&:id) + [added.id]) } },
+               headers: auth_headers_for(user)
+          expect(response).to have_http_status(:forbidden)
+          expect(session.reload.memo).not_to eq('書き換え')
+          expect(session.improvement_theme_ids).to match_array(themes.map(&:id))
+        end
+      end
     end
   end
 

--- a/spec/requests/api/v2/schedules/week_copies_spec.rb
+++ b/spec/requests/api/v2/schedules/week_copies_spec.rb
@@ -41,6 +41,20 @@ RSpec.describe 'Api::V2::Schedules::WeekCopies', type: :request do
       expect(copied['menus'].first['practice_menu_id']).to eq(menu.id)
     end
 
+    it '2回連続で実行しても予定が重複しない（冪等）' do
+      make_pro(user)
+      create(:schedule, user:, title: '朝練', days_of_week: nil, planned_on: '2026-07-06', scheduled_time: '06:00')
+
+      post '/api/v2/schedules/week_copy', params: { week_start: '2026-07-06' }, headers: auth_headers_for(user)
+      expect(response).to have_http_status(:created)
+
+      expect do
+        post '/api/v2/schedules/week_copy', params: { week_start: '2026-07-06' }, headers: auth_headers_for(user)
+      end.not_to(change { user.schedules.count })
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body).to eq([])
+    end
+
     it 'コピー元の週に単発予定が無ければ空配列を返す' do
       make_pro(user)
       post '/api/v2/schedules/week_copy', params: { week_start: '2026-07-06' }, headers: auth_headers_for(user)

--- a/spec/requests/api/v2/schedules/week_copies_spec.rb
+++ b/spec/requests/api/v2/schedules/week_copies_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::Schedules::WeekCopies', type: :request do
+  let(:user) { create(:user) }
+
+  def make_pro(target)
+    target.subscription.update!(status: 'active', expires_at: 1.month.from_now)
+  end
+
+  describe 'POST /api/v2/schedules/week_copy' do
+    context '未認証' do
+      it '401' do
+        post '/api/v2/schedules/week_copy', params: { week_start: '2026-07-06' }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    it '無料ユーザーは403（Pro限定機能）' do
+      create(:schedule, user:, title: '朝練', days_of_week: nil, planned_on: '2026-07-06', scheduled_time: '06:00')
+      post '/api/v2/schedules/week_copy', params: { week_start: '2026-07-06' }, headers: auth_headers_for(user)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'Proユーザーは週内の単発予定を翌週へ複製する' do
+      make_pro(user)
+      menu = create(:practice_menu, user:)
+      schedule = create(:schedule, user:, title: '朝練', days_of_week: nil,
+                                   planned_on: '2026-07-06', scheduled_time: '06:00')
+      schedule.schedule_menus.create!(practice_menu: menu, target_value: 100, sort_order: 0)
+      # 繰り返し予定は対象外。
+      create(:schedule, user:, title: '毎週の素振り', days_of_week: '1', scheduled_time: '06:00')
+
+      expect do
+        post '/api/v2/schedules/week_copy', params: { week_start: '2026-07-06' }, headers: auth_headers_for(user)
+      end.to change { user.schedules.count }.by(1)
+
+      expect(response).to have_http_status(:created)
+      copied = response.parsed_body.first
+      expect(copied['planned_on']).to eq('2026-07-13')
+      expect(copied['title']).to eq('朝練')
+      expect(copied['menus'].first['practice_menu_id']).to eq(menu.id)
+    end
+
+    it 'コピー元の週に単発予定が無ければ空配列を返す' do
+      make_pro(user)
+      post '/api/v2/schedules/week_copy', params: { week_start: '2026-07-06' }, headers: auth_headers_for(user)
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body).to eq([])
+    end
+
+    it 'week_start が不正なら422' do
+      make_pro(user)
+      post '/api/v2/schedules/week_copy', params: { week_start: 'invalid' }, headers: auth_headers_for(user)
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end

--- a/spec/requests/api/v2/schedules_spec.rb
+++ b/spec/requests/api/v2/schedules_spec.rb
@@ -54,13 +54,10 @@ RSpec.describe 'Api::V2::Schedules', type: :request do
       expect(response.parsed_body['menus']).to be_empty
     end
 
-    context '無料ユーザーが上限(3)を超える' do
-      before { create_list(:schedule, 3, user:) }
-
-      it '403' do
-        post '/api/v2/schedules', params:, headers: auth_headers_for(user)
-        expect(response).to have_http_status(:forbidden)
-      end
+    it '無料ユーザーでも件数上限なく作成できる' do
+      create_list(:schedule, 3, user:)
+      post '/api/v2/schedules', params:, headers: auth_headers_for(user)
+      expect(response).to have_http_status(:created)
     end
 
     context 'カスタム通知文' do
@@ -78,6 +75,54 @@ RSpec.describe 'Api::V2::Schedules', type: :request do
         post '/api/v2/schedules', params: custom_params, headers: auth_headers_for(user)
         expect(response.parsed_body['notification_message']).to eq('頑張れ')
       end
+    end
+  end
+
+  describe 'PATCH /api/v2/schedules/:id' do
+    let(:menu) { create(:practice_menu, user:) }
+    let!(:schedule) do
+      create(:schedule, user:, title: '朝練', days_of_week: '1', scheduled_time: '06:00')
+    end
+
+    before do
+      patch "/api/v2/schedules/#{schedule.id}",
+            params: { schedule: { menus: [{ practice_menu_id: menu.id, target_value: 100 }] } },
+            headers: auth_headers_for(user)
+    end
+
+    it 'メニューを更新できる' do
+      patch "/api/v2/schedules/#{schedule.id}",
+            params: { schedule: { title: '朝練2' } }, headers: auth_headers_for(user)
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['title']).to eq('朝練2')
+    end
+
+    it 'バリデーション失敗時は schedule_menus を巻き戻し、保存前の状態を維持する（トランザクションバグの回帰防止）' do
+      expect(schedule.reload.schedule_menus.count).to eq(1)
+
+      # menus を含めて assign_menus（destroy_all → 再build）を発火させつつ、
+      # title/days_of_week/planned_on を不正にして save! を失敗させる。
+      patch "/api/v2/schedules/#{schedule.id}",
+            params: { schedule: { title: '', days_of_week: '', planned_on: '',
+                                  menus: [{ practice_menu_id: menu.id, target_value: 999 }] } },
+            headers: auth_headers_for(user)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(schedule.reload.schedule_menus.count).to eq(1)
+      expect(schedule.schedule_menus.first.target_value.to_i).to eq(100)
+    end
+  end
+
+  describe 'GET /api/v2/schedules（logged_practice_menu_ids）' do
+    it '練習ログが記録済みのpractice_menu_idを返す' do
+      schedule = create(:schedule, user:, title: '朝練', days_of_week: '1', scheduled_time: '06:00')
+      menu = create(:practice_menu, user:)
+      create(:practice_log, user:, practice_menu: menu, schedule:, logged_on: '2026-07-09')
+
+      get '/api/v2/schedules', headers: auth_headers_for(user)
+
+      body = response.parsed_body.find { |item| item['id'] == schedule.id }
+      expect(body['logged_practice_menu_ids']).to eq([menu.id])
     end
   end
 


### PR DESCRIPTION
## issue
close ippei-shimizu/buzzbase#439

## 実装概要
無料プランでもPro限定機能に到達できてしまう箇所がないか mobile/back 全体を精査し（issue #439）、発見した抜け漏れに entitlement / 上限チェックを追加した。監査の過程で見つかった403・N+1・冪等性等のバグ修正も含む。

## 背景
Pro機能追加を重ねる中で、境界チェックの実装漏れやコピー&ペーストによる不整合が生じていないか棚卸しする必要があった（issue #439）。back側は特に「サーバー側で本当に弾けているか」（クライアント制御に依存していないか）の観点で全コントローラを確認した。

## やらなかったこと
- 既存の無料/Pro境界の再設計（今回はあくまで漏れの検出・追加）
- 決済・エンタイトルメント付与ロジック自体の変更

## 受入基準
- [x] `bundle exec rspec` が通る
- [x] `bundle exec rubocop` が通る
- [ ] 各エンドポイントで無料/Proの境界が entitlement 定義通りに動作する

## 実装詳細

### 野球ノート
- `note_tags` / `multi_game_result_notes` / `multi_improvement_theme_links` entitlementキーを追加
- 自作タグ作成（`note_tags#create`）とタグ付与（`baseball_notes`）をPro限定に
- 試合記録の紐付けを `game_result_id` 単数カラムから `note_game_links` 中間テーブル経由の複数紐付けに変更（無料は1件・Proは複数件）。既存データをbackfillしてからカラム削除
- 課題（改善テーマ）の紐付けも同様に `note_theme_links` 中間テーブル化
- Pro解約後も既存の複数紐付けノートを編集・削減できるようグランドファザリング対応
- バグ修正: ノート紐付きの試合記録が削除できない不具合／ノート更新時に紐付けが意図せず全消去される不具合を修正

### 練習記録・課題（改善テーマ）
- 練習記録の課題紐付けも単一カラムから `practice_session_theme_links` 中間テーブル経由の複数紐付けに変更（無料は1件・Proは複数件）
- 課題テーマの無料上限を「取組中1つまで」から「2つまで」に変更

### グループ
- `group_invitations` / `group_invite_links` / `groups` の各コントローラに所属数チェックを追加（無料は所属1件まで、Proで無制限）

### 目標
- カスタム期間の目標（`custom_period_goals`）・自由指標の目標（`manual_metric_goals`）をPro限定に変更

### 練習メニュー
- 無料登録上限を5件から3件に変更

### スケジュール
- 予定の登録件数上限を撤廃（無料でも無制限）
- 週の練習プランを来週へ一括コピーするAPI（`POST /api/v2/schedules/week_copy`）を新設し、Pro限定（`schedule_copy_next_week`）に。連続実行での重複コピーを防ぐ冪等化、コピー元取得のN+1解消も実施
- 予定編集時、保存失敗で `schedule_menus` だけ消えて残るバグをトランザクションで修正
- `ScheduleSerializer` に `logged_practice_menu_ids` を追加

### その他
- メニュー推移詳細API（`practice_menu_trend_detail`）にサーバー側entitlementチェックを追加
- 素振りカウンターのインターバル/バイブレーション設定に entitlementキー（`shadow_swing_custom_interval` / `shadow_swing_vibration`）を追加
- 週次/月次の振り返りレポート機能自体をPro限定に変更（無料ユーザーには一件も返さない）
- `entitlement.rb` のカスタム期間目標コメントの矛盾を修正

## スクリーンショット
なし（APIのみの変更）

## 確認手順
1. 無料ユーザーで `POST /api/v2/note_tags` → 403
2. 無料ユーザーで `baseball_notes` に `tag_ids` を含めて作成 → 403
3. 無料ユーザーで `baseball_notes` / `practice_sessions` に複数の `game_result_ids` / `improvement_theme_ids` を渡して作成 → 403、1件なら作成可
4. 無料ユーザーで2つ目のグループに参加・作成 → 403
5. 無料ユーザーで `POST /api/v2/schedules/week_copy` → 403
6. 無料ユーザーでカスタム期間・自由指標の目標を作成 → 403
7. Proユーザーはいずれも成功

## 影響範囲
`baseball_notes`, `improvement_themes`, `practice_sessions`, `groups`, `goals`, `practice_menus`, `schedules`（`week_copy` 新設）, `periodic_reviews`, `practice_menu_trends` の各API

## コード上の懸念点
- マイグレーションで `baseball_notes.game_result_id` / `practice_sessions.improvement_theme_id` を削除しているため、ロールバック時のデータ復元手順に注意
- `week_copy` の冪等判定はタイトル・種別・時刻・メニューセットの一致で判定しており、ユーザーが同名の予定を意図的に複数登録しているケースでは意図せずスキップされる可能性がある

## その他
`release/pro-202605` 向けのリリース前監査PR。対応する mobile 側は buzzbase_mobile#157。
