### PR TITLE
Add: 成績内訳4項目のPro権限ゲーティングを実装

### DIFF
--- a/app/controllers/api/v2/stats_controller.rb
+++ b/app/controllers/api/v2/stats_controller.rb
@@ -4,6 +4,16 @@ module Api
       include MatchTypeConvertible
       before_action :authenticate_api_v1_user!
       before_action :authorize_target_user!
+      before_action :require_entitlement!, only: %i[count_situations pitch_types pitcher_faceoffs]
+
+      # 成績内訳の詳細のうちPro限定の3項目（カウント別・球種別・対戦投手別）に必要なentitlement。
+      # hit_directions は無料機能のSprayChart（打球方向散布図）も同じレスポンスを使うため
+      # エンドポイント自体は無料開放のままにし、詳細テーブル表示のみmobile側でPro判定する。
+      ENTITLEMENT_BY_ACTION = {
+        count_situations: 'count_situation_average',
+        pitch_types: 'pitch_type_average',
+        pitcher_faceoffs: 'pitcher_faceoff_average'
+      }.freeze
 
       def hit_directions
         render json: Stats::HitDirectionAggregator.new(**aggregator_params).call
@@ -120,6 +130,15 @@ module Api
       # render 後に Rails が後続 action を自動で止めるため、明示 return は不要。
       def authorize_target_user!
         render_forbidden_if_private!(target_user)
+      end
+
+      # entitlementは閲覧者（current_api_v1_user）のPro加入状況で判定する
+      # （他ユーザーの成績を見る場合も、詳細内訳を見られるかは自分のプラン次第）。
+      def require_entitlement!
+        feature = ENTITLEMENT_BY_ACTION[action_name.to_sym]
+        return if current_api_v1_user.has_entitlement?(feature)
+
+        render json: { error: 'この機能は Pro プラン限定です' }, status: :forbidden
       end
     end
   end

--- a/app/controllers/api/v2/stats_controller.rb
+++ b/app/controllers/api/v2/stats_controller.rb
@@ -4,8 +4,6 @@ module Api
       include MatchTypeConvertible
       before_action :authenticate_api_v1_user!
       before_action :authorize_target_user!
-      before_action :require_entitlement!, only: %i[count_situations pitch_types pitcher_faceoffs]
-
       # 成績内訳の詳細のうちPro限定の3項目（カウント別・球種別・対戦投手別）に必要なentitlement。
       # hit_directions は無料機能のSprayChart（打球方向散布図）も同じレスポンスを使うため
       # エンドポイント自体は無料開放のままにし、詳細テーブル表示のみmobile側でPro判定する。
@@ -14,6 +12,7 @@ module Api
         pitch_types: 'pitch_type_average',
         pitcher_faceoffs: 'pitcher_faceoff_average'
       }.freeze
+      before_action :require_entitlement!, only: ENTITLEMENT_BY_ACTION.keys
 
       def hit_directions
         render json: Stats::HitDirectionAggregator.new(**aggregator_params).call

--- a/app/models/concerns/entitlement.rb
+++ b/app/models/concerns/entitlement.rb
@@ -44,7 +44,11 @@ module Entitlement
     'manual_metric_goals', # 自由指標(手動更新)の目標設定(無料は利用不可)
     'shadow_swing_custom_interval', # 素振りカウンターのインターバル自由設定(無料は5〜10秒のみ)
     'shadow_swing_vibration', # 素振りカウンターのバイブレーション設定(無料は利用不可)
-    'unlimited_groups' # グループ作成・参加を無制限に(無料は所属1件まで)
+    'unlimited_groups', # グループ作成・参加を無制限に(無料は所属1件まで)
+    'hit_direction_average', # 方向別の打率(打球方向ごとのヒートマップ)
+    'count_situation_average', # カウント別の打率(初球・有利・追い込み等)
+    'pitch_type_average', # 球種別の打率(ストレート・変化球等)
+    'pitcher_faceoff_average' # 対戦投手別の打撃成績
   ].freeze
 
   ALL_FEATURES = (FREE_FEATURES + PRO_FEATURES).freeze

--- a/app/models/concerns/entitlement.rb
+++ b/app/models/concerns/entitlement.rb
@@ -30,7 +30,6 @@ module Entitlement
     'season_goals',                 # シーズン目標(無料は利用不可)
     'tournament_goals',             # 大会目標(無料は利用不可)
     'custom_notification_messages', # カスタム通知メッセージの設定
-    'advanced_goal_tracking',       # 高度な目標トラッキング(達成率の詳細推移)
     'detailed_condition_log',       # 詳細コンディションログ(体調・気分の詳細記録)
     'unlimited_improvement_themes', # 課題テーマ無制限(無料は取組中2つまで)
     'correlation_insights',         # 相関インサイト(練習量・コンディション×成績の傾向)

--- a/spec/models/concerns/entitlement_spec.rb
+++ b/spec/models/concerns/entitlement_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe Entitlement, type: :model do
   let(:user) { create(:user) }
 
   describe 'feature key constants' do
