### PR TITLE
Add: 野球ノートへの画像・動画アップロード機能(back)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,9 @@ gem 'dotenv'
 
 gem 'fog-aws'
 
+# Cloudflare R2（S3互換）への署名URL発行専用。CarrierWave + fog-aws（アバター等）とは別系統で、混在させない。
+gem 'aws-sdk-s3', require: false
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,25 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     attr_extras (7.1.0)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1271.0)
+    aws-sdk-core (3.254.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.130.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.228.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     bcrypt (3.1.22)
     benchmark (0.5.0)
@@ -201,6 +220,7 @@ GEM
     irb (1.10.0)
       rdoc
       reline (>= 0.3.8)
+    jmespath (1.6.2)
     json (2.7.1)
     jsonapi-renderer (0.2.2)
     jwt (3.1.2)
@@ -453,6 +473,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (~> 0.10.14)
+  aws-sdk-s3
   bootsnap
   carrierwave
   debug

--- a/app/controllers/api/v2/baseball_notes_controller.rb
+++ b/app/controllers/api/v2/baseball_notes_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V2
     # 野球ノート（v2）。試合 / 練習への紐付けに対応（モデルA）。
-    # メディア（画像・動画）は別 PR。本コントローラはテキスト＋紐付けのみ。
+    # メディア（画像・動画）の作成・完了通知・削除は Api::V2::MediaAttachments 配下の別コントローラで扱う。
     class BaseballNotesController < Api::V2::ApplicationController
       before_action :authenticate_api_v1_user!
       before_action :load_note, only: %i[show update destroy]
@@ -9,7 +9,8 @@ module Api
       FILTERABLE_COLUMNS = %i[date practice_log_id practice_session_id].freeze
 
       def index
-        notes = current_api_v1_user.baseball_notes.includes(:note_tags, :game_results, :improvement_themes)
+        notes = current_api_v1_user.baseball_notes
+                                   .includes(:note_tags, :game_results, :improvement_themes, :media_attachments)
                                    .order(date: :desc, created_at: :desc)
         FILTERABLE_COLUMNS.each do |column|
           notes = notes.where(column => params[column]) if params[column].present?

--- a/app/controllers/api/v2/media_attachments/presigns_controller.rb
+++ b/app/controllers/api/v2/media_attachments/presigns_controller.rb
@@ -5,12 +5,19 @@ module Api
       class PresignsController < Api::V2::ApplicationController
         before_action :authenticate_api_v1_user!
 
-        CONTENT_TYPE_EXTENSIONS = {
-          'image/jpeg' => 'jpg',
-          'image/png' => 'png',
-          'image/heic' => 'heic',
-          'video/mp4' => 'mp4',
-          'video/quicktime' => 'mov'
+        # media_typeごとに許可するcontent_typeを分けることで、例えば
+        # media_type: 'image' に content_type: 'video/mp4' を組み合わせて
+        # LimitValidatorの動画チェック（長さ・解像度）を回避されるのを防ぐ。
+        CONTENT_TYPE_EXTENSIONS_BY_MEDIA_TYPE = {
+          'image' => {
+            'image/jpeg' => 'jpg',
+            'image/png' => 'png',
+            'image/heic' => 'heic'
+          }.freeze,
+          'video' => {
+            'video/mp4' => 'mp4',
+            'video/quicktime' => 'mov'
+          }.freeze
         }.freeze
 
         def create
@@ -18,7 +25,7 @@ module Api
 
           return render json: { error: '今月のアップロード上限に達しています' }, status: :forbidden unless current_api_v1_user.can_upload_media_this_month?
 
-          extension = CONTENT_TYPE_EXTENSIONS[presign_params[:content_type]]
+          extension = extension_for(presign_params[:media_type], presign_params[:content_type])
           return render json: { errors: ['対応していないファイル形式です'] }, status: :unprocessable_entity unless extension
 
           attachment = build_attachment(note, extension)
@@ -33,6 +40,10 @@ module Api
 
         def presign_params
           params.require(:media_attachment).permit(:baseball_note_id, :media_type, :content_type)
+        end
+
+        def extension_for(media_type, content_type)
+          CONTENT_TYPE_EXTENSIONS_BY_MEDIA_TYPE[media_type]&.[](content_type)
         end
 
         def build_attachment(note, extension)

--- a/app/controllers/api/v2/media_attachments/presigns_controller.rb
+++ b/app/controllers/api/v2/media_attachments/presigns_controller.rb
@@ -1,0 +1,66 @@
+module Api
+  module V2
+    module MediaAttachments
+      # メディア添付の署名アップロードURLを発行する。本体は常にクライアントからR2へ直接PUTする。
+      class PresignsController < Api::V2::ApplicationController
+        before_action :authenticate_api_v1_user!
+
+        CONTENT_TYPE_EXTENSIONS = {
+          'image/jpeg' => 'jpg',
+          'image/png' => 'png',
+          'image/heic' => 'heic',
+          'video/mp4' => 'mp4',
+          'video/quicktime' => 'mov'
+        }.freeze
+
+        def create
+          note = current_api_v1_user.baseball_notes.find(presign_params[:baseball_note_id])
+
+          return render json: { error: '今月のアップロード上限に達しています' }, status: :forbidden unless current_api_v1_user.can_upload_media_this_month?
+
+          extension = CONTENT_TYPE_EXTENSIONS[presign_params[:content_type]]
+          return render json: { errors: ['対応していないファイル形式です'] }, status: :unprocessable_entity unless extension
+
+          attachment = build_attachment(note, extension)
+          if attachment.save
+            render json: presign_response(attachment), status: :created
+          else
+            render json: { errors: attachment.errors.full_messages }, status: :unprocessable_entity
+          end
+        end
+
+        private
+
+        def presign_params
+          params.require(:media_attachment).permit(:baseball_note_id, :media_type, :content_type)
+        end
+
+        def build_attachment(note, extension)
+          key = "#{note.user_id}/#{note.id}/#{SecureRandom.uuid}.#{extension}"
+          is_video = presign_params[:media_type] == 'video'
+          current_api_v1_user.media_attachments.new(
+            baseball_note: note,
+            media_type: presign_params[:media_type],
+            r2_key: key,
+            thumbnail_r2_key: is_video ? key.sub(/\.\w+\z/, '_thumb.jpg') : nil,
+            status: 'pending'
+          )
+        end
+
+        def presign_response(attachment)
+          {
+            id: attachment.id,
+            media_type: attachment.media_type,
+            status: attachment.status,
+            upload_url: signed_url(attachment.r2_key, presign_params[:content_type]),
+            thumbnail_upload_url: attachment.thumbnail_r2_key && signed_url(attachment.thumbnail_r2_key, 'image/jpeg')
+          }
+        end
+
+        def signed_url(key, content_type)
+          ::MediaAttachments::PresignedUrlService.new(r2_key: key, content_type:).call
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/media_attachments_controller.rb
+++ b/app/controllers/api/v2/media_attachments_controller.rb
@@ -1,0 +1,40 @@
+module Api
+  module V2
+    class MediaAttachmentsController < Api::V2::ApplicationController
+      before_action :authenticate_api_v1_user!
+      before_action :load_media_attachment
+
+      def update
+        return render json: { errors: ['既に完了処理済みです'] }, status: :unprocessable_entity unless @media_attachment.status == 'pending'
+
+        @media_attachment.assign_attributes(completion_params)
+        unless ::MediaAttachments::LimitValidator.new(user: current_api_v1_user, attachment: @media_attachment).valid?
+          @media_attachment.update!(status: 'failed')
+          return render json: { errors: ['アップロード可能な上限を超えています'] }, status: :unprocessable_entity
+        end
+
+        @media_attachment.status = 'ready'
+        if @media_attachment.save
+          render json: @media_attachment, serializer: ::V2::MediaAttachmentSerializer, status: :ok
+        else
+          render json: { errors: @media_attachment.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        @media_attachment.destroy
+        render json: { message: '削除しました' }, status: :ok
+      end
+
+      private
+
+      def load_media_attachment
+        @media_attachment = current_api_v1_user.media_attachments.find(params[:id])
+      end
+
+      def completion_params
+        params.require(:media_attachment).permit(:duration_seconds, :width, :height, :file_size_bytes)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/media_attachments_controller.rb
+++ b/app/controllers/api/v2/media_attachments_controller.rb
@@ -29,6 +29,15 @@ module Api
         return render json: { errors: ['既に完了処理済みです'] }, status: :unprocessable_entity unless @media_attachment.status == 'pending'
 
         @media_attachment.assign_attributes(completion_params)
+
+        actual_size = ::MediaAttachments::ObjectSizeFetcher.new(r2_key: @media_attachment.r2_key).call
+        if actual_size.nil?
+          @media_attachment.update!(status: 'failed')
+          return render json: { errors: ['アップロードが確認できませんでした'] }, status: :unprocessable_entity
+        end
+        # file_size_bytesはクライアントの自己申告値のため、R2上の実サイズで上書きしてから検証する。
+        @media_attachment.file_size_bytes = actual_size
+
         unless ::MediaAttachments::LimitValidator.new(user: current_api_v1_user, attachment: @media_attachment).valid?
           @media_attachment.update!(status: 'failed')
           return render json: { errors: ['アップロード可能な上限を超えています'] }, status: :unprocessable_entity

--- a/app/controllers/api/v2/media_attachments_controller.rb
+++ b/app/controllers/api/v2/media_attachments_controller.rb
@@ -4,7 +4,28 @@ module Api
       before_action :authenticate_api_v1_user!
       before_action :load_media_attachment
 
+      # アップロード完了通知（file_size_bytesを含む）とメモ更新は同じPATCHで受け、
+      # パラメータの形で意図を判別する。前者はstatus: pending時のみの一度きりの遷移。
       def update
+        if params[:media_attachment]&.key?(:file_size_bytes)
+          complete_upload
+        else
+          update_memo
+        end
+      end
+
+      def destroy
+        @media_attachment.destroy
+        render json: { message: '削除しました' }, status: :ok
+      end
+
+      private
+
+      def load_media_attachment
+        @media_attachment = current_api_v1_user.media_attachments.find(params[:id])
+      end
+
+      def complete_upload
         return render json: { errors: ['既に完了処理済みです'] }, status: :unprocessable_entity unless @media_attachment.status == 'pending'
 
         @media_attachment.assign_attributes(completion_params)
@@ -21,19 +42,20 @@ module Api
         end
       end
 
-      def destroy
-        @media_attachment.destroy
-        render json: { message: '削除しました' }, status: :ok
-      end
-
-      private
-
-      def load_media_attachment
-        @media_attachment = current_api_v1_user.media_attachments.find(params[:id])
+      def update_memo
+        if @media_attachment.update(memo_params)
+          render json: @media_attachment, serializer: ::V2::MediaAttachmentSerializer, status: :ok
+        else
+          render json: { errors: @media_attachment.errors.full_messages }, status: :unprocessable_entity
+        end
       end
 
       def completion_params
-        params.require(:media_attachment).permit(:duration_seconds, :width, :height, :file_size_bytes)
+        params.require(:media_attachment).permit(:duration_seconds, :width, :height, :file_size_bytes, :memo)
+      end
+
+      def memo_params
+        params.require(:media_attachment).permit(:memo)
       end
     end
   end

--- a/app/controllers/api/v2/shadow_swing_sessions_controller.rb
+++ b/app/controllers/api/v2/shadow_swing_sessions_controller.rb
@@ -4,6 +4,7 @@ module Api
     # 開始時に作成し、完了時に練習ログを自動生成する。
     class ShadowSwingSessionsController < Api::V2::ApplicationController
       before_action :authenticate_api_v1_user!
+      before_action :require_trend_detail_entitlement, only: :trend
 
       # POST /api/v2/shadow_swing_sessions
       def create
@@ -38,7 +39,19 @@ module Api
         }, status: :ok
       end
 
+      # GET /api/v2/shadow_swing_sessions/trend
+      # 素振りの推移詳細は Pro 限定（メニュー推移詳細と同じ entitlement）。
+      def trend
+        render json: ::Practices::ShadowSwingTrend.new(current_api_v1_user).call, status: :ok
+      end
+
       private
+
+      def require_trend_detail_entitlement
+        return if current_api_v1_user.has_entitlement?('practice_menu_trend_detail')
+
+        render json: { error: 'メニュー推移の詳細表示は Pro プラン限定です' }, status: :forbidden
+      end
 
       def complete_params
         params.require(:shadow_swing_session).permit(:swing_count)

--- a/app/jobs/media_attachment_deletion_job.rb
+++ b/app/jobs/media_attachment_deletion_job.rb
@@ -1,0 +1,7 @@
+class MediaAttachmentDeletionJob < ApplicationJob
+  queue_as :default
+
+  def perform(r2_key, thumbnail_r2_key = nil)
+    MediaAttachments::ObjectDeleter.new(keys: [r2_key, thumbnail_r2_key]).call
+  end
+end

--- a/app/models/baseball_note.rb
+++ b/app/models/baseball_note.rb
@@ -11,6 +11,7 @@ class BaseballNote < ApplicationRecord
   has_many :game_results, through: :note_game_links
   has_many :note_theme_links, dependent: :destroy
   has_many :improvement_themes, through: :note_theme_links
+  has_many :media_attachments, -> { ordered }, dependent: :destroy, inverse_of: :baseball_note
 
   def extract_and_truncate_memo
     return '' if memo.blank?

--- a/app/models/concerns/entitlement.rb
+++ b/app/models/concerns/entitlement.rb
@@ -24,7 +24,6 @@ module Entitlement
     'grass_full_history',           # 草機能: 全期間ヒートマップ表示
     'unlimited_practice_menus',     # 練習メニュー無制限(無料は5件まで)
     'unlimited_media_uploads',      # 動画・画像アップロード無制限(無料は月3件)
-    'media_long_term_storage',      # メディア長期保管(31日以上前も閲覧可)
     'schedule_copy_next_week',      # 週の練習プランを来週へ一括コピー
     'unlimited_menu_sets',          # メニューセット無制限(無料は2件まで)
     'unlimited_monthly_goals',      # 個人の期間目標無制限(無料は2件まで)

--- a/app/models/concerns/plan_limits.rb
+++ b/app/models/concerns/plan_limits.rb
@@ -110,8 +110,9 @@ module PlanLimits
     practice_menus.where(archived: false).count
   end
 
+  # アップロード失敗分は無料枠を消費させないため除外する。
   def media_attachments_count_this_month
-    0
+    media_attachments.where(created_at: Time.current.all_month).where.not(status: 'failed').count
   end
 
   def menu_sets_count

--- a/app/models/concerns/plan_limits.rb
+++ b/app/models/concerns/plan_limits.rb
@@ -14,6 +14,8 @@ module PlanLimits
   # 「練習と成績のつながり」の自作カード上限（機能自体が Pro 限定のため Pro 内での歯止め）。
   INSIGHT_COMBINATION_LIMIT = 20
   GROUP_FREE_LIMIT = 1
+  # PUT用署名URLの有効期限は10分だが、クライアント側の圧縮・アップロード時間を考慮して余裕を持たせる。
+  MEDIA_UPLOAD_STALE_PENDING_THRESHOLD = 1.hour
 
   # 練習メニューを新規作成できるか。無料は archived 以外3つまで。
   # @return [Boolean]
@@ -110,9 +112,14 @@ module PlanLimits
     practice_menus.where(archived: false).count
   end
 
-  # アップロード失敗分は無料枠を消費させないため除外する。
+  # アップロード失敗分に加え、クラッシュ・中断等で完了しないまま放置されたpendingも
+  # 無料枠を消費させないため除外する。
   def media_attachments_count_this_month
-    media_attachments.where(created_at: Time.current.all_month).where.not(status: 'failed').count
+    media_attachments
+      .where(created_at: Time.current.all_month)
+      .where.not(status: 'failed')
+      .where('status != ? OR created_at > ?', 'pending', MEDIA_UPLOAD_STALE_PENDING_THRESHOLD.ago)
+      .count
   end
 
   def menu_sets_count

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -1,0 +1,26 @@
+class MediaAttachment < ApplicationRecord
+  belongs_to :user
+  belongs_to :baseball_note, counter_cache: true, inverse_of: :media_attachments
+
+  MEDIA_TYPES = %w[image video].freeze
+  STATUSES = %w[pending ready failed].freeze
+
+  validates :media_type, inclusion: { in: MEDIA_TYPES }
+  validates :status, inclusion: { in: STATUSES }
+  validates :r2_key, presence: true
+
+  scope :ordered, -> { order(:position, :id) }
+
+  after_commit :enqueue_r2_deletion, on: :destroy
+
+  def video?
+    media_type == 'video'
+  end
+
+  private
+
+  # R2への外部API呼び出しはリクエストの応答時間に含めないため非同期化する。
+  def enqueue_r2_deletion
+    MediaAttachmentDeletionJob.perform_later(r2_key, thumbnail_r2_key)
+  end
+end

--- a/app/models/shadow_swing_session.rb
+++ b/app/models/shadow_swing_session.rb
@@ -24,17 +24,33 @@ class ShadowSwingSession < ApplicationRecord
       if log
         log.update!(amount: log.amount.to_i + swing_count)
       else
+        menu = linked_menu
         log = user.practice_logs.create!(
-          practice_menu: nil,
+          practice_menu: menu,
           logged_on:,
           amount: swing_count,
           menu_name: MENU_NAME,
-          unit_label: UNIT_LABEL,
+          unit_label: menu&.unit_label || UNIT_LABEL,
           source: 'shadow_swing'
         )
       end
       update!(swing_count:, completed_at: Time.current, practice_log: log)
     end
     self
+  end
+
+  private
+
+  # 「素振り」という名前の練習メニューが既にあれば紐付け、積み上げ・推移を一本化する。
+  # 単位が「回数」以外の既存メニューは統合すると数値の意味が壊れるため紐付けない
+  # （その場合は practice_menu: nil のまま、従来通り別集計になる）。
+  # 該当メニューが無ければ「回数」単位で新規作成する。
+  # @return [PracticeMenu, nil]
+  def linked_menu
+    existing = user.practice_menus.find_by(name: MENU_NAME)
+    return existing if existing&.unit == 'count'
+    return nil if existing
+
+    user.practice_menus.create!(name: MENU_NAME, category: 'batting', unit: 'count', unit_label: UNIT_LABEL)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,7 @@ class User < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
                                  dependent: :destroy, inverse_of: :actor
   has_many :device_tokens, dependent: :destroy
   has_many :baseball_notes, dependent: :destroy
+  has_many :media_attachments, dependent: :destroy
   has_many :match_results, dependent: :destroy
   has_many :seasons, dependent: :destroy
   has_many :game_results, dependent: :destroy

--- a/app/serializers/v2/baseball_note_serializer.rb
+++ b/app/serializers/v2/baseball_note_serializer.rb
@@ -3,6 +3,8 @@ module V2
     attributes :id, :title, :date, :memo, :memo_preview, :game_result_ids, :practice_log_id, :practice_session_id,
                :improvement_theme_ids, :reflection_template_id, :reflection_answers, :tags
 
+    has_many :media_attachments, serializer: ::V2::MediaAttachmentSerializer
+
     def memo_preview
       object.extract_and_truncate_memo
     end

--- a/app/serializers/v2/media_attachment_serializer.rb
+++ b/app/serializers/v2/media_attachment_serializer.rb
@@ -1,7 +1,7 @@
 module V2
   class MediaAttachmentSerializer < ActiveModel::Serializer
     attributes :id, :media_type, :status, :file_size_bytes, :duration_seconds,
-               :width, :height, :position, :playback_url, :thumbnail_url, :created_at
+               :width, :height, :position, :memo, :playback_url, :thumbnail_url, :created_at
 
     def playback_url
       ::MediaAttachments::PublicUrlBuilder.for(object.r2_key)

--- a/app/serializers/v2/media_attachment_serializer.rb
+++ b/app/serializers/v2/media_attachment_serializer.rb
@@ -1,0 +1,14 @@
+module V2
+  class MediaAttachmentSerializer < ActiveModel::Serializer
+    attributes :id, :media_type, :status, :file_size_bytes, :duration_seconds,
+               :width, :height, :position, :playback_url, :thumbnail_url, :created_at
+
+    def playback_url
+      ::MediaAttachments::PublicUrlBuilder.for(object.r2_key)
+    end
+
+    def thumbnail_url
+      ::MediaAttachments::PublicUrlBuilder.for(object.thumbnail_r2_key)
+    end
+  end
+end

--- a/app/services/media_attachments/limit_validator.rb
+++ b/app/services/media_attachments/limit_validator.rb
@@ -1,0 +1,34 @@
+module MediaAttachments
+  # クライアント側のチェックはバイパス可能なため、アップロード完了通知時にサーバー側でも
+  # 無料/Pro上限（動画長さ・解像度、画像サイズ）を再検証する。
+  class LimitValidator
+    FREE_VIDEO_MAX_DURATION = 30
+    PRO_VIDEO_MAX_DURATION = 60
+    FREE_VIDEO_MAX_HEIGHT = 480
+    PRO_VIDEO_MAX_HEIGHT = 1080
+    FREE_IMAGE_MAX_BYTES = 5.megabytes
+    PRO_IMAGE_MAX_BYTES = 10.megabytes
+
+    def initialize(user:, attachment:)
+      @user = user
+      @attachment = attachment
+    end
+
+    # @return [Boolean]
+    def valid?
+      pro = @user.has_entitlement?('unlimited_media_uploads')
+      @attachment.video? ? valid_video?(pro) : valid_image?(pro)
+    end
+
+    private
+
+    def valid_video?(pro)
+      @attachment.duration_seconds.to_i <= (pro ? PRO_VIDEO_MAX_DURATION : FREE_VIDEO_MAX_DURATION) &&
+        @attachment.height.to_i <= (pro ? PRO_VIDEO_MAX_HEIGHT : FREE_VIDEO_MAX_HEIGHT)
+    end
+
+    def valid_image?(pro)
+      @attachment.file_size_bytes.to_i <= (pro ? PRO_IMAGE_MAX_BYTES : FREE_IMAGE_MAX_BYTES)
+    end
+  end
+end

--- a/app/services/media_attachments/limit_validator.rb
+++ b/app/services/media_attachments/limit_validator.rb
@@ -3,7 +3,7 @@ module MediaAttachments
   # 無料/Pro上限（動画長さ・解像度、画像サイズ）を再検証する。
   class LimitValidator
     FREE_VIDEO_MAX_DURATION = 30
-    PRO_VIDEO_MAX_DURATION = 60
+    PRO_VIDEO_MAX_DURATION = 180
     FREE_VIDEO_MAX_HEIGHT = 480
     PRO_VIDEO_MAX_HEIGHT = 1080
     FREE_IMAGE_MAX_BYTES = 5.megabytes

--- a/app/services/media_attachments/object_deleter.rb
+++ b/app/services/media_attachments/object_deleter.rb
@@ -1,0 +1,17 @@
+module MediaAttachments
+  # R2上のオブジェクト（本体・サムネイル）をまとめて削除する。
+  class ObjectDeleter
+    def initialize(keys:)
+      @keys = keys.compact
+    end
+
+    def call
+      return if @keys.empty?
+
+      PresignedUrlService.client.delete_objects(
+        bucket: ENV.fetch('R2_BUCKET_NAME'),
+        delete: { objects: @keys.map { |key| { key: } } }
+      )
+    end
+  end
+end

--- a/app/services/media_attachments/object_size_fetcher.rb
+++ b/app/services/media_attachments/object_size_fetcher.rb
@@ -1,0 +1,20 @@
+module MediaAttachments
+  # クライアント自己申告のfile_size_bytesは改ざん可能なため、完了処理時にR2上の実サイズで
+  # 上書きして検証する。呼び出し時点でPUTは完了している前提のため、存在しない場合は
+  # アップロード自体が完了していないとみなす。
+  class ObjectSizeFetcher
+    def initialize(r2_key:)
+      @r2_key = r2_key
+    end
+
+    # @return [Integer, nil] オブジェクトがR2上に存在しない場合はnil
+    def call
+      PresignedUrlService.client.head_object(
+        bucket: ENV.fetch('R2_BUCKET_NAME'),
+        key: @r2_key
+      ).content_length
+    rescue Aws::S3::Errors::NotFound
+      nil
+    end
+  end
+end

--- a/app/services/media_attachments/presigned_url_service.rb
+++ b/app/services/media_attachments/presigned_url_service.rb
@@ -1,0 +1,44 @@
+module MediaAttachments
+  # Cloudflare R2（S3互換）への署名PUT URLを発行する。
+  # 本体アップロードは常にクライアントからR2へ直接行い、サーバーはURL発行のみを担う。
+  class PresignedUrlService
+    PUT_EXPIRES_IN = 10.minutes.to_i
+
+    # @param r2_key [String] R2オブジェクトキー
+    # @param content_type [String] MIMEタイプ
+    def initialize(r2_key:, content_type:)
+      @r2_key = r2_key
+      @content_type = content_type
+    end
+
+    # @return [String] 署名済みPUT URL
+    def call
+      presigner.presigned_url(
+        :put_object,
+        bucket: ENV.fetch('R2_BUCKET_NAME'),
+        key: @r2_key,
+        content_type: @content_type,
+        expires_in: PUT_EXPIRES_IN
+      )
+    end
+
+    class << self
+      # R2はバケット名を含むvirtual-hosted style解決に対応しないため path_style を強制する。
+      def client
+        @client ||= Aws::S3::Client.new(
+          endpoint: ENV.fetch('R2_ENDPOINT'),
+          region: 'auto',
+          access_key_id: ENV.fetch('R2_ACCESS_KEY_ID'),
+          secret_access_key: ENV.fetch('R2_SECRET_ACCESS_KEY'),
+          force_path_style: true
+        )
+      end
+    end
+
+    private
+
+    def presigner
+      Aws::S3::Presigner.new(client: self.class.client)
+    end
+  end
+end

--- a/app/services/media_attachments/public_url_builder.rb
+++ b/app/services/media_attachments/public_url_builder.rb
@@ -1,0 +1,13 @@
+module MediaAttachments
+  # R2オブジェクトキーから公開URLを組み立てる。r2_key自体はフルURLを持たないため、
+  # CDNドメイン変更時にこのモジュールの変更のみで済むようにする。
+  module PublicUrlBuilder
+    module_function
+
+    def for(key)
+      return nil if key.blank?
+
+      "#{ENV.fetch('R2_PUBLIC_BASE_URL')}/#{key}"
+    end
+  end
+end

--- a/app/services/practices/shadow_swing_trend.rb
+++ b/app/services/practices/shadow_swing_trend.rb
@@ -1,0 +1,50 @@
+module Practices
+  # 素振り（source: shadow_swing）の推移を年別・月別・日別で集計して返す。
+  # 素振りログは practice_menu に紐付かないため MenuTrend とは別サービスに分離する。
+  class ShadowSwingTrend
+    DAY_LIMIT = 60
+
+    def initialize(user)
+      @user = user
+    end
+
+    # @return [Hash]
+    def call
+      logs = @user.practice_logs.where(source: 'shadow_swing').order(logged_on: :desc).to_a
+      {
+        menu: menu_info,
+        by_year: grouped(logs) { |log| log.logged_on.year.to_s },
+        by_month: grouped(logs) { |log| log.logged_on.strftime('%Y-%m') },
+        by_day: grouped(logs) { |log| log.logged_on.to_s }.first(DAY_LIMIT)
+      }
+    end
+
+    private
+
+    def menu_info
+      {
+        id: nil,
+        name: ShadowSwingSession::MENU_NAME,
+        unit: 'count',
+        unit_label: ShadowSwingSession::UNIT_LABEL,
+        is_weight_reps: false
+      }
+    end
+
+    def grouped(logs, &)
+      logs.group_by(&)
+          .map { |period, group| bucket(period, group) }
+          .sort_by { |entry| entry[:period] }
+          .reverse
+    end
+
+    def bucket(period, group)
+      {
+        period:,
+        total_amount: group.sum { |log| log.amount.to_f },
+        total_volume: 0,
+        days_count: group.map(&:logged_on).uniq.size
+      }
+    end
+  end
+end

--- a/config/initializers/r2.rb
+++ b/config/initializers/r2.rb
@@ -1,0 +1,1 @@
+require 'aws-sdk-s3'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -297,6 +297,8 @@ Rails.application.routes.draw do
       resources :periodic_reviews, only: %i[index update]
       resource :correlation_insights, only: %i[show], controller: 'correlation_insights'
       resources :insight_combinations, only: %i[create destroy]
+      resources :media_attachments, only: %i[update destroy]
+      post 'media_attachments/presign', to: 'media_attachments/presigns#create'
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -276,7 +276,10 @@ Rails.application.routes.draw do
       resource :practice_overview, only: %i[show], controller: 'practice_overview'
       resources :shadow_swing_sessions, only: %i[create] do
         member { post :complete }
-        collection { get :stats }
+        collection do
+          get :stats
+          get :trend
+        end
       end
       resources :activity_logs, only: %i[index] do
         collection { get :streak }

--- a/db/migrate/20260720083726_create_media_attachments.rb
+++ b/db/migrate/20260720083726_create_media_attachments.rb
@@ -1,0 +1,21 @@
+class CreateMediaAttachments < ActiveRecord::Migration[7.1]
+  def change
+    create_table :media_attachments do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :baseball_note, null: false, foreign_key: true
+      t.string :media_type, null: false
+      t.string :r2_key, null: false
+      t.string :thumbnail_r2_key
+      t.integer :file_size_bytes
+      t.integer :duration_seconds
+      t.integer :width
+      t.integer :height
+      t.integer :position, null: false, default: 0
+      t.string :status, null: false, default: 'pending'
+
+      t.timestamps
+    end
+
+    add_index :media_attachments, %i[user_id created_at]
+  end
+end

--- a/db/migrate/20260720083752_add_media_attachments_count_to_baseball_notes.rb
+++ b/db/migrate/20260720083752_add_media_attachments_count_to_baseball_notes.rb
@@ -1,0 +1,5 @@
+class AddMediaAttachmentsCountToBaseballNotes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :baseball_notes, :media_attachments_count, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20260721150618_add_memo_to_media_attachments.rb
+++ b/db/migrate/20260721150618_add_memo_to_media_attachments.rb
@@ -1,0 +1,5 @@
+class AddMemoToMediaAttachments < ActiveRecord::Migration[7.1]
+  def change
+    add_column :media_attachments, :memo, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_07_20_083752) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_21_150618) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -434,6 +434,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_20_083752) do
     t.string "status", default: "pending", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "memo"
     t.index ["baseball_note_id"], name: "index_media_attachments_on_baseball_note_id"
     t.index ["user_id", "created_at"], name: "index_media_attachments_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_media_attachments_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_07_20_010001) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_20_083752) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -149,6 +149,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_20_010001) do
     t.bigint "practice_session_id"
     t.jsonb "reflection_answers", default: [], null: false
     t.bigint "reflection_template_id"
