### PR TITLE
Add: パスワードリセット機能のホスト検証・アカウント列挙対策付きバックエンド実装

### DIFF
--- a/app/controllers/concerns/custom_confirmations_controller.rb
+++ b/app/controllers/concerns/custom_confirmations_controller.rb
@@ -1,4 +1,6 @@
 class CustomConfirmationsController < DeviseTokenAuth::ConfirmationsController
+  include RedirectUrlWhitelistable
+
   def show
     @resource = resource_class.confirm_by_token(params[:confirmation_token])
 
@@ -24,48 +26,5 @@ class CustomConfirmationsController < DeviseTokenAuth::ConfirmationsController
     redirect_url = params[:redirect_url] || default_redirect_url
 
     validate_redirect_url(redirect_url)
-  end
-
-  def default_redirect_url
-    ENV['CONFIRM_SUCCESS_URL'].presence || '/signin'
-  end
-
-  def validate_redirect_url(redirect_url)
-    return default_redirect_url if redirect_url.blank?
-
-    uri = URI.parse(redirect_url)
-
-    # モバイルアプリのカスタムスキームを許可
-    allowed_schemes = [ENV.fetch('MOBILE_APP_SCHEME', 'buzzbase')]
-    return redirect_url if allowed_schemes.include?(uri.scheme)
-
-    # ホワイトリスト: 環境変数で指定されたホストのみ許可
-    allowed_hosts = [
-      ENV.fetch('FRONTEND_URL', nil),
-      ENV.fetch('CONFIRM_SUCCESS_URL', nil)
-    ].compact.map { |url| URI.parse(url).host }
-
-    if allowed_hosts.include?(uri.host)
-      redirect_url
-    else
-      # 不正なリダイレクト先をブロック
-      Rails.logger.warn("Blocked redirect to unauthorized host: #{uri.host}. Allowed: #{allowed_hosts.inspect}")
-      default_redirect_url
-    end
-  rescue URI::InvalidURIError => e
-    Rails.logger.error("Invalid redirect URL: #{redirect_url} - #{e.message}")
-    default_redirect_url
-  end
-
-  def add_query_param(url, key, value)
-    return default_redirect_url if url.blank?
-
-    uri = URI.parse(url)
-    params = URI.decode_www_form(uri.query || '') << [key, value]
-    uri.query = URI.encode_www_form(params)
-    uri.to_s
-  rescue URI::InvalidURIError => e
-    Rails.logger.error("Invalid URL in add_query_param: #{url} - #{e.message}")
-    default_redirect_url
   end
 end

--- a/app/controllers/concerns/custom_passwords_controller.rb
+++ b/app/controllers/concerns/custom_passwords_controller.rb
@@ -1,0 +1,29 @@
+class CustomPasswordsController < DeviseTokenAuth::PasswordsController
+  include RedirectUrlWhitelistable
+
+  private
+
+  # 標準実装は redirect_url 欠落/不許可ホストをエラーで弾くが、フロント/モバイルは常に
+  # redirect_url を送る想定のため、ここではエラーにせずホワイトリスト検証済みの値へ
+  # 静かにフォールバックする（CustomConfirmationsController と同じ方針）。
+  def validate_redirect_url_param
+    @redirect_url = validate_redirect_url(params.fetch(:redirect_url, default_redirect_url))
+  end
+
+  # edit アクションはメールリンククリック時に redirect_url（front等の別ホスト）へ
+  # 遷移させるため、Rails 7 のクロスホストリダイレクト制限を明示的に許可する。
+  # validate_redirect_url_param でホワイトリスト検証済みのため安全。
+  def redirect_options
+    { allow_other_host: true }
+  end
+
+  # DeviseTokenAuth::Concerns::ResourceFinder#provider は 'email' 固定のため、
+  # Google/Apple アカウントのメールアドレスは元々 @resource が見つからず
+  # このメソッドに到達する（= render_not_found_error は「存在しないメール」と
+  # 「email/password 未使用のアカウント」を区別できない）。
+  # アカウント列挙・認証方式の推測を防ぐため、どちらの場合も送信成功と同じ
+  # レスポンスを返す。
+  def render_not_found_error
+    render_create_success
+  end
+end