-    it 'defines exactly 10 free features and 26 pro features' do
+    it 'defines exactly 10 free features and 30 pro features' do
       # %w[] とインラインコメントの混在で feature key が壊れる回帰を防ぐ
       expect(described_class::FREE_FEATURES.size).to eq 10
-      expect(described_class::PRO_FEATURES.size).to eq 26
-      expect(described_class::ALL_FEATURES.size).to eq 36
+      expect(described_class::PRO_FEATURES.size).to eq 30
+      expect(described_class::ALL_FEATURES.size).to eq 40
     end
 
     it 'contains only valid feature key strings (no stray symbols)' do

--- a/spec/models/concerns/entitlement_spec.rb
+++ b/spec/models/concerns/entitlement_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe Entitlement, type: :model do
   let(:user) { create(:user) }
 
   describe 'feature key constants' do
-    it 'defines exactly 10 free features and 30 pro features' do
+    it 'defines exactly 10 free features and 29 pro features' do
       # %w[] とインラインコメントの混在で feature key が壊れる回帰を防ぐ
       expect(described_class::FREE_FEATURES.size).to eq 10
-      expect(described_class::PRO_FEATURES.size).to eq 30
-      expect(described_class::ALL_FEATURES.size).to eq 40
+      expect(described_class::PRO_FEATURES.size).to eq 29
+      expect(described_class::ALL_FEATURES.size).to eq 39
     end
 
     it 'contains only valid feature key strings (no stray symbols)' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,6 +27,7 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
   config.include AuthHelpers, type: :request
+  config.include SubscriptionHelpers, type: :request
   config.include ActiveJob::TestHelper, type: :job
   config.include ActiveJob::TestHelper, type: :model
   config.include ActiveJob::TestHelper, type: :request

--- a/spec/requests/api/v2/stats_spec.rb
+++ b/spec/requests/api/v2/stats_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe 'Api::V2::Stats', type: :request do
   let(:user) { create(:user) }
   let(:headers) { auth_headers_for(user) }
 