+    t.integer "media_attachments_count", default: 0, null: false
     t.index ["practice_log_id"], name: "index_baseball_notes_on_practice_log_id"
     t.index ["practice_session_id"], name: "index_baseball_notes_on_practice_session_id"
     t.index ["reflection_template_id"], name: "index_baseball_notes_on_reflection_template_id"
@@ -417,6 +418,25 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_20_010001) do
     t.index ["opponent_team_id"], name: "index_match_results_on_opponent_team_id"
     t.index ["stadium_id"], name: "index_match_results_on_stadium_id"
     t.index ["user_id"], name: "index_match_results_on_user_id"
+  end
+
+  create_table "media_attachments", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "baseball_note_id", null: false
+    t.string "media_type", null: false
+    t.string "r2_key", null: false
+    t.string "thumbnail_r2_key"
+    t.integer "file_size_bytes"
+    t.integer "duration_seconds"
+    t.integer "width"
+    t.integer "height"
+    t.integer "position", default: 0, null: false
+    t.string "status", default: "pending", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["baseball_note_id"], name: "index_media_attachments_on_baseball_note_id"
+    t.index ["user_id", "created_at"], name: "index_media_attachments_on_user_id_and_created_at"
+    t.index ["user_id"], name: "index_media_attachments_on_user_id"
   end
 
   create_table "menu_set_items", force: :cascade do |t|