--- a/app/controllers/concerns/redirect_url_whitelistable.rb
+++ b/app/controllers/concerns/redirect_url_whitelistable.rb
@@ -1,0 +1,49 @@
+# メール内リンクのリダイレクト先を検証する共通ロジック。CustomConfirmationsController /
+# CustomPasswordsController の双方から使われるオープンリダイレクト対策。
+module RedirectUrlWhitelistable
+  extend ActiveSupport::Concern
+
+  private
+
+  def default_redirect_url
+    ENV['CONFIRM_SUCCESS_URL'].presence || '/signin'
+  end
+
+  # モバイルのカスタムスキームと、FRONTEND_URL / CONFIRM_SUCCESS_URL のホストのみ許可する。
+  # 不正な値は例外を投げず default_redirect_url に静かにフォールバックする。
+  def validate_redirect_url(redirect_url)
+    return default_redirect_url if redirect_url.blank?
+
+    uri = URI.parse(redirect_url)
+
+    allowed_schemes = [ENV.fetch('MOBILE_APP_SCHEME', 'buzzbase')]
+    return redirect_url if allowed_schemes.include?(uri.scheme)
+
+    allowed_hosts = [
+      ENV.fetch('FRONTEND_URL', nil),
+      ENV.fetch('CONFIRM_SUCCESS_URL', nil)
+    ].compact.map { |url| URI.parse(url).host }
+
+    if allowed_hosts.include?(uri.host)
+      redirect_url
+    else
+      Rails.logger.warn("Blocked redirect to unauthorized host: #{uri.host}. Allowed: #{allowed_hosts.inspect}")
+      default_redirect_url
+    end
+  rescue URI::InvalidURIError => e
+    Rails.logger.error("Invalid redirect URL: #{redirect_url} - #{e.message}")
+    default_redirect_url
+  end
+
+  def add_query_param(url, key, value)
+    return default_redirect_url if url.blank?
+
+    uri = URI.parse(url)
+    params = URI.decode_www_form(uri.query || '') << [key, value]
+    uri.query = URI.encode_www_form(params)
+    uri.to_s
+  rescue URI::InvalidURIError => e
+    Rails.logger.error("Invalid URL in add_query_param: #{url} - #{e.message}")
+    default_redirect_url
+  end
+end

--- a/app/controllers/concerns/redirect_url_whitelistable.rb
+++ b/app/controllers/concerns/redirect_url_whitelistable.rb
@@ -39,8 +39,8 @@ module RedirectUrlWhitelistable
     return default_redirect_url if url.blank?
 
     uri = URI.parse(url)
-    params = URI.decode_www_form(uri.query || '') << [key, value]
-    uri.query = URI.encode_www_form(params)
+    query_params = URI.decode_www_form(uri.query || '') << [key, value]
+    uri.query = URI.encode_www_form(query_params)
     uri.to_s
   rescue URI::InvalidURIError => e
     Rails.logger.error("Invalid URL in add_query_param: #{url} - #{e.message}")

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,8 @@
-<p>Hello <%= @resource.email %>!</p>
+<p>登録メールアドレス : <%= @resource.email %></p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p><%= t('.instruction') %></p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to t('.action'), edit_password_url(@resource, {reset_password_token: @token, config: message['client-config'].to_s, redirect_url: message['redirect-url']}).html_safe %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p><%= t('.instruction_2') %></p>
+<p><%= t('.instruction_3') %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,8 @@ Rails.application.routes.draw do
     namespace :v1 do
       mount_devise_token_auth_for 'User', at: 'auth', controllers: {
         registrations: 'api/v1/auth/registrations',
-        confirmations: 'custom_confirmations'
+        confirmations: 'custom_confirmations',
+        passwords: 'custom_passwords'
       }
       namespace :admin do
         post 'sign_in', to: 'sessions#create'

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -13,5 +13,17 @@ FactoryBot.define do
       confirmation_token { Devise.friendly_token }
       confirmation_sent_at { Time.current }
     end
