### PR TITLE
Remove: 早期特典期間の30日間トライアル特例ロジックを削除

### DIFF
--- a/app/services/revenue_cat/handlers/initial_purchase_handler.rb
+++ b/app/services/revenue_cat/handlers/initial_purchase_handler.rb
@@ -1,7 +1,7 @@
 module RevenueCat
   module Handlers
     # INITIAL_PURCHASE / TRIAL_STARTED 兼用。period_type で trial / active を出し分け、
-    # 早期特典期間内のタイムスタンプなら is_early_subscriber を立てる。
+    # 早期加入者期間内のタイムスタンプなら is_early_subscriber を立てる。
     class InitialPurchaseHandler < BaseHandler
       def call
         with_resolved_subscription(require_persisted: false, require_known_product: true) do |user, subscription|

--- a/app/services/trial_days_calculator.rb
+++ b/app/services/trial_days_calculator.rb
@@ -1,25 +1,25 @@
-# 早期特典期間を含むトライアル日数判定の単一ソース。
+# トライアル日数判定と、早期加入者判定（is_early_subscriber）の単一ソース。
 # Webhook handler / Stripe Checkout の双方から参照されるため、副作用のないクラスメソッドのみ提供する。
 class TrialDaysCalculator
-  # Pro リリース日（2026-05-31）から 7 日間の早期特典期間。
+  # Pro リリース日（2026-05-31）から 7 日間の早期加入者期間。
   # リリース日が後ろ倒しになる可能性があるため、確定までは ENV
   # (EARLY_SUBSCRIBER_WINDOW_START / END) で実環境ごとに override する運用とし、
   # 最終リリース日が決まった段階で本定数を更新する。
   DEFAULT_WINDOW_START = '2026-05-31 00:00:00 +0900'.freeze
   DEFAULT_WINDOW_END   = '2026-06-06 23:59:59 +0900'.freeze
   NORMAL_TRIAL_DAYS = 7
-  EARLY_TRIAL_DAYS  = 30
 
   # 与えられたユーザーの「今回適用すべきトライアル日数」を返す。
   # 再加入（has_used_trial=true）は仕様で 0 固定とする。
-  # @return [Integer] 0 / 7 / 30
-  def self.for(user, at: Time.current)
+  # @return [Integer] 0 / 7
+  def self.for(user)
     return 0 if user.subscription&.has_used_trial?
 
-    in_early_window?(at) ? EARLY_TRIAL_DAYS : NORMAL_TRIAL_DAYS
+    NORMAL_TRIAL_DAYS
   end
 
-  # 与えられた時刻が早期特典期間内かを判定する。期間は ENV で override 可能（緊急時に運営が前後に伸ばすため）。
+  # 与えられた時刻が早期加入者期間内かを判定する（is_early_subscriber 用）。
+  # 期間は ENV で override 可能（緊急時に運営が前後に伸ばすため）。
   # @param at [Time] 判定対象の時刻
   # @return [Boolean]
   def self.in_early_window?(at = Time.current)

--- a/spec/services/app/stripe/checkout_session_builder_spec.rb
+++ b/spec/services/app/stripe/checkout_session_builder_spec.rb
@@ -12,15 +12,11 @@ RSpec.describe App::Stripe::CheckoutSessionBuilder do
     allow(ENV).to receive(:fetch).and_call_original
     allow(ENV).to receive(:fetch).with('STRIPE_PRICE_ID_MONTHLY').and_return('price_monthly_test_123')
     allow(ENV).to receive(:fetch).with('STRIPE_PRICE_ID_YEARLY').and_return('price_yearly_test_456')
-    allow(ENV).to receive(:fetch).with('EARLY_SUBSCRIBER_WINDOW_START', any_args).and_call_original
-    allow(ENV).to receive(:fetch).with('EARLY_SUBSCRIBER_WINDOW_END', any_args).and_call_original
     allow(Stripe::Checkout::Session).to receive(:create).and_return(stripe_session)
   end
 
   describe '#call' do
-    context '通常ケース（has_used_trial=false、早期特典期間外）' do
-      before { travel_to_outside_early_window }
-
+    context '通常ケース（has_used_trial=false）' do
       it 'Stripe::Checkout::Session.create を期待値で呼び出す' do
         builder.call
         expect(Stripe::Checkout::Session).to have_received(:create) do |args|
@@ -39,13 +35,13 @@ RSpec.describe App::Stripe::CheckoutSessionBuilder do
       end
     end
 
-    context '早期特典期間内' do
-      before { travel_to_inside_early_window }
+    context '早期加入者期間内でも trial_period_days は 7 のまま（早期特典による延長は廃止）' do
+      before { travel_to Time.zone.parse('2026-06-01 12:00 JST') }
 
-      it 'trial_period_days: 30 で呼び出す' do
+      it 'trial_period_days: 7 で呼び出す' do
         builder.call
         expect(Stripe::Checkout::Session).to have_received(:create) do |args|
-          expect(args[:subscription_data][:trial_period_days]).to eq(30)
+          expect(args[:subscription_data][:trial_period_days]).to eq(7)
         end
       end
     end
@@ -53,7 +49,6 @@ RSpec.describe App::Stripe::CheckoutSessionBuilder do
     context '再加入（has_used_trial=true）' do
       before do
         user.subscription.update!(has_used_trial: true)
-        travel_to_inside_early_window
       end
 
       it 'trial_period_days を渡さない（即時課金）' do