@@ -1111,6 +1131,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_20_010001) do
   add_foreign_key "match_results", "teams", column: "my_team_id"
   add_foreign_key "match_results", "teams", column: "opponent_team_id"
   add_foreign_key "match_results", "users"
+  add_foreign_key "media_attachments", "baseball_notes"
+  add_foreign_key "media_attachments", "users"
   add_foreign_key "menu_set_items", "menu_sets"
   add_foreign_key "menu_set_items", "practice_menus"
   add_foreign_key "menu_sets", "users"

--- a/spec/factories/media_attachments.rb
+++ b/spec/factories/media_attachments.rb
@@ -1,0 +1,23 @@
+FactoryBot.define do
+  factory :media_attachment do
+    user
+    baseball_note { association :baseball_note, user: }
+    media_type { 'image' }
+    sequence(:r2_key) { |n| "#{user.id}/#{baseball_note.id}/test-#{n}.jpg" }
+    status { 'pending' }
+
+    trait :video do
+      media_type { 'video' }
+      sequence(:r2_key) { |n| "#{user.id}/#{baseball_note.id}/test-#{n}.mp4" }
+      sequence(:thumbnail_r2_key) { |n| "#{user.id}/#{baseball_note.id}/test-#{n}_thumb.jpg" }
+    end
+
+    trait :ready do
+      status { 'ready' }
+      file_size_bytes { 1_000_000 }
+      duration_seconds { 10 }
+      width { 720 }
+      height { 480 }
+    end
+  end
+end