+
+    trait :google do
+      provider { 'google' }
+      password { nil }
+      password_confirmation { nil }
+    end
+
+    trait :apple do
+      provider { 'apple' }
+      password { nil }
+      password_confirmation { nil }
+    end
   end
 end

--- a/spec/requests/api/v1/auth/passwords_spec.rb
+++ b/spec/requests/api/v1/auth/passwords_spec.rb
@@ -138,12 +138,16 @@ RSpec.describe 'Api::V1::Auth::Passwords', type: :request do
 
     context 'with an invalid reset_password_token' do
       it 'does not redirect to an authenticated URL' do
+        # devise_token_auth標準のrender_edit_errorはActionController::RoutingErrorを
+        # raiseするだけで明示的にrescueしていないため500になる（gem標準の挙動）。
+        # ここでは「認証済みURLへリダイレクトされない」ことを実際のステータスコードで
+        # 固定し、将来意図せず200/redirectへ変化した場合に検知できるようにする。
         get '/api/v1/auth/password/edit', params: {
           reset_password_token: 'invalid-token',
           redirect_url: 'http://localhost:8100/reset-password'
         }
 
-        expect(response).not_to have_http_status(:redirect)
+        expect(response).to have_http_status(:internal_server_error)
       end
     end
   end

--- a/spec/requests/api/v1/auth/passwords_spec.rb
+++ b/spec/requests/api/v1/auth/passwords_spec.rb
@@ -31,23 +31,119 @@ RSpec.describe 'Api::V1::Auth::Passwords', type: :request do
       end
     end
 
+    # アカウント列挙・認証方式の推測を防ぐため、存在しないメール/Google・Appleアカウント/
+    # メール・パスワードアカウントのいずれも同じ成功レスポンスを返す（メール送信の有無のみ異なる）。
     context 'with non-existent email' do
-      it 'returns not found' do
-        post '/api/v1/auth/password', params: {
-          email: 'notfound@example.com',
-          redirect_url: 'http://localhost:8100/reset-password'
-        }
+      it 'returns success without sending an email' do
+        expect do
+          post '/api/v1/auth/password', params: {
+            email: 'notfound@example.com',
+            redirect_url: 'http://localhost:8100/reset-password'
+          }
+        end.not_to change(ActionMailer::Base.deliveries, :count)
 
-        expect(response).to have_http_status(:not_found)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'with a google account' do
+      let(:google_user) { create(:user, :google, email: 'google-user@example.com', uid: 'google-uid-123') }
+
+      it 'returns the same success response without sending an email' do
+        expect do
+          post '/api/v1/auth/password', params: {
+            email: google_user.email,
+            redirect_url: 'http://localhost:8100/reset-password'
+          }
+        end.not_to change(ActionMailer::Base.deliveries, :count)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'with an apple account' do
+      let(:apple_user) { create(:user, :apple, email: 'apple-user@example.com', uid: 'apple-uid-123') }
+
+      it 'returns the same success response without sending an email' do
+        expect do
+          post '/api/v1/auth/password', params: {
+            email: apple_user.email,
+            redirect_url: 'http://localhost:8100/reset-password'
+          }
+        end.not_to change(ActionMailer::Base.deliveries, :count)
+
+        expect(response).to have_http_status(:ok)
       end
     end
 
     context 'without redirect_url' do
-      it 'returns unauthorized' do
-        # devise_token_auth は redirect_url 欠落時に 401 を返す
+      it 'returns success by falling back to the default redirect URL instead of erroring' do
         post '/api/v1/auth/password', params: { email: user.email }
 