@@ -103,13 +98,5 @@ RSpec.describe App::Stripe::CheckoutSessionBuilder do
         expect { builder.call }.to raise_error(described_class::InvalidPlanError)
       end
     end
-  end
-
-  def travel_to_inside_early_window
-    travel_to Time.zone.parse('2026-06-01 12:00 JST')
-  end
-
-  def travel_to_outside_early_window
-    travel_to Time.zone.parse('2026-08-01 12:00 JST')
   end
 end

--- a/spec/services/revenue_cat/webhook_processor_spec.rb
+++ b/spec/services/revenue_cat/webhook_processor_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe RevenueCat::WebhookProcessor do
         end
       end
 
-      context 'event_timestamp_ms が早期特典期間内のとき' do
+      context 'event_timestamp_ms が早期加入者期間内のとき' do
         let(:overrides) do
           # 2026-06-01 12:00 JST → epoch ms
           { event_timestamp_ms: Time.zone.parse('2026-06-01 12:00 JST').to_i * 1000 }
@@ -133,7 +133,7 @@ RSpec.describe RevenueCat::WebhookProcessor do
         end
       end
 
-      context 'event_timestamp_ms が早期特典期間外のとき' do
+      context 'event_timestamp_ms が早期加入者期間外のとき' do
         let(:overrides) do
           { event_timestamp_ms: Time.zone.parse('2026-08-01 12:00 JST').to_i * 1000 }
         end

--- a/spec/services/trial_days_calculator_spec.rb
+++ b/spec/services/trial_days_calculator_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe TrialDaysCalculator do
   end
 
   describe '.in_early_window?' do
-    context 'ENV で早期特典期間を override したとき' do
+    context 'ENV で早期加入者期間を override したとき' do
       before do
         allow(ENV).to receive(:fetch).with('EARLY_SUBSCRIBER_WINDOW_START', any_args).and_return('2027-01-01 00:00')
         allow(ENV).to receive(:fetch).with('EARLY_SUBSCRIBER_WINDOW_END', any_args).and_return('2027-01-07 23:59')
@@ -35,7 +35,7 @@ RSpec.describe TrialDaysCalculator do
         expect(described_class.in_early_window?(Time.zone.parse('2027-01-03 12:00 JST'))).to be(true)
       end
 
-      it 'override 後の期間外なら false（デフォルトの早期特典期間が無視される）' do
+      it 'override 後の期間外なら false（デフォルトの早期加入者期間が無視される）' do
         expect(described_class.in_early_window?(Time.zone.parse('2026-06-01 12:00 JST'))).to be(false)
       end
     end

--- a/spec/services/trial_days_calculator_spec.rb
+++ b/spec/services/trial_days_calculator_spec.rb
@@ -8,40 +8,18 @@ RSpec.describe TrialDaysCalculator do
     allow(ENV).to receive(:fetch).and_call_original
   end
 
-  describe '.for(user, at:)' do
+  describe '.for(user)' do
     context 'has_used_trial が true のとき' do
       before { user.subscription.update!(has_used_trial: true) }
 
-      it '早期特典期間内でも 0 を返す（再加入はトライアル無し）' do
-        days = described_class.for(user, at: Time.zone.parse('2026-06-01 12:00 JST'))
-        expect(days).to eq(0)
-      end
-
-      it '早期特典期間外でも 0 を返す' do
-        days = described_class.for(user, at: Time.zone.parse('2026-08-01 12:00 JST'))
-        expect(days).to eq(0)
+      it '0 を返す（再加入はトライアル無し）' do
+        expect(described_class.for(user)).to eq(0)
       end
     end
 
     context 'has_used_trial が false のとき' do
-      it '早期特典期間内（2026-05-31 00:00 〜 06-06 23:59 JST）なら 30 を返す' do
-        [
-          Time.zone.parse('2026-05-31 00:00 JST'),
-          Time.zone.parse('2026-06-03 12:00 JST'),
-          Time.zone.parse('2026-06-06 23:59 JST')
-        ].each do |at|
-          expect(described_class.for(user, at:)).to eq(30)
-        end
-      end
-
-      it '早期特典期間外（直前・直後）なら 7 を返す' do
-        [
-          Time.zone.parse('2026-05-30 23:59 JST'),
-          Time.zone.parse('2026-06-07 00:00 JST'),
-          Time.zone.parse('2026-08-01 12:00 JST')
-        ].each do |at|
-          expect(described_class.for(user, at:)).to eq(7)
-        end
+      it '7 を返す' do
+        expect(described_class.for(user)).to eq(7)
       end
     end
   end


### PR DESCRIPTION
## 概要

Proプランの「7日間無料トライアル」実装調査中に見つかった、リリース記念の早期特典期間（2026-05-31〜06-06）中は30日間トライアルになる特例ロジックを削除する。

## 変更内容

- `TrialDaysCalculator.for` は早期加入者期間かどうかに関わらず常に7日（`NORMAL_TRIAL_DAYS`）を返すように変更
- `EARLY_TRIAL_DAYS` 定数を削除、`for` の `at:` 引数も時刻分岐が不要になったため削除
- `in_early_window?`（`is_early_subscriber` フラグの判定に使用）はそのまま維持。トライアル日数とは無関係な「早期加入者の記録」用途として残す

## Test plan

- [x] `bundle exec rspec spec/services/trial_days_calculator_spec.rb spec/services/app/stripe/checkout_session_builder_spec.rb`
- [x] `bundle exec rspec spec/services/revenue_cat/ spec/services/app/stripe/`（関連する既存テストの回帰なし）
- [x] `bundle exec rubocop`