--- a/spec/models/concerns/entitlement_spec.rb
+++ b/spec/models/concerns/entitlement_spec.rb
@@ -136,5 +136,15 @@ RSpec.describe Entitlement, type: :model do
       create_list(:media_attachment, 3, :ready, user:, baseball_note: note)
       expect(user.can_upload_media_this_month?).to be true
     end
+
+    it 'excludes pending attachments older than the stale threshold' do
+      travel_to(2.hours.ago) { create_list(:media_attachment, 3, user:, baseball_note: note) }
+      expect(user.can_upload_media_this_month?).to be true
+    end
+
+    it 'counts pending attachments still within the stale threshold' do
+      create_list(:media_attachment, 3, user:, baseball_note: note)
+      expect(user.can_upload_media_this_month?).to be false
+    end
   end
 end

--- a/spec/models/concerns/entitlement_spec.rb
+++ b/spec/models/concerns/entitlement_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe Entitlement, type: :model do
   let(:user) { create(:user) }
 
   describe 'feature key constants' do
-    it 'defines exactly 10 free features and 27 pro features' do
+    it 'defines exactly 10 free features and 26 pro features' do
       # %w[] とインラインコメントの混在で feature key が壊れる回帰を防ぐ
       expect(described_class::FREE_FEATURES.size).to eq 10