-        expect(response).to have_http_status(:unauthorized)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'with a disallowed redirect_url host' do
+      it 'returns success and sends the email with the link pointing to the default redirect URL' do
+        post '/api/v1/auth/password', params: {
+          email: user.email,
+          redirect_url: 'https://evil.example.com/steal-token'
+        }
+
+        expect(response).to have_http_status(:ok)
+        mail_body = ActionMailer::Base.deliveries.last.body.to_s
+        expect(mail_body).not_to include('evil.example.com')
+      end
+    end
+  end
+
+  describe 'GET /api/v1/auth/password/edit' do
+    let(:user) do
+      create(:user, email: 'edit-reset@example.com', uid: 'edit-reset@example.com')
+    end
+
+    context 'with valid reset_password_token and web redirect_url' do
+      it 'redirects to the front URL with auth token params' do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with('FRONTEND_URL', nil).and_return('http://localhost:8100')
+        allow(ENV).to receive(:fetch).with('CONFIRM_SUCCESS_URL', nil).and_return('http://localhost:8100')
+
+        raw_token = user.send_reset_password_instructions
+
+        get '/api/v1/auth/password/edit', params: {
+          reset_password_token: raw_token,
+          redirect_url: 'http://localhost:8100/reset-password'
+        }
+
+        expect(response).to have_http_status(:redirect)
+        expect(response.location).to start_with('http://localhost:8100/reset-password')
+        expect(response.location).to include('reset_password=true')
+      end
+    end
+
+    context 'with unauthorized redirect_url host' do
+      it 'falls back to the default redirect URL instead of the untrusted host' do
+        raw_token = user.send_reset_password_instructions
+
+        get '/api/v1/auth/password/edit', params: {
+          reset_password_token: raw_token,
+          redirect_url: 'https://evil.example.com/steal-token'
+        }
+
+        expect(response).to have_http_status(:redirect)
+        expect(response.location).not_to include('evil.example.com')
+      end
+    end
+
+    context 'with an invalid reset_password_token' do
+      it 'does not redirect to an authenticated URL' do
+        get '/api/v1/auth/password/edit', params: {
+          reset_password_token: 'invalid-token',
+          redirect_url: 'http://localhost:8100/reset-password'
+        }
+
+        expect(response).not_to have_http_status(:redirect)
       end
     end
   end


### PR DESCRIPTION
## Summary

- devise_token_auth標準のPasswordsControllerをホスト検証・アカウント列挙対策付きのCustomPasswordsControllerに差し替え
- パスワードリセットメールを日本語化し、redirect_urlを引き回すよう修正
- CustomConfirmationsControllerと共通のリダイレクトURL検証ロジックをconcernに抽出

## 背景

ippei-shimizu/buzzbase#441 参照。

- 標準PasswordsControllerにはredirect_urlのホスト検証が無くオープンリダイレクトが可能だった
- Rails 7のクロスホストリダイレクト制限でfrontへのリダイレクトが失敗しうる状態だった
- devise_token_authのResourceFinder#providerが'email'固定のため、Google/Appleアカウントの
  メールアドレスへのリセット要求が「存在しないメール」と同じ404になり、メール/パスワード
  アカウントとの応答差からアカウントの存在・認証方式が外部から推測できた
- reset_password_instructions.html.erbがgemデフォルトの英語テンプレートのままで、
  confirmation_instructions.html.erbと異なりredirect_urlをリンクに引き回していなかった

## 変更内容

- `app/controllers/concerns/redirect_url_whitelistable.rb`（新規）: ホスト検証ロジックを
  CustomConfirmationsControllerから抽出した共通concern
- `app/controllers/concerns/custom_passwords_controller.rb`（新規）: redirect_urlの
  ホワイトリスト検証・allow_other_host許可・404を握りつぶし一律成功レスポンスを返す対応
- `config/routes.rb`: passwordsコントローラーをcustom_passwordsに差し替え
- `app/views/devise/mailer/reset_password_instructions.html.erb`: 日本語化・redirect_url対応
- `spec/factories/users.rb`, `spec/requests/api/v1/auth/passwords_spec.rb`: テスト追加・更新

## Test plan

- [x] `bundle exec rubocop` 通過
- [x] `bundle exec rspec` 全971例成功（既存含め回帰なし）
- [x] ローカル環境でパスワードリセットの全フロー（申請メール送信→letter_openerで
      日本語メール確認→リンククリック→front /reset-password への正しいリダイレクト
      →新パスワード設定→新パスワードでログイン成功）を実機検証済み
