### PR TITLE
Fix: 新規登録ユーザーに登録前のお知らせが未読表示される不具合を修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,6 +70,8 @@ class User < ActiveRecord::Base
   end
 
   before_validation :normalize_user_id
+  # 登録前に公開済みの運営からのお知らせを未読扱いにしないよう、登録時点を既読基準にする。
+  before_create :initialize_last_management_notice_read_at
   after_commit :notify_slack_new_user, on: :create
 
   validates :password, custom_password: true, on: :create, unless: -> { provider.in?(%w[google apple]) }
@@ -171,6 +173,10 @@ class User < ActiveRecord::Base
 
   def normalize_user_id
     self.user_id = nil if user_id.blank?
+  end
+
+  def initialize_last_management_notice_read_at
+    self.last_management_notice_read_at ||= Time.current
   end
 
   def notify_slack_new_user

--- a/spec/golden_v1/users_show.json
+++ b/spec/golden_v1/users_show.json
@@ -10,7 +10,7 @@
   "introduction": "null",
   "is_private": "Boolean",
   "last_login_at": "null",
-  "last_management_notice_read_at": "null",
+  "last_management_notice_read_at": "String",
   "name": "String",
   "positions": [
     {

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -424,4 +424,18 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe '#last_management_notice_read_at initialization' do
+    it 'sets it to the registration time on create so pre-existing notices are not treated as unread' do
+      user = create(:user)
+      expect(user.last_management_notice_read_at).to be_present
+      expect(user.last_management_notice_read_at).to be_within(5.seconds).of(user.created_at)
+    end
+
+    it 'does not overwrite an explicitly given value' do
+      given_time = 3.days.ago
+      user = create(:user, last_management_notice_read_at: given_time)
+      expect(user.last_management_notice_read_at).to be_within(1.second).of(given_time)
+    end
+  end
 end

--- a/spec/requests/api/v1/notifications_management_notice_spec.rb
+++ b/spec/requests/api/v1/notifications_management_notice_spec.rb
@@ -1,9 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe 'Api::V1::Notifications - ManagementNotice', type: :request do
+  # ManagementNotice#set_published_at が新規作成時に published_at を Time.current で
+  # 上書きするため、任意の published_at を検証したい場合は保存後に update_column で
+  # コールバックを回避して固定する。
+  def published_notice(published_at:)
+    notice = create(:management_notice, :published)
+    notice.update_column(:published_at, published_at) # rubocop:disable Rails/SkipsModelValidations
+    notice
+  end
+
   describe 'GET /api/v1/notifications' do
     it 'marks a notice published before signup as already read for a newly registered user' do
-      old_notice = create(:management_notice, :published, published_at: 3.days.ago)
+      old_notice = published_notice(published_at: 3.days.ago)
       new_user = create(:user, user_id: 'newcomer')
 
       get '/api/v1/notifications',
@@ -18,7 +27,7 @@ RSpec.describe 'Api::V1::Notifications - ManagementNotice', type: :request do
 
     it 'still shows an unread notice published after signup' do
       new_user = create(:user, user_id: 'newcomer2')
-      new_notice = create(:management_notice, :published, published_at: 1.minute.from_now)
+      new_notice = published_notice(published_at: 1.minute.from_now)
 
       get '/api/v1/notifications',
           params: { user_id: new_user.user_id },
@@ -33,7 +42,7 @@ RSpec.describe 'Api::V1::Notifications - ManagementNotice', type: :request do
 
   describe 'GET /api/v1/notifications/count' do
     it 'does not count a notice published before signup for a newly registered user' do
-      create(:management_notice, :published, published_at: 3.days.ago)
+      published_notice(published_at: 3.days.ago)
       new_user = create(:user, user_id: 'newcomer3')
 
       get '/api/v1/notifications/count', headers: auth_headers_for(new_user)
@@ -44,7 +53,7 @@ RSpec.describe 'Api::V1::Notifications - ManagementNotice', type: :request do
 
     it 'counts a notice published after signup' do
       new_user = create(:user, user_id: 'newcomer4')
-      create(:management_notice, :published, published_at: 1.minute.from_now)
+      published_notice(published_at: 1.minute.from_now)
 
       get '/api/v1/notifications/count', headers: auth_headers_for(new_user)
 

--- a/spec/requests/api/v1/notifications_management_notice_spec.rb
+++ b/spec/requests/api/v1/notifications_management_notice_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Notifications - ManagementNotice', type: :request do
+  describe 'GET /api/v1/notifications' do
+    it 'marks a notice published before signup as already read for a newly registered user' do
+      old_notice = create(:management_notice, :published, published_at: 3.days.ago)
+      new_user = create(:user, user_id: 'newcomer')
+
+      get '/api/v1/notifications',
+          params: { user_id: new_user.user_id },
+          headers: auth_headers_for(new_user)
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      entry = json.find { |n| n['management_notice_id'] == old_notice.id }
+      expect(entry['read_at']).to be_present
+    end
+
+    it 'still shows an unread notice published after signup' do
+      new_user = create(:user, user_id: 'newcomer2')
+      new_notice = create(:management_notice, :published, published_at: 1.minute.from_now)
+
+      get '/api/v1/notifications',
+          params: { user_id: new_user.user_id },
+          headers: auth_headers_for(new_user)
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      entry = json.find { |n| n['management_notice_id'] == new_notice.id }
+      expect(entry['read_at']).to be_nil
+    end
+  end
+
+  describe 'GET /api/v1/notifications/count' do
+    it 'does not count a notice published before signup for a newly registered user' do
+      create(:management_notice, :published, published_at: 3.days.ago)
+      new_user = create(:user, user_id: 'newcomer3')
+
+      get '/api/v1/notifications/count', headers: auth_headers_for(new_user)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['count']).to eq(0)
+    end
+
+    it 'counts a notice published after signup' do
+      new_user = create(:user, user_id: 'newcomer4')
+      create(:management_notice, :published, published_at: 1.minute.from_now)
+
+      get '/api/v1/notifications/count', headers: auth_headers_for(new_user)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['count']).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- 新規登録ユーザーが、登録前(過去)に公開済みの運営からのお知らせ(`ManagementNotice`)を全て未読として表示・カウントしてしまう不具合を修正
- `User` に `before_create` フックを追加し、`last_management_notice_read_at` をユーザー登録時刻で初期化する。これにより登録前のお知らせは既読扱いになり、登録後に公開されたお知らせのみ未読として扱われる
- 既存ユーザーには影響しない(`before_create` のため新規作成時のみ発火)
- v1スキーマスナップショット(`spec/golden_v1/users_show.json`)の `last_management_notice_read_at` が `null` 固定ではなくなったため更新

## Fixes
Fixes ippei-shimizu/buzzbase#448

## Test plan
- [x] `spec/models/user_spec.rb` に `last_management_notice_read_at` 初期化のモデルスペックを追加
- [x] `spec/requests/api/v1/notifications_management_notice_spec.rb` を新規作成し、登録前/登録後のお知らせで index・count の挙動を確認
- [x] `bundle exec rspec` （関連spec一式）全て成功
- [x] `bundle exec rubocop` 変更ファイルすべて指摘なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