-      expect(described_class::PRO_FEATURES.size).to eq 27
-      expect(described_class::ALL_FEATURES.size).to eq 37
+      expect(described_class::PRO_FEATURES.size).to eq 26
+      expect(described_class::ALL_FEATURES.size).to eq 36
     end
 
     it 'contains only valid feature key strings (no stray symbols)' do
@@ -105,6 +105,36 @@ RSpec.describe Entitlement, type: :model do
       2.times { GroupInvitation.create!(user:, group: create(:group), state: 'accepted', sent_at: Time.current) }
       expect { user.can_create_or_join_group? }.not_to(change { user.group_invitations.accepted.count })
       expect(user.group_invitations.accepted.count).to eq 2
+    end
+  end
+
+  describe '#can_upload_media_this_month?' do
+    let(:note) { create(:baseball_note, user:) }
+
+    it 'returns true for a free user below the monthly limit' do
+      create_list(:media_attachment, 2, :ready, user:, baseball_note: note)
+      expect(user.can_upload_media_this_month?).to be true
+    end
+
+    it 'returns false for a free user who reached the monthly limit' do
+      create_list(:media_attachment, 3, :ready, user:, baseball_note: note)
+      expect(user.can_upload_media_this_month?).to be false
+    end
+
+    it 'excludes failed attachments from the monthly count' do
+      create_list(:media_attachment, 3, :ready, status: 'failed', user:, baseball_note: note)
+      expect(user.can_upload_media_this_month?).to be true
+    end
+
+    it 'excludes attachments created in a previous month' do
+      travel_to(1.month.ago) { create_list(:media_attachment, 3, :ready, user:, baseball_note: note) }
+      expect(user.can_upload_media_this_month?).to be true
+    end
+
+    it 'returns true for a Pro user beyond the monthly limit' do
+      user.subscription.update!(status: 'active', expires_at: 30.days.from_now)
+      create_list(:media_attachment, 3, :ready, user:, baseball_note: note)
+      expect(user.can_upload_media_this_month?).to be true
     end
   end
 end

--- a/spec/models/media_attachment_spec.rb
+++ b/spec/models/media_attachment_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe MediaAttachment, type: :model do
+  describe 'validations' do
+    it 'requires a valid media_type' do
+      attachment = build(:media_attachment, media_type: 'audio')
+      expect(attachment).not_to be_valid
+      expect(attachment.errors[:media_type]).to be_present
+    end
+
+    it 'requires a valid status' do
+      attachment = build(:media_attachment, status: 'uploading')
+      expect(attachment).not_to be_valid
+      expect(attachment.errors[:status]).to be_present
+    end
+
+    it 'requires r2_key' do
+      attachment = build(:media_attachment, r2_key: nil)
+      expect(attachment).not_to be_valid
+      expect(attachment.errors[:r2_key]).to be_present
+    end
+  end
+
+  describe '#video?' do
+    it 'returns true for video attachments' do
+      expect(build(:media_attachment, :video).video?).to be true
+    end
+
+    it 'returns false for image attachments' do
+      expect(build(:media_attachment).video?).to be false
+    end
+  end
+
+  describe 'counter_cache' do
+    it 'increments and decrements baseball_note.media_attachments_count' do
+      note = create(:baseball_note)
+      attachment = create(:media_attachment, baseball_note: note, user: note.user)
+
+      expect(note.reload.media_attachments_count).to eq 1
+
+      attachment.destroy
+      expect(note.reload.media_attachments_count).to eq 0
+    end
+  end
+
+  describe 'after destroy' do
+    it 'enqueues MediaAttachmentDeletionJob with the r2 keys' do
+      attachment = create(:media_attachment, :video)
+      expect { attachment.destroy }
+        .to have_enqueued_job(MediaAttachmentDeletionJob).with(attachment.r2_key, attachment.thumbnail_r2_key)
+    end
+  end
+end

--- a/spec/models/shadow_swing_session_spec.rb
+++ b/spec/models/shadow_swing_session_spec.rb
@@ -33,5 +33,36 @@ RSpec.describe ShadowSwingSession, type: :model do
         expect(logs.first.amount).to eq(150)
       end
     end