+  def make_pro(target)
+    target.subscription.update!(status: 'active', expires_at: 30.days.from_now)
+  end
+
   before do
     gr = create(:game_result, user:)
     gr.match_result.update!(
@@ -221,7 +225,13 @@ RSpec.describe 'Api::V2::Stats', type: :request do
       expect(response).to have_http_status(:unauthorized)
     end
 
-    it 'returns 200 with first_pitch / favorable_count / pinch_count + total_target_pa' do
+    it 'returns 403 for a free user' do
+      get('/api/v2/stats/count_situations', headers:)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'returns 200 with first_pitch / favorable_count / pinch_count + total_target_pa for a Pro user' do
+      make_pro(user)
       get('/api/v2/stats/count_situations', headers:)
 
       expect(response).to have_http_status(:ok)
@@ -256,7 +266,13 @@ RSpec.describe 'Api::V2::Stats', type: :request do
       expect(response).to have_http_status(:unauthorized)
     end
 
-    it 'returns 200 with rows for all 10 master pitch types + total_target_pa' do
+    it 'returns 403 for a free user' do
+      get('/api/v2/stats/pitch_types', headers:)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'returns 200 with rows for all 10 master pitch types + total_target_pa for a Pro user' do
+      make_pro(user)
       get('/api/v2/stats/pitch_types', headers:)
 
       expect(response).to have_http_status(:ok)
@@ -276,7 +292,13 @@ RSpec.describe 'Api::V2::Stats', type: :request do
       expect(response).to have_http_status(:unauthorized)
     end
 
-    it 'returns 200 with rows + total_target_pa + min_plate_appearances' do
+    it 'returns 403 for a free user' do
+      get('/api/v2/stats/pitcher_faceoffs', headers:)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'returns 200 with rows + total_target_pa + min_plate_appearances for a Pro user' do
+      make_pro(user)
       get('/api/v2/stats/pitcher_faceoffs', headers:)
 
       expect(response).to have_http_status(:ok)

--- a/spec/requests/api/v2/stats_spec.rb
+++ b/spec/requests/api/v2/stats_spec.rb
@@ -434,4 +434,20 @@ RSpec.describe 'Api::V2::Stats', type: :request do
       end
     end
   end
+
+  describe 'entitlementは閲覧者(current_api_v1_user)基準で判定される' do
+    let(:target_user) { create(:user) }
+
+    it 'returns 403 when a free viewer requests a Pro target user stats' do
+      make_pro(target_user)
+      get('/api/v2/stats/count_situations', params: { user_id: target_user.id }, headers:)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'returns 200 when a Pro viewer requests a free target user stats' do
+      make_pro(user)
+      get('/api/v2/stats/count_situations', params: { user_id: target_user.id }, headers:)
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end

--- a/spec/requests/api/v2/stats_spec.rb
+++ b/spec/requests/api/v2/stats_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe 'Api::V2::Stats', type: :request do
   let(:user) { create(:user) }
   let(:headers) { auth_headers_for(user) }
 
-  def make_pro(target)
-    target.subscription.update!(status: 'active', expires_at: 30.days.from_now)
-  end
-
   before do
     gr = create(:game_result, user:)
     gr.match_result.update!(

--- a/spec/support/subscription_helpers.rb
+++ b/spec/support/subscription_helpers.rb
@@ -1,0 +1,5 @@
+module SubscriptionHelpers
+  def make_pro(target)
+    target.subscription.update!(status: 'active', expires_at: 30.days.from_now)
+  end
+end


### PR DESCRIPTION
## issue
close ippei-shimizu/buzzbase#443

## 実装概要
Paywallの比較表に「方向別の打率」「カウント別の打率」「球種別の打率」「対戦投手別の打撃成績」の4項目がPro限定機能として表示されているが、Pro権限チェックが一切なく認証済みユーザーなら誰でも呼べる状態だった。この4項目にentitlementゲーティングを実装する。

## 背景
issue #440（Paywall未実装機能の解消）の積み残し調査の結果、この4項目はデータモデル・集計サービス（`app/services/stats/*_aggregator.rb`）・APIエンドポイント（`Api::V2::StatsController`）まで実装は既に完了していることが判明した。欠けていたのはPro権限チェックのみ。issue #443として再整理し対応する。

## やらなかったこと
- `hit_directions`エンドポイント自体のPro制限（下記「コード上の懸念点」参照）
- 動画・画像アップロード関連の対応（別issue・別PRで対応済み）

## 受入基準
- [x] `Entitlement::PRO_FEATURES`に`hit_direction_average`/`count_situation_average`/`pitch_type_average`/`pitcher_faceoff_average`の4キーを追加
- [x] `count_situations`/`pitch_types`/`pitcher_faceoffs`の3アクションに`has_entitlement?`ガードを追加し、無料ユーザーには403を返す
- [x] entitlementは閲覧者（`current_api_v1_user`）の加入状況で判定（他ユーザーの成績を見る場合も自分のプラン次第）
- [x] 各アクションの既存rspecを、無料ユーザー403・Proユーザー200の2パターンに更新
- [x] `advanced_goal_tracking`entitlementをPaywallから削除（達成率の推移グラフ等、実装の裏付けが一切ない状態でPro訴求に掲載され続けていたため。設計が固まるまで一旦外す）
- [x] rspec・rubocopが通ること

## 実装詳細
- `app/controllers/api/v2/stats_controller.rb`: `require_entitlement!`という`before_action`を追加し、アクション名→entitlementキーのマッピング（`ENTITLEMENT_BY_ACTION`）で3アクションを判定。`only:`は`ENTITLEMENT_BY_ACTION.keys`から導出し、対象アクションの二重管理を避ける
- `app/models/concerns/entitlement.rb`: `PRO_FEATURES`に4キー追加、`advanced_goal_tracking`を削除（差し引き無料10・Pro29・計39）
- `spec/models/concerns/entitlement_spec.rb`: feature数のアサーションを更新
- `spec/requests/api/v2/stats_spec.rb`: `make_pro`ヘルパーを追加し、3エンドポイントに「無料ユーザーは403」「Proユーザーは200」のテストを追加

## スクリーンショット
なし（APIのみ）

## 確認手順
1. `docker compose exec back bundle exec rspec spec/requests/api/v2/stats_spec.rb spec/models/concerns/entitlement_spec.rb` で新規・関連テストが通ることを確認
2. `docker compose exec back bundle exec rspec` で全体テストに回帰がないことを確認（1587例、全通過済み）
3. `docker compose exec back bundle exec rubocop` でlintが通ることを確認（582ファイル、全通過済み）

## 影響範囲
- `GET /api/v2/stats/count_situations` / `/pitch_types` / `/pitcher_faceoffs`: 無料ユーザーは403 Forbiddenに変わる（従来は認証済みなら誰でも200を取得できていた）
- `Entitlement::PRO_FEATURES`のサイズ変更に伴い、この定数のサイズを直接アサートする既存テストを更新済み
- `advanced_goal_tracking`削除に伴い、mobile側のPaywall比較表・目標管理グループから該当行が消える（mobile側PRで対応済み）

## コード上の懸念点
- `hit_directions`エンドポイントは今回あえてPro制限を追加していない。無料機能のSprayChart（打球方向散布図、`mobile`側）が同じレスポンス（`directions`/`home_runs`）を参照しているため、エンドポイント自体を403にすると無料ユーザーの既存機能を壊してしまう。詳細内訳テーブル（`HitDirectionTable`）の表示のみをmobile側で`hasEntitlement("hit_direction_average")`により制御している（対応PR: mobile側参照）。バックエンドで完全に防御したい場合、レスポンスの一部フィールドのみをentitlementで出し分けるような設計変更が別途必要
- 上記の理由により、`hit_directions`は技術的には無料ユーザーもAPI経由で「詳細」相当のデータを取得できる状態が残る（mobileアプリを介さない直接APIコールの場合）。影響は限定的と判断し今回はスコープ外とした

## その他
mobileの対応PR: ippei-shimizu/buzzbase_mobile#164