+
+    it '「素振り」という回数単位の練習メニューが無ければ自動作成して紐付ける' do
+      session = create(:shadow_swing_session, user:)
+
+      expect { session.complete!(swing_count: 120) }
+        .to change { user.practice_menus.where(name: '素振り', unit: 'count').count }.from(0).to(1)
+      log = user.practice_logs.find_by(source: 'shadow_swing')
+      expect(log.practice_menu).to eq(user.practice_menus.find_by(name: '素振り'))
+    end
+
+    it '既存の「素振り」メニューが回数単位なら紐付けて積み上げを統合する' do
+      menu = create(:practice_menu, user:, name: '素振り', unit: 'count', unit_label: '回')
+      session = create(:shadow_swing_session, user:)
+
+      session.complete!(swing_count: 120)
+
+      log = user.practice_logs.find_by(source: 'shadow_swing')
+      expect(log.practice_menu).to eq(menu)
+      expect(log.unit_label).to eq('回')
+    end
+
+    it '既存の「素振り」メニューが回数以外の単位なら紐付けない（統合しない）' do
+      create(:practice_menu, user:, name: '素振り', unit: 'minutes')
+      session = create(:shadow_swing_session, user:)
+
+      session.complete!(swing_count: 120)
+
+      log = user.practice_logs.find_by(source: 'shadow_swing')
+      expect(log.practice_menu_id).to be_nil
+      expect(log.unit_label).to eq('本')
+    end
   end
 end

--- a/spec/requests/api/v2/media_attachments/presigns_spec.rb
+++ b/spec/requests/api/v2/media_attachments/presigns_spec.rb
@@ -50,6 +50,13 @@ RSpec.describe 'Api::V2::MediaAttachments::Presigns', type: :request do
       expect(response).to have_http_status(:unprocessable_entity)
     end
 
+    it 'returns unprocessable_entity when media_type and content_type do not match' do
+      # media_type: 'image'で動画を送ると、complete_upload時にLimitValidatorが
+      # valid_image?（file_size_bytesのみ）に流れ、動画の長さ・解像度チェックを回避できてしまう。
+      presign(media_attachment: { baseball_note_id: note.id, media_type: 'image', content_type: 'video/mp4' })
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
     context 'monthly limit' do
       before do
         create_list(:media_attachment, 3, :ready, user:, baseball_note: note)

--- a/spec/requests/api/v2/media_attachments/presigns_spec.rb
+++ b/spec/requests/api/v2/media_attachments/presigns_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::MediaAttachments::Presigns', type: :request do
+  def make_pro(target)
+    target.subscription.update!(status: 'active', expires_at: 30.days.from_now)
+  end
+
+  let(:user) { create(:user) }
+  let(:note) { create(:baseball_note, user:) }
+
+  def presign(media_attachment:, headers: auth_headers_for(user))
+    post '/api/v2/media_attachments/presign', params: { media_attachment: }, headers:
+  end
+
+  context 'when not authenticated' do
+    it 'returns unauthorized' do
+      presign(media_attachment: { baseball_note_id: note.id, media_type: 'image', content_type: 'image/jpeg' }, headers: {})
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  context 'when authenticated' do
+    it 'creates a pending media_attachment and returns an upload_url for an image' do
+      expect do
+        presign(media_attachment: { baseball_note_id: note.id, media_type: 'image', content_type: 'image/jpeg' })
+      end.to change(MediaAttachment, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      json = response.parsed_body
+      expect(json['status']).to eq 'pending'
+      expect(json['upload_url']).to be_present
+      expect(json['thumbnail_upload_url']).to be_nil
+    end
+
+    it 'also returns a thumbnail_upload_url for a video' do
+      presign(media_attachment: { baseball_note_id: note.id, media_type: 'video', content_type: 'video/mp4' })
+
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body['thumbnail_upload_url']).to be_present
+    end
+
+    it 'returns not_found for another user note (IDOR)' do
+      other_note = create(:baseball_note, user: create(:user))
+      presign(media_attachment: { baseball_note_id: other_note.id, media_type: 'image', content_type: 'image/jpeg' })
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns unprocessable_entity for an unsupported content_type' do
+      presign(media_attachment: { baseball_note_id: note.id, media_type: 'image', content_type: 'image/webp' })
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    context 'monthly limit' do
+      before do
+        create_list(:media_attachment, 3, :ready, user:, baseball_note: note)
+      end
+
+      it 'returns forbidden for a free user who already used the monthly limit' do
+        presign(media_attachment: { baseball_note_id: note.id, media_type: 'image', content_type: 'image/jpeg' })
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'allows a Pro user beyond the monthly limit' do
+        make_pro(user)
+        presign(media_attachment: { baseball_note_id: note.id, media_type: 'image', content_type: 'image/jpeg' })
+        expect(response).to have_http_status(:created)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/media_attachments_spec.rb
+++ b/spec/requests/api/v2/media_attachments_spec.rb
@@ -11,7 +11,16 @@ RSpec.describe 'Api::V2::MediaAttachments', type: :request do
   describe 'PATCH /api/v2/media_attachments/:id' do
     let(:attachment) { create(:media_attachment, :video, user:, baseball_note: note) }
 
-    def complete(attachment, params, headers: auth_headers_for(user))
+    # 実運用ではfile_size_bytesはR2上の実サイズで上書きされるため、テストでは
+    # head_objectがcontent_length: actual_sizeを返すものとしてスタブする
+    # （既定はparamsのfile_size_bytesと同じ値にし、既存の検証ロジックのテストに影響しない）。
+    def stub_r2_head_object(content_length:)
+      allow(MediaAttachments::PresignedUrlService.client).to receive(:head_object)
+        .and_return(instance_double(Aws::S3::Types::HeadObjectOutput, content_length:))
+    end
+
+    def complete(attachment, params, headers: auth_headers_for(user), actual_size: params[:file_size_bytes])
+      stub_r2_head_object(content_length: actual_size) if actual_size
       patch "/api/v2/media_attachments/#{attachment.id}", params: { media_attachment: params }, headers:
     end
 
@@ -54,6 +63,28 @@ RSpec.describe 'Api::V2::MediaAttachments', type: :request do
 
       expect(response).to have_http_status(:ok)
       expect(attachment.reload.memo).to eq '初回の所感'
+    end
+
+    it 'ignores a spoofed file_size_bytes and validates against the real R2 object size' do
+      image_attachment = create(:media_attachment, user:, baseball_note: note)
+      # 無料の画像上限(5MB)を回避しようと小さい値を自己申告しても、実際のR2オブジェクトサイズで検証される。
+      complete(image_attachment, { file_size_bytes: 100 }, actual_size: 8_000_000)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(image_attachment.reload.status).to eq 'failed'
+      expect(image_attachment.file_size_bytes).to eq 8_000_000
+    end
+
+    it 'marks as failed when the object cannot be found on R2' do
+      allow(MediaAttachments::PresignedUrlService.client).to receive(:head_object)
+        .and_raise(Aws::S3::Errors::NotFound.new(nil, 'not found'))
+
+      patch "/api/v2/media_attachments/#{attachment.id}",
+            params: { media_attachment: { duration_seconds: 10, width: 720, height: 480, file_size_bytes: 1_000 } },
+            headers: auth_headers_for(user)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(attachment.reload.status).to eq 'failed'
     end
   end
 

--- a/spec/requests/api/v2/media_attachments_spec.rb
+++ b/spec/requests/api/v2/media_attachments_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Api::V2::MediaAttachments', type: :request do
 
     it 'allows Pro users up to the pro video duration' do
       make_pro(user)
-      complete(attachment, { duration_seconds: 60, width: 1080, height: 1080, file_size_bytes: 8_000_000 })
+      complete(attachment, { duration_seconds: 180, width: 1080, height: 1080, file_size_bytes: 8_000_000 })
 
       expect(response).to have_http_status(:ok)
       expect(attachment.reload.status).to eq 'ready'

--- a/spec/requests/api/v2/media_attachments_spec.rb
+++ b/spec/requests/api/v2/media_attachments_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V2::MediaAttachments', type: :request do
+  def make_pro(target)
+    target.subscription.update!(status: 'active', expires_at: 30.days.from_now)
+  end
+
+  let(:user) { create(:user) }
+  let(:note) { create(:baseball_note, user:) }
+
+  describe 'PATCH /api/v2/media_attachments/:id' do
+    let(:attachment) { create(:media_attachment, :video, user:, baseball_note: note) }
+
+    def complete(attachment, params, headers: auth_headers_for(user))
+      patch "/api/v2/media_attachments/#{attachment.id}", params: { media_attachment: params }, headers:
+    end
+
+    it 'marks the attachment as ready when within free limits' do
+      complete(attachment, { duration_seconds: 25, width: 720, height: 480, file_size_bytes: 8_000_000 })
+
+      expect(response).to have_http_status(:ok)
+      expect(attachment.reload.status).to eq 'ready'
+    end
+
+    it 'returns not_found for another user attachment (IDOR)' do
+      other_attachment = create(:media_attachment, :video, user: create(:user))
+      complete(other_attachment, { duration_seconds: 10, width: 720, height: 480, file_size_bytes: 1_000 })
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'marks as failed and returns unprocessable_entity when a free user exceeds video duration' do
+      complete(attachment, { duration_seconds: 31, width: 720, height: 480, file_size_bytes: 8_000_000 })
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(attachment.reload.status).to eq 'failed'
+    end
+
+    it 'allows Pro users up to the pro video duration' do
+      make_pro(user)
+      complete(attachment, { duration_seconds: 60, width: 1080, height: 1080, file_size_bytes: 8_000_000 })
+
+      expect(response).to have_http_status(:ok)
+      expect(attachment.reload.status).to eq 'ready'
+    end
+
+    it 'returns unprocessable_entity when the attachment is already completed' do
+      attachment.update!(status: 'ready')
+      complete(attachment, { duration_seconds: 10, width: 720, height: 480, file_size_bytes: 1_000 })
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe 'DELETE /api/v2/media_attachments/:id' do
+    let(:attachment) { create(:media_attachment, :ready, user:, baseball_note: note) }
+
+    it 'destroys the attachment and enqueues R2 object deletion' do
+      expect do
+        delete "/api/v2/media_attachments/#{attachment.id}", headers: auth_headers_for(user)
+      end.to have_enqueued_job(MediaAttachmentDeletionJob).with(attachment.r2_key, attachment.thumbnail_r2_key)
+
+      expect(response).to have_http_status(:ok)
+      expect(MediaAttachment.exists?(attachment.id)).to be false
+    end
+
+    it 'returns not_found for another user attachment (IDOR)' do
+      other_attachment = create(:media_attachment, :ready, user: create(:user))
+      delete "/api/v2/media_attachments/#{other_attachment.id}", headers: auth_headers_for(user)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/api/v2/media_attachments_spec.rb
+++ b/spec/requests/api/v2/media_attachments_spec.rb
@@ -48,6 +48,42 @@ RSpec.describe 'Api::V2::MediaAttachments', type: :request do
       complete(attachment, { duration_seconds: 10, width: 720, height: 480, file_size_bytes: 1_000 })
       expect(response).to have_http_status(:unprocessable_entity)
     end
+
+    it 'accepts memo together with completion params' do
+      complete(attachment, { duration_seconds: 25, width: 720, height: 480, file_size_bytes: 8_000_000, memo: '初回の所感' })
+
+      expect(response).to have_http_status(:ok)
+      expect(attachment.reload.memo).to eq '初回の所感'
+    end
+  end
+
+  describe 'PATCH /api/v2/media_attachments/:id（メモ更新）' do
+    let(:attachment) { create(:media_attachment, :ready, user:, baseball_note: note) }
+
+    def update_memo(attachment, memo, headers: auth_headers_for(user))
+      patch "/api/v2/media_attachments/#{attachment.id}", params: { media_attachment: { memo: } }, headers:
+    end
+
+    it 'updates the memo of an already-ready attachment' do
+      long_text = "1段落目です。\n\n2段落目、フォームについての詳しい所感。" * 5
+      update_memo(attachment, long_text)
+
+      expect(response).to have_http_status(:ok)
+      expect(attachment.reload.memo).to eq long_text
+      expect(response.parsed_body['memo']).to eq long_text
+    end
+
+    it 'does not require re-validation of upload limits' do
+      make_pro(user)
+      update_memo(attachment, 'メモだけ更新')
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns not_found for another user attachment (IDOR)' do
+      other_attachment = create(:media_attachment, :ready, user: create(:user))
+      update_memo(other_attachment, 'メモ')
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe 'DELETE /api/v2/media_attachments/:id' do

--- a/spec/requests/api/v2/shadow_swing_sessions_spec.rb
+++ b/spec/requests/api/v2/shadow_swing_sessions_spec.rb
@@ -72,4 +72,29 @@ RSpec.describe 'Api::V2::ShadowSwingSessions', type: :request do
       expect(body['total_count']).to eq(150)
     end
   end
+
+  describe 'GET /api/v2/shadow_swing_sessions/trend' do
+    def make_pro(target)
+      target.subscription.update!(status: 'active', expires_at: 1.month.from_now)
+    end
+
+    it '無料ユーザーは403（推移詳細は Pro 限定）' do
+      get '/api/v2/shadow_swing_sessions/trend', headers: auth_headers_for(user)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'Proユーザーは素振りの年別・月別・日別の集計を返す' do
+      make_pro(user)
+      create(:practice_log, :shadow_swing, user:, logged_on: today, amount: 100)
+      create(:practice_log, :shadow_swing, user:, logged_on: today - 40, amount: 50)
+
+      get '/api/v2/shadow_swing_sessions/trend', headers: auth_headers_for(user)
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body['menu']['name']).to eq('素振り')
+      expect(body['menu']['is_weight_reps']).to be(false)
+      expect(body['by_year'].first['period']).to eq(today.year.to_s)
+      expect(body['by_month'].first['total_amount'].to_f).to eq(100)
+    end
+  end
 end

--- a/spec/services/media_attachments/limit_validator_spec.rb
+++ b/spec/services/media_attachments/limit_validator_spec.rb
@@ -23,15 +23,15 @@ RSpec.describe MediaAttachments::LimitValidator do
       expect(described_class.new(user:, attachment:).valid?).to be false
     end
 
-    it 'allows a Pro user at exactly 60 seconds / 1080p' do
+    it 'allows a Pro user at exactly 180 seconds / 1080p' do
       make_pro(user)
-      attachment = build(:media_attachment, :video, duration_seconds: 60, height: 1080)
+      attachment = build(:media_attachment, :video, duration_seconds: 180, height: 1080)
       expect(described_class.new(user:, attachment:).valid?).to be true
     end
 
-    it 'rejects a Pro user at 61 seconds' do
+    it 'rejects a Pro user at 181 seconds' do
       make_pro(user)
-      attachment = build(:media_attachment, :video, duration_seconds: 61, height: 1080)
+      attachment = build(:media_attachment, :video, duration_seconds: 181, height: 1080)
       expect(described_class.new(user:, attachment:).valid?).to be false
     end
   end

--- a/spec/services/media_attachments/limit_validator_spec.rb
+++ b/spec/services/media_attachments/limit_validator_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe MediaAttachments::LimitValidator do
+  def make_pro(target)
+    target.subscription.update!(status: 'active', expires_at: 30.days.from_now)
+  end
+
+  let(:user) { create(:user) }
+
+  describe '#valid? for video' do
+    it 'allows a free user at exactly 30 seconds / 480p' do
+      attachment = build(:media_attachment, :video, duration_seconds: 30, height: 480)
+      expect(described_class.new(user:, attachment:).valid?).to be true
+    end
+
+    it 'rejects a free user at 31 seconds' do
+      attachment = build(:media_attachment, :video, duration_seconds: 31, height: 480)
+      expect(described_class.new(user:, attachment:).valid?).to be false
+    end
+
+    it 'rejects a free user at 481px height' do
+      attachment = build(:media_attachment, :video, duration_seconds: 30, height: 481)
+      expect(described_class.new(user:, attachment:).valid?).to be false
+    end
+
+    it 'allows a Pro user at exactly 60 seconds / 1080p' do
+      make_pro(user)
+      attachment = build(:media_attachment, :video, duration_seconds: 60, height: 1080)
+      expect(described_class.new(user:, attachment:).valid?).to be true
+    end
+
+    it 'rejects a Pro user at 61 seconds' do
+      make_pro(user)
+      attachment = build(:media_attachment, :video, duration_seconds: 61, height: 1080)
+      expect(described_class.new(user:, attachment:).valid?).to be false
+    end
+  end
+
+  describe '#valid? for image' do
+    it 'allows a free user at exactly 5MB' do
+      attachment = build(:media_attachment, file_size_bytes: 5.megabytes)
+      expect(described_class.new(user:, attachment:).valid?).to be true
+    end
+
+    it 'rejects a free user over 5MB' do
+      attachment = build(:media_attachment, file_size_bytes: 5.megabytes + 1)
+      expect(described_class.new(user:, attachment:).valid?).to be false
+    end
+
+    it 'allows a Pro user at exactly 10MB' do
+      make_pro(user)
+      attachment = build(:media_attachment, file_size_bytes: 10.megabytes)
+      expect(described_class.new(user:, attachment:).valid?).to be true
+    end
+
+    it 'rejects a Pro user over 10MB' do
+      make_pro(user)
+      attachment = build(:media_attachment, file_size_bytes: 10.megabytes + 1)
+      expect(described_class.new(user:, attachment:).valid?).to be false
+    end
+  end
+end

--- a/spec/support/r2_test_env.rb
+++ b/spec/support/r2_test_env.rb
@@ -1,0 +1,6 @@
+# 署名URL生成はネットワークアクセスを伴わないため、実際のR2認証情報がなくてもテストで実行できる。
+ENV['R2_ENDPOINT'] ||= 'https://test-account.r2.cloudflarestorage.com'
+ENV['R2_ACCESS_KEY_ID'] ||= 'test-access-key-id'
+ENV['R2_SECRET_ACCESS_KEY'] ||= 'test-secret-access-key'
+ENV['R2_BUCKET_NAME'] ||= 'buzzbase-test'
+ENV['R2_PUBLIC_BASE_URL'] ||= 'https://media.buzzbase.test'


### PR DESCRIPTION
## issue
close ippei-shimizu/buzzbase#325

## 実装概要
野球ノートへの画像・動画アップロード機能のback側実装。Cloudflare R2への署名URL方式でメディア添付を可能にする。あわせて、素振り記録のメニュー推移集計・練習メニュー自動統合の対応も含む。

## 背景
既存の野球ノート（baseball_notes）はテキスト・紐付けのみ対応済み（試合/練習への紐付けは実装済み）。フォームチェック動画やコーチの指摘記録など「定性的な気づき」を残す用途で、画像・動画添付を追加する。PRD: `docs/strategy/product/pro-plan-prd/09-pro-feature-baseball-note-ext.md`。

## やらなかったこと
- front（Web）対応（PRDで「アップロードはmobile優先、Web対応は将来」と明記）
- 自動削除ジョブ（保存期間は無料・Proとも永続のため不採用）
- Cloudflare R2バケットの実インフラ構築（コード外の準備作業として別途必要）

## 受入基準
- [x] `media_attachments`テーブルとモデルの追加
- [x] Cloudflare R2への署名URL発行（presign）・完了通知・削除のAPI実装
- [x] サーバー側での無料/Pro上限再検証（動画: 無料30秒/480p・Pro 180秒/1080p、画像: 無料5MB/Pro 10MB）
- [x] `plan_limits.rb`のダミー実装（月間アップロード数）を実カウントに差し替え
- [x] `media_long_term_storage` entitlementの削除（保存期間の無料/Pro差がないため。issue #440の指摘1・3を解消）
- [x] メディアごとに長文メモを書けるようにする（`media_attachments.memo`）
- [x] 素振り専用のメニュー推移API追加、素振りタイマーと同名メニューの単位一致時自動統合
- [x] file_size_bytesをR2の実サイズ（head_object）で再検証し、クライアント自己申告値の改ざんを防ぐ
- [x] media_typeとcontent_typeの組み合わせを検証し、動画を画像と偽って上限チェックを回避できないようにする
- [x] 完了しないまま放置されたpendingが月間上限を永続的に消費しないよう、一定時間経過分を除外する
- [x] rspec・rubocopが通ること

## 実装詳細
- `db/migrate/`: `media_attachments`テーブル新設、`baseball_notes.media_attachments_count`（counter_cache）追加、`media_attachments.memo`追加
- `app/models/media_attachment.rb`: バリデーション、`counter_cache`、destroy時にR2オブジェクト削除ジョブをenqueue
- `app/services/media_attachments/`: `PresignedUrlService`（署名URL発行）、`ObjectDeleter`（R2削除）、`PublicUrlBuilder`（公開URL組み立て）、`LimitValidator`（サーバー側上限再検証。Pro動画長さは60秒→180秒に変更）、`ObjectSizeFetcher`（R2実サイズ取得、file_size_bytes改ざん対策）
- `app/controllers/api/v2/media_attachments/presigns_controller.rb`: `POST /api/v2/media_attachments/presign`。media_type別にcontent_typeを検証
- `app/controllers/api/v2/media_attachments_controller.rb`: `PATCH`（完了通知・メモ更新の両方を`file_size_bytes`の有無で分岐。完了通知時はObjectSizeFetcherで実サイズに上書きしてから上限検証）/`DELETE`
- `app/serializers/v2/media_attachment_serializer.rb`、`baseball_note_serializer.rb`への追加
- `app/models/concerns/entitlement.rb`: `media_long_term_storage`削除
- `app/models/concerns/plan_limits.rb`: `media_attachments_count_this_month`を実カウントに差し替え。1時間超のpendingは除外
- `app/services/practices/shadow_swing_trend.rb`、`app/controllers/api/v2/shadow_swing_sessions_controller.rb`: 素振りログはpractice_menuに紐付かないため、メニュー推移と同形式で年別・月別・日別集計を返す専用エンドポイントを追加
- `app/models/shadow_swing_session.rb`: 「素振り」という名前で単位が「回数」の練習メニューが既にあれば紐付けて一本化、無ければ自動作成（単位が異なる既存メニューには紐付けない）

## スクリーンショット
なし（APIのみ）

## 確認手順
1. `docker compose exec back bundle exec rspec spec/requests/api/v2/media_attachments spec/requests/api/v2/media_attachments_spec.rb spec/models/media_attachment_spec.rb spec/services/media_attachments spec/models/concerns/entitlement_spec.rb spec/models/shadow_swing_session_spec.rb spec/requests/api/v2/shadow_swing_sessions_spec.rb` で新規・関連テストが通ることを確認
2. `docker compose exec back bundle exec rubocop` でlintが通ることを確認
3. R2バケット・環境変数（`R2_ENDPOINT`等）を用意した上で、presign→R2への実PUT→完了通知の一連の流れを手動確認（実インフラ整備後）

## 影響範囲
- `baseball_notes`関連のAPI（`includes`にmedia_attachments追加、既存のindex/showに影響）
- entitlement一覧（`media_long_term_storage`削除によりPaywall表示・mobile側の対応行も削除必要、mobile側PRで対応済み）
- 素振りログの積み上げ・推移が、同名「素振り」メニュー（単位:回数）と統合される既存ユーザーへの挙動変化
- `complete_upload`で毎回R2への`head_object`同期呼び出しが発生する（実サイズ検証のためのレイテンシ増、許容範囲と判断）

## コード上の懸念点
- R2バケットのpublic access + カスタムドメイン設定が前提の実装（`PublicUrlBuilder`）。private運用にする場合は読み出し時の署名GET URL発行に設計変更が必要
- HEIC画像の自動変換はクライアント側（mobile）に委ねている
- **動画のduration_seconds/heightは依然としてクライアント自己申告値のまま**。file_size_bytesはR2実測値で再検証するようにしたが、動画メタデータのサーバー側抽出（ffprobe等）は導入コストが高いため今回のスコープ外とし、対応漏れではなく意図的な据え置きとしてここに明記する。media_type/content_typeの整合性検証により「動画を画像と偽る」経路は塞いだが、「正しくvideoと申告した上でduration_seconds/heightを偽る」余地は技術的に残る
- `baseball_note.media_attachments_count`（counter_cache）はstatusに関わらず全レコードをカウントする。pending/failedが残っていると件数表示がズレうるが、シリアライザ・mobile側どちらにも未露出のため現状は実害なし

## その他
mobileの対応PR: https://github.com/ippei-shimizu/buzzbase_mobile/pull/160
