### PR TITLE
Fix: issue#450 Pro機能レビュー指摘対応（back）

### DIFF
--- a/ISSUE_450_PLAN.md
+++ b/ISSUE_450_PLAN.md
@@ -1,0 +1,381 @@
+# Issue #450 対応プラン
+
+## Context
+
+mobile版Proを先行リリースするにあたり、back PR #216 / mobile PR #80 の多角的レビュー（issue #450）で見つかった16件の考慮漏れ・バグ・デグレに対応する。作業ブランチは back/mobile とも `fix/450-pro-review-fixes`（起点: `release/pro-202605`）。
+
+ユーザーの希望により、各項目の対応方針を1つずつ質問し、全16件について合意形成済み（実装対応するもの・調査の結果対応不要と判断したもの・今回は見送るものに分類済み）。以下は確定した対応方針。
+
+## 調査により優先度が変わった項目
+
+- **back-高2（v1 baseball_notes の `game_result_id` 消失）**: front は v1 baseball_notes API（create/update/delete）を実際に使用しているが、`game_result_id` フィールド自体はfrontのどこにも参照されていない（型定義・画面表示ともになし）。back内にも `.game_result_id` への直接参照はなく実行時エラーもない。→ **実害なし、優先度「低」に格下げ**（対応するとしても最後）
+- **back-高3（グループ招待リンクの1件上限）**: mobile側 `app/(tabs)/(groups)/join.tsx` は `hasEntitlement("unlimited_groups")` と所属数を事前チェックし、上限時は `PaywallModal` でアップセル表示する設計が既に実装済み（`create.tsx` も同様）。→ **mobile単独リリースには対応不要**（front側の同等機能は front 対応時に検討）
+
+## 合意済み項目（対応方針が確定したもの）
+
+### 1. back-高1: RevenueCat EXPIRATIONのイベント順序逆転ガード欠如
+
+**方針**: `ExpirationHandler`に個別ガードを追加（最小修正、RenewalHandlerと同パターン）
+
+```ruby
+class ExpirationHandler < BaseHandler
+  def call
+    with_resolved_subscription do |user, subscription|
+      next if outdated_expiration?(subscription.expires_at, payload.expiration_at)
+
+      subscription.update!(status: 'expired', last_synced_at: Time.current)
+      event_recorder.record(user, subscription, 'expired')
+      SubscriptionExpiredNotificationJob.perform_now(user.id)
+    end
+  end
+
+  private
+
+  def outdated_expiration?(current_expires_at, event_expires_at)
+    current_expires_at.present? && event_expires_at.present? && current_expires_at > event_expires_at
+  end
+end
+```
+
+対象ファイル: `back/app/services/revenue_cat/handlers/expiration_handler.rb`
+テスト追加: `spec/services/revenue_cat/handlers/expiration_handler_spec.rb`（新しいRENEWALで延長済みのexpires_atがある状態で古いEXPIRATIONが届いてもstatusが変わらないこと）
+
+### 2. mobile-高: 課金成功後の同期失敗が「購入失敗」と誤表示される
+
+**方針**: 最小修正。`purchasePackage()`が成功した時点で「購入成功」とし、以降の`syncProStatus()`失敗はSentryに記録するのみで購入失敗表示にはしない。
+
+対象ファイル（同一パターンが重複しているため両方修正）:
+- `mobile/components/pro/PaywallModal.tsx`（`handlePurchase`, L467-490）
+- `mobile/app/pro/index.tsx`（同等の`handlePurchase`実装）
+
+修正イメージ:
+```ts
+const handlePurchase = async () => {
+  if (!selectedPackage) return;
+  setPurchasing(true);
+  try {
+    await purchasePackage(selectedPackage);
+  } catch (error) {
+    if (isUserCancelled(error)) return setPurchasing(false);
+    Sentry.captureException(error, { tags: { source: "revenue_cat_purchase" } });
+    showSnackbar({ type: "error", message: "購入に失敗しました。時間を置いて再度お試しください" });
+    return setPurchasing(false);
+  }
+
+  // ここから先、Appleへの課金は既に成功している。sync失敗は「購入失敗」にしない。
+  try {
+    await syncProStatus();
+  } catch (error) {
+    Sentry.captureException(error, { tags: { source: "revenue_cat_purchase_sync" } });
+  }
+  await queryClient.invalidateQueries({ queryKey: ["pro", "status"] });
+  setPurchasing(false);
+  onClose();
+  router.push("/pro/success");
+};
+```
+
+テスト追加: `syncProStatus`が例外を投げても`router.push("/pro/success")`が呼ばれること（`PaywallModal.test.tsx`, `app/pro/__tests__/index.test.tsx`）
+
+### 3. mobile-高: `pro_features` 機能フラグのキルスイッチが効いていない
+
+**方針**: バグ修正 + テストも修正
+
+対象ファイル: `mobile/app/account/subscription/index.tsx`（L19,23）
+
+```ts
+const { enabled: proFeatures } = useFeatureFlag("pro_features");
+// ...
+if (!proFeatures) return <Redirect href="/" />;
+```
+
+テスト修正: `mobile/app/account/subscription/__tests__/index.test.tsx:57`。現状`router.push`が呼ばれないことだけを見ているが、`<Redirect>`はpushを呼ばない宣言的コンポーネントのため検知できない。`useFeatureFlag`をfalseにモックした状態で、Redirect先の画面要素（またはナビゲーションのモック側でRedirect呼び出し）が描画されないことを検証する形に直す。
+
+### 4. mobile-高: APIエラーと「未加入」が区別されない
+
+**方針**: サブスクリプション画面のみ修正（範囲限定）
+
+対象ファイル: `mobile/app/account/subscription/index.tsx`
+
+```ts
+const { proStatus, isLoading, isError, refetch } = useProStatus();
+// ...
+if (isError) {
+  return (
+    <View style={styles.center}>
+      <Text style={styles.errorText}>状態の取得に失敗しました</Text>
+      <TouchableOpacity onPress={() => refetch()} accessibilityRole="button">
+        <Text>再試行</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+```
+
+`useEntitlement`側への`isError`伝播・ProGate等の見直しは対応範囲外（TanStack Queryのキャッシュにより初回取得失敗時のみの限定的影響のため）。
+
+### 5. back-中: Webhook二重配信時の排他制御なし（lost update）
+
+**方針**: 悲観的ロック（`with_lock`）
+
+対象ファイル: `back/app/services/revenue_cat/handlers/base_handler.rb`（`with_resolved_subscription`）
+
+```ruby
+def with_resolved_subscription(require_persisted: true, require_known_product: false)
+  user = UserResolver.resolve(payload.app_user_id)
+  return UserResolver.notify_unknown(payload.app_user_id) unless user
+
+  subscription = user.subscription_or_default
+  return if require_persisted && !subscription.persisted?
+  return if require_known_product && unknown_product?
+
+  if subscription.persisted?
+    subscription.with_lock { yield user, subscription }
+  else
+    yield user, subscription
+  end
+end
+```
+
+テスト追加: 並行更新を模したテスト（2スレッド、または`with_lock`が呼ばれることをモックで検証）を`spec/services/revenue_cat/handlers/base_handler_spec.rb`等に追加
+
+### 6. back-中: `after_commit :recalculate_activity` の同期実行
+
+**方針**: 同期のまま、rescueで分離（最小修正）
+
+対象ファイル: `back/app/models/match_result.rb`（`recalculate_activity`メソッド）
+
+```ruby
+def recalculate_activity
+  [date_and_time, previous_date_and_time].compact.uniq.each do |time|
+    Activities::DailyActivityRecalculator.new(
+      user_id:, date: time.in_time_zone('Asia/Tokyo').to_date
+    ).call
+  end
+rescue StandardError => e
+  Sentry.capture_exception(e, tags: { source: "match_result_recalculate_activity" })
+end
+```
+
+テスト追加: `DailyActivityRecalculator`が例外を投げても`match_result`の保存自体は成功すること（`spec/models/match_result_spec.rb`）
+
+### 7. back-中: Subscriptionバックフィルマイグレーションが並行登録とレースする
+
+**方針**: 対応不要。PostgreSQLの単一INSERT...SELECT文はstatement開始時の1スナップショットで実行されるため、指摘された並行登録との真のraceは実質起きない。対応なしで終了。
+
+### 8. back-中: アカウント削除がPro加入中はブロックされる（mobile未対応）
+
+**方針**: `pro_active`エラーコードを取得して専用文言を表示、解約画面への導線を付ける
+
+対象ファイル: `mobile/app/(tabs)/(profile)/account-deletion.tsx`
+
+```ts
+onPress: async () => {
+  setIsDeleting(true);
+  try {
+    await deleteAccount();
+    await logout();
+  } catch (error) {
+    setIsDeleting(false);
+    const code = axios.isAxiosError(error) ? error.response?.data?.error : null;
+    if (code === "pro_active") {
+      Alert.alert(
+        "削除できません",
+        "Pro加入中のため、先に解約してください。",
+        [
+          { text: "キャンセル", style: "cancel" },
+          { text: "解約する", onPress: () => router.push("/account/subscription") },
+        ],
+      );
+      return;
+    }
+    Alert.alert("エラー", "アカウントの削除に失敗しました");
+  }
+},
+```
+
+`useRouter`のimport追加が必要。テスト追加: `pro_active`エラー時に専用ダイアログが出ることを検証
+
+### 9. back-中: 同一Webhookイベントが同時到達した際、片方が500になる
+
+**方針**: `RecordNotUnique`をrescueして既存行を返す
+
+対象ファイル: `back/app/models/webhook_event.rb`（`find_or_create_pending!`）
+
+```ruby
+def self.find_or_create_pending!(provider:, external_event_id:, event_type:, payload:)
+  find_or_create_by!(provider:, external_event_id:) do |we|
+    we.event_type = event_type
+    we.payload = payload
+    we.received_at = Time.current
+    we.status = 'pending'
+  end
+rescue ActiveRecord::RecordNotUnique
+  find_by!(provider:, external_event_id:)
+end
+```
+
+Stripe/RevenueCat両方のwebhookコントローラで共通利用しているため、この1箇所の修正で両方に効く。
+テスト追加: 同一`external_event_id`で2回連続作成を試みても例外にならず同一レコードが返ること
+
+### 10. back-中: Web決済完了後のPro有効化監視なし
+
+**方針**: 今回は見送り。別issueとして後日対応する。
+
+### 11. mobile-中: 購入復元で対象0件でも「復元しました」と成功表示される
+
+**方針**: `entitlements.active`を確認して分岐
+
+対象ファイル: `mobile/components/pro/PaywallModal.tsx`（`handleRestore`）、`mobile/app/pro/index.tsx`（同等実装）
+
+```ts
+const handleRestore = async () => {
+  setRestoring(true);
+  try {
+    const customerInfo = await restorePurchases();
+    await syncProStatus();
+    await queryClient.invalidateQueries({ queryKey: ["pro", "status"] });
+
+    const hasActiveEntitlement =
+      Object.keys(customerInfo.entitlements.active).length > 0;
+    if (hasActiveEntitlement) {
+      showSnackbar({ type: "success", message: "購入情報を復元しました" });
+      onClose();
+    } else {
+      showSnackbar({
+        type: "info",
+        message: "復元できる購入情報がありませんでした",
+      });
+    }
+  } catch {
+    showSnackbar({ type: "error", message: "復元に失敗しました。時間を置いて再度お試しください" });
+  } finally {
+    setRestoring(false);
+  }
+};
+```
+
+### 12. mobile-中: 二重タップ防止が`disabled`プロパティのみに依存
+
+**方針**: 関数先頭にガードを追加
+
+対象ファイル: `mobile/components/pro/PaywallModal.tsx`, `mobile/app/pro/index.tsx`
+
+```ts
+const handlePurchase = async () => {
+  if (!selectedPackage || purchasing) return;
+  setPurchasing(true);
+  // ...
+};
+
+const handleRestore = async () => {
+  if (restoring) return;
+  setRestoring(true);
+  // ...
+};
+```
+
+### 13. mobile-中: RevenueCatのエラーコードが出し分けされていない
+
+**方針**: 主要2つ（PAYMENT_PENDING_ERROR, PRODUCT_ALREADY_PURCHASED_ERROR）を出し分け
+
+対象ファイル: `mobile/components/pro/PaywallModal.tsx`（`handlePurchase`のcatch節）、`mobile/app/pro/index.tsx`（同等実装）
+
+```ts
+} catch (error: unknown) {
+  if (isUserCancelled(error)) return;
+  const code = (error as { code?: string })?.code;
+  if (code === PURCHASES_ERROR_CODE.PAYMENT_PENDING_ERROR) {
+    showSnackbar({ type: "info", message: "お支払いが保留中です。承認が完了し次第、Proが有効になります" });
+    return;
+  }
+  if (code === PURCHASES_ERROR_CODE.PRODUCT_ALREADY_PURCHASED_ERROR) {
+    showSnackbar({ type: "info", message: "既に購入済みです。「購入を復元」をお試しください" });
+    return;
+  }
+  Sentry.captureException(error, { tags: { source: "revenue_cat_purchase" } });
+  showSnackbar({ type: "error", message: "購入に失敗しました。時間を置いて再度お試しください" });
+}
+```
+
+`PURCHASES_ERROR_CODE`は`react-native-purchases`からimport。
+
+### 14. mobile-中: `customerInfoUpdateListener`が未登録
+
+**方針**: 常設リスナーを追加
+
+対象ファイル: `mobile/services/revenueCatService.ts`（新規export）、`mobile/app/_layout.tsx`（登録）
+
+```ts
+// services/revenueCatService.ts
+export function addCustomerInfoUpdateListener(
+  listener: (customerInfo: CustomerInfo) => void,
+): () => void {
+  Purchases.addCustomerInfoUpdateListener(listener);
+  return () => Purchases.removeCustomerInfoUpdateListener(listener);
+}
+
+// app/_layout.tsx
+useEffect(() => {
+  const unsubscribe = addCustomerInfoUpdateListener(() => {
+    queryClient.invalidateQueries({ queryKey: ["pro", "status"] });
+  });
+  return unsubscribe;
+}, []);
+```
+
+### 15. mobile-中: プラットフォームをまたいだ解約導線の誤案内
+
+**方針**: 今回は見送り。RevenueCat/Google Play側にAndroid向けPro商品が未設定で実害ユーザーがいないため、Android向けPro展開時に対応する。
+
+### 16. 低優先度5件
+
+**方針**: 簡単な2件のみ対応、残り3件は見送り
+
+- 対応: `mobile/services/proService.ts:26` のコメントから issue 番号（`#318`）を削除
+- 対応: `back/app/models/concerns/entitlement.rb` の練習メニュー上限コメントを実装値（3件、`PRACTICE_MENU_FREE_LIMIT`）に合わせて修正
+- 見送り: 大規模テーブルへの非concurrentインデックス作成、`TrialExpiringBanner`の残日数境界値、テストの実装詳細依存・網羅性不足
+
+## 未合意項目
+
+(すべて合意完了)
+
+---
+
+## 全体まとめ・実装順序
+
+1. **back** (`fix/450-pro-review-fixes`)
+   - #1 ExpirationHandlerの順序逆転ガード + spec追加
+   - #5 BaseHandlerに`with_lock`追加 + spec追加
+   - #6 MatchResult#recalculate_activityをrescueで分離 + spec追加
+   - #9 WebhookEvent.find_or_create_pending!のRecordNotUniqueをrescue + spec追加
+   - #16 entitlement.rbのコメント修正
+   - 検証: `docker compose exec back bundle exec rspec spec/services/revenue_cat/ spec/services/app/stripe/ spec/models/match_result_spec.rb`、`bundle exec rubocop`
+
+2. **mobile** (`fix/450-pro-review-fixes`)
+   - #2 PaywallModal.tsx / app/pro/index.tsx の handlePurchase 分離（購入成功≠同期成功）
+   - #3 account/subscription/index.tsx の feature flag 分割代入修正 + テスト修正
+   - #4 account/subscription/index.tsx に isError 分岐追加
+   - #8 account-deletion.tsx に pro_active エラー専用ハンドリング追加
+   - #11 PaywallModal.tsx / app/pro/index.tsx の handleRestore に entitlements.active 分岐追加
+   - #12 handlePurchase / handleRestore に二重タップガード追加
+   - #13 RevenueCatエラーコード（PAYMENT_PENDING_ERROR, PRODUCT_ALREADY_PURCHASED_ERROR）出し分け追加
+   - #14 revenueCatService.ts に addCustomerInfoUpdateListener 追加、_layout.tsx に登録
+   - #16 proService.ts のコメントからissue番号削除
+   - 検証: `yarn lint`, `yarn typecheck`（`yarn test`はローカル実行せずCI任せ）
+
+3. 完了後、back/mobileそれぞれコミット分割（指摘ごとに1コミット）、push、PR作成（base: release/pro-202605）
+
+## 見送り項目（対応しない、理由付き）
+
+- back-高2: v1 baseball_notes の `game_result_id` 消失 → front未使用のため実害なし
+- back-高3: グループ招待リンクの1件上限 → mobile側は既にPaywallModalで対応済み
+- back-中: Subscriptionバックフィルのrace → Postgres単一statement snapshotのため実質発生しない
+- back-中: Web決済完了後のPro有効化監視なし → 運用監視は別issueで後日対応
+- mobile-中: プラットフォームをまたいだ解約導線の誤案内 → Android向けPro商品が未設定で実害ユーザーなし
+- 低優先度3件: 非concurrentインデックス、TrialExpiringBanner境界値、テスト網羅性不足 → 余裕があるときに対応
+
+## 検証方法（各項目共通）
+
+- back: 該当spec追加・修正後 `docker compose exec back bundle exec rspec <対象spec>`、`bundle exec rubocop`
+- mobile: `yarn lint` / `yarn typecheck`（`yarn test`はCI任せ、ローカル実行しない）

--- a/app/models/concerns/entitlement.rb
+++ b/app/models/concerns/entitlement.rb
@@ -22,7 +22,7 @@ module Entitlement
     'no_ads',                       # 広告非表示
     'season_transition_graph',      # シーズン跨ぎ成績推移グラフ(複数シーズン比較)
     'grass_full_history',           # 草機能: 全期間ヒートマップ表示
-    'unlimited_practice_menus',     # 練習メニュー無制限(無料は5件まで)
+    'unlimited_practice_menus',     # 練習メニュー無制限(無料は3件まで: PlanLimits::PRACTICE_MENU_FREE_LIMIT)
     'unlimited_media_uploads',      # 動画・画像アップロード無制限(無料は月3件)
     'schedule_copy_next_week',      # 週の練習プランを来週へ一括コピー
     'unlimited_menu_sets',          # メニューセット無制限(無料は2件まで)

--- a/app/models/match_result.rb
+++ b/app/models/match_result.rb
@@ -50,10 +50,14 @@ class MatchResult < ApplicationRecord
 
   # 更新後の日付に加え、date_and_time を変更した場合は変更前の日付も再計算する。
   # 旧日付の activity_log（試合ありの強度）が古いまま残るのを防ぐ。
+  # after_commit の同期実行のため、再計算の失敗が試合結果の保存レスポンス自体を
+  # 失敗させないよう rescue で分離し、Sentry への記録に留める。
   def recalculate_activity
     [date_and_time, previous_date_and_time].compact.uniq.each do |time|
       Activities::DailyActivityRecalculator.new(user_id:, date: time.in_time_zone('Asia/Tokyo').to_date).call
     end
+  rescue StandardError => e
+    Sentry.capture_exception(e, tags: { source: 'match_result_recalculate_activity' })
   end
 
   def previous_date_and_time

--- a/app/models/webhook_event.rb
+++ b/app/models/webhook_event.rb
@@ -10,6 +10,10 @@ class WebhookEvent < ApplicationRecord
   # 既存レコードがあれば status を書き換えず返す（同一イベント二重受信時の冪等性確保）。
   # 同一イベントが同時到達すると find_or_create_by! は SELECT → INSERT の間で競合し
   # RecordNotUnique になりうるため、rescue して勝者の既存行を返す（500 を防ぐ）。
+  #
+  # NOTE: 外側のトランザクション内から呼んではならない。RecordNotUnique でトランザクションが
+  # abort 状態になり、rescue 節の find_by! も道連れで失敗するため。
+  # 現状の呼び出し元（Stripe / RevenueCat の webhook コントローラ）はいずれもトランザクション外。
   # @return [WebhookEvent]
   def self.find_or_create_pending!(provider:, external_event_id:, event_type:, payload:)
     find_or_create_by!(provider:, external_event_id:) do |we|

--- a/app/models/webhook_event.rb
+++ b/app/models/webhook_event.rb
@@ -8,6 +8,8 @@ class WebhookEvent < ApplicationRecord
 
   # provider × external_event_id をキーに pending な受信レコードを取得する。
   # 既存レコードがあれば status を書き換えず返す（同一イベント二重受信時の冪等性確保）。
+  # 同一イベントが同時到達すると find_or_create_by! は SELECT → INSERT の間で競合し
+  # RecordNotUnique になりうるため、rescue して勝者の既存行を返す（500 を防ぐ）。
   # @return [WebhookEvent]
   def self.find_or_create_pending!(provider:, external_event_id:, event_type:, payload:)
     find_or_create_by!(provider:, external_event_id:) do |we|
@@ -16,6 +18,8 @@ class WebhookEvent < ApplicationRecord
       we.received_at = Time.current
       we.status = 'pending'
     end
+  rescue ActiveRecord::RecordNotUnique
+    find_by!(provider:, external_event_id:)
   end
 
   STATUSES.each do |status_name|

--- a/app/services/revenue_cat/handlers/base_handler.rb
+++ b/app/services/revenue_cat/handlers/base_handler.rb
@@ -19,6 +19,9 @@ module RevenueCat
       # 初回購入時は subscription が未保存のことがあるため require_persisted で挙動を切り替える。
       # plan_type / platform を書き換える handler は require_known_product を true にし、
       # 未登録の product_id / store を silent に保存することを防ぐ。
+      # 永続化済みの subscription は with_lock で排他し、webhook 二重配信・同時到達時の
+      # lost update（read-modify-write の交錯）を防ぐ。未保存レコードはロック対象が
+      # 存在しないためそのまま yield する。
       def with_resolved_subscription(require_persisted: true, require_known_product: false)
         user = UserResolver.resolve(payload.app_user_id)
         return UserResolver.notify_unknown(payload.app_user_id) unless user
@@ -27,7 +30,11 @@ module RevenueCat
         return if require_persisted && !subscription.persisted?
         return if require_known_product && unknown_product?
 
-        yield user, subscription
+        if subscription.persisted?
+          subscription.with_lock { yield user, subscription }
+        else
+          yield user, subscription
+        end
       end
 
       private

--- a/app/services/revenue_cat/handlers/base_handler.rb
+++ b/app/services/revenue_cat/handlers/base_handler.rb
@@ -22,6 +22,16 @@ module RevenueCat
       # 永続化済みの subscription は with_lock で排他し、webhook 二重配信・同時到達時の
       # lost update（read-modify-write の交錯）を防ぐ。未保存レコードはロック対象が
       # 存在しないためそのまま yield する。
+      #
+      # ブロックには第3引数として after_unlock 配列を渡す。メール送信・Push 通知のような
+      # 外部 I/O は応答時間が読めず、ロックを保持したまま実行すると同一 subscription への
+      # 後続 webhook を待たせ、DB コネクションも占有し続けるため、ここに積んでロック解放後
+      # （トランザクションのコミット後）に実行する。
+      # ブロック内で next した場合は何も積まれないので、スキップ時に通知だけ飛ぶことはない。
+      #
+      # @yieldparam user [User]
+      # @yieldparam subscription [Subscription]
+      # @yieldparam after_unlock [Array<Proc>] ロック解放後に実行したい処理の積み先
       def with_resolved_subscription(require_persisted: true, require_known_product: false)
         user = UserResolver.resolve(payload.app_user_id)
         return UserResolver.notify_unknown(payload.app_user_id) unless user
@@ -30,11 +40,13 @@ module RevenueCat
         return if require_persisted && !subscription.persisted?
         return if require_known_product && unknown_product?
 
+        after_unlock = []
         if subscription.persisted?
-          subscription.with_lock { yield user, subscription }
+          subscription.with_lock { yield user, subscription, after_unlock }
         else
-          yield user, subscription
+          yield user, subscription, after_unlock
         end
+        after_unlock.each(&:call)
       end
 
       private

--- a/app/services/revenue_cat/handlers/billing_issue_handler.rb
+++ b/app/services/revenue_cat/handlers/billing_issue_handler.rb
@@ -3,7 +3,7 @@ module RevenueCat
     # BILLING_ISSUE は課金失敗。Grace Period 中は Pro 機能利用可なので expires_at は変えない。
     class BillingIssueHandler < BaseHandler
       def call
-        with_resolved_subscription do |user, subscription|
+        with_resolved_subscription do |user, subscription, after_unlock|
           # Job リトライによる時刻ズレを避けるため、billing_issue_at は Webhook payload のイベント時刻を採用する。
           subscription.update!(
             status: 'billing_issue',
@@ -11,7 +11,7 @@ module RevenueCat
             last_synced_at: Time.current
           )
           event_recorder.record(user, subscription, 'billing_issue')
-          BillingIssueNotificationJob.perform_now(user.id)
+          after_unlock << -> { BillingIssueNotificationJob.perform_now(user.id) }
         end
       end
     end

--- a/app/services/revenue_cat/handlers/cancellation_handler.rb
+++ b/app/services/revenue_cat/handlers/cancellation_handler.rb
@@ -3,7 +3,7 @@ module RevenueCat
     # CANCELLATION は解約申請。期限まで Pro 機能利用可なので expires_at は変えない。
     class CancellationHandler < BaseHandler
       def call
-        with_resolved_subscription do |user, subscription|
+        with_resolved_subscription do |user, subscription, after_unlock|
           # Job リトライによる時刻ズレを避けるため、cancelled_at は Webhook payload のイベント時刻を採用する。
           subscription.update!(
             status: 'cancelled',
@@ -11,7 +11,7 @@ module RevenueCat
             last_synced_at: Time.current
           )
           event_recorder.record(user, subscription, 'cancelled')
-          SubscriptionCancelledNotificationJob.perform_now(user.id)
+          after_unlock << -> { SubscriptionCancelledNotificationJob.perform_now(user.id) }
         end
       end
     end

--- a/app/services/revenue_cat/handlers/expiration_handler.rb
+++ b/app/services/revenue_cat/handlers/expiration_handler.rb
@@ -5,12 +5,12 @@ module RevenueCat
     # 古い EXPIRATION が遅れて届いても、有効な subscription を expired に落とさない。
     class ExpirationHandler < BaseHandler
       def call
-        with_resolved_subscription do |user, subscription|
+        with_resolved_subscription do |user, subscription, after_unlock|
           next if outdated_expiration?(subscription.expires_at, payload.expiration_at)
 
           subscription.update!(status: 'expired', last_synced_at: Time.current)
           event_recorder.record(user, subscription, 'expired')
-          SubscriptionExpiredNotificationJob.perform_now(user.id)
+          after_unlock << -> { SubscriptionExpiredNotificationJob.perform_now(user.id) }
         end
       end
 

--- a/app/services/revenue_cat/handlers/expiration_handler.rb
+++ b/app/services/revenue_cat/handlers/expiration_handler.rb
@@ -1,13 +1,25 @@
 module RevenueCat
   module Handlers
     # EXPIRATION は期限到来時の最終ステータス。Pro 機能を無効化する。
+    # RENEWAL 同様に順序逆転への耐性が必要。新しい RENEWAL で expires_at が延長された後に
+    # 古い EXPIRATION が遅れて届いても、有効な subscription を expired に落とさない。
     class ExpirationHandler < BaseHandler
       def call
         with_resolved_subscription do |user, subscription|
+          next if outdated_expiration?(subscription.expires_at, payload.expiration_at)
+
           subscription.update!(status: 'expired', last_synced_at: Time.current)
           event_recorder.record(user, subscription, 'expired')
           SubscriptionExpiredNotificationJob.perform_now(user.id)
         end
+      end
+
+      private
+
+      # 現在の expires_at がイベントの expiration_at より後 = 別イベントで延長済み。
+      # 等しい場合は正規の期限到来なので expired へ進める（RenewalHandler の >= とは境界が異なる）。
+      def outdated_expiration?(current_expires_at, event_expires_at)
+        current_expires_at.present? && event_expires_at.present? && current_expires_at > event_expires_at
       end
     end
   end

--- a/app/services/revenue_cat/handlers/refund_handler.rb
+++ b/app/services/revenue_cat/handlers/refund_handler.rb
@@ -3,11 +3,11 @@ module RevenueCat
     # REFUND は返金確定。Pro 機能を即時無効化するため expires_at を現在に詰める。
     class RefundHandler < BaseHandler
       def call
-        with_resolved_subscription do |user, subscription|
+        with_resolved_subscription do |user, subscription, after_unlock|
           now = Time.current
           subscription.update!(status: 'expired', refunded_at: now, expires_at: now, last_synced_at: now)
           event_recorder.record(user, subscription, 'refunded')
-          RefundNotificationJob.perform_now(user.id)
+          after_unlock << -> { RefundNotificationJob.perform_now(user.id) }
         end
       end
     end

--- a/app/services/revenue_cat/handlers/renewal_handler.rb
+++ b/app/services/revenue_cat/handlers/renewal_handler.rb
@@ -4,7 +4,7 @@ module RevenueCat
     # billing_issue → active への遷移時は recovered イベントも同時に記録する。
     class RenewalHandler < BaseHandler
       def call
-        with_resolved_subscription do |user, subscription|
+        with_resolved_subscription do |user, subscription, after_unlock|
           new_expires_at = payload.expiration_at
           next if outdated_event?(subscription.expires_at, new_expires_at)
 
@@ -13,7 +13,7 @@ module RevenueCat
           event_recorder.record(user, subscription, 'renewed')
           if was_billing_issue
             record_recovery(user, subscription)
-            RecoveredNotificationJob.perform_now(user.id)
+            after_unlock << -> { RecoveredNotificationJob.perform_now(user.id) }
           end
         end
       end

--- a/app/services/revenue_cat/subscription_event_recorder.rb
+++ b/app/services/revenue_cat/subscription_event_recorder.rb
@@ -14,17 +14,21 @@ module RevenueCat
     end
 
     def record(user, subscription, event_type, event_id: @payload.event_id)
-      UserSubscriptionEvent.create!(
-        user:,
-        subscription:,
-        event_type:,
-        platform: PlanCatalog.platform_from(@payload.store),
-        product_id: @payload.product_id,
-        period_type: @payload.period_type,
-        occurred_at: @payload.event_timestamp || Time.current,
-        raw_payload: @payload.to_h,
-        revenuecat_event_id: event_id
-      )
+      # BaseHandler の with_lock トランザクション内から呼ばれても INSERT の失敗が
+      # 呼び出し元のトランザクションを abort させないよう、savepoint で分離する。
+      UserSubscriptionEvent.transaction(requires_new: true) do
+        UserSubscriptionEvent.create!(
+          user:,
+          subscription:,
+          event_type:,
+          platform: PlanCatalog.platform_from(@payload.store),
+          product_id: @payload.product_id,
+          period_type: @payload.period_type,
+          occurred_at: @payload.event_timestamp || Time.current,
+          raw_payload: @payload.to_h,
+          revenuecat_event_id: event_id
+        )
+      end
     rescue ActiveRecord::RecordNotUnique
       nil
     rescue StandardError => e

--- a/spec/models/match_result_spec.rb
+++ b/spec/models/match_result_spec.rb
@@ -123,5 +123,25 @@ RSpec.describe MatchResult, type: :model do
         expect(user.activity_logs.find_by(activity_date: new_date.to_date)).to be_present
       end
     end
+
+    context '活動集計の再計算が例外を投げたとき' do
+      before do
+        allow(Activities::DailyActivityRecalculator).to receive(:new).and_raise(StandardError, 'recalc boom')
+        allow(Sentry).to receive(:capture_exception)
+      end
+
+      it '試合結果の保存自体は成功し、例外は Sentry に記録される' do
+        game_result = create(:game_result, user:)
+        match_result = game_result.match_result
+
+        expect { match_result.update!(date_and_time: Time.zone.local(2026, 7, 10, 10, 0)) }.not_to raise_error
+
+        expect(match_result.reload.date_and_time).to eq(Time.zone.local(2026, 7, 10, 10, 0))
+        expect(Sentry).to have_received(:capture_exception).with(
+          instance_of(StandardError),
+          hash_including(tags: hash_including(source: 'match_result_recalculate_activity'))
+        ).at_least(:once)
+      end
+    end
   end
 end

--- a/spec/models/webhook_event_spec.rb
+++ b/spec/models/webhook_event_spec.rb
@@ -42,6 +42,33 @@ RSpec.describe WebhookEvent, type: :model do
         expect(result.status).to eq('processed')
       end
     end
+
+    context '同一イベントが同時到達し INSERT がユニーク制約に競合したとき' do
+      let!(:existing) do
+        create(:webhook_event,
+               provider: 'revenuecat',
+               external_event_id: event_id,
+               status: 'pending')
+      end
+
+      before do
+        # find_or_create_by! の SELECT 時点では未登録 → INSERT 時に相手方が先に
+        # コミット済み、という同時到達の敗者側を RecordNotUnique の raise で再現する。
+        allow(described_class).to receive(:find_or_create_by!)
+          .and_raise(ActiveRecord::RecordNotUnique)
+      end
+
+      it '例外にせず、先勝ちした既存レコードを返す' do
+        result = described_class.find_or_create_pending!(
+          provider: 'revenuecat',
+          external_event_id: event_id,
+          event_type: 'INITIAL_PURCHASE',
+          payload:
+        )
+
+        expect(result.id).to eq(existing.id)
+      end
+    end
   end
 
   describe '#mark_processed!' do

--- a/spec/services/revenue_cat/handlers/base_handler_spec.rb
+++ b/spec/services/revenue_cat/handlers/base_handler_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe RevenueCat::Handlers::BaseHandler do
+  # BaseHandler は抽象クラスのため、with_resolved_subscription の共通フロー
+  # （排他制御・未保存レコードの扱い）だけを検証する最小のサブクラスを定義する。
+  let(:handler_class) do
+    Class.new(described_class) do
+      attr_reader :yielded_subscription
+
+      def call
+        with_resolved_subscription(require_persisted: false) do |_user, subscription|
+          @yielded_subscription = subscription
+          subscription.update!(last_synced_at: Time.current) if subscription.persisted?
+        end
+      end
+    end
+  end
+
+  let(:user) { create(:user) }
+  let(:payload) do
+    RevenueCat::WebhookPayload.new(
+      'event' => { 'id' => 'evt_lock_001', 'type' => 'RENEWAL', 'app_user_id' => user.id.to_s }
+    )
+  end
+
+  before do
+    allow(RevenueCat::UserResolver).to receive(:resolve).and_return(user)
+  end
+
+  describe '#with_resolved_subscription' do
+    context 'subscription が永続化済みのとき' do
+      before do
+        user.subscription.update!(status: 'active', expires_at: 30.days.from_now)
+      end
+
+      it 'with_lock で排他した上で本処理を実行する（webhook 二重配信時の lost update 防止）' do
+        subscription = user.subscription_or_default
+        allow(subscription).to receive(:with_lock).and_call_original
+
+        handler_class.new(payload).call
+
+        expect(subscription).to have_received(:with_lock)
+        expect(subscription.reload.last_synced_at).to be_within(1.second).of(Time.current)
+      end
+    end
+
+    context 'subscription が未保存（無料ユーザー）のとき' do
+      before do
+        user.subscription&.destroy!
+        user.reload
+      end
+
+      it 'ロック対象が存在しないため with_lock を経由せず本処理まで到達する' do
+        handler = handler_class.new(payload)
+        handler.call
+
+        expect(handler.yielded_subscription).to be_present
+        expect(handler.yielded_subscription).not_to be_persisted
+      end
+    end
+  end
+end

--- a/spec/services/revenue_cat/handlers/base_handler_spec.rb
+++ b/spec/services/revenue_cat/handlers/base_handler_spec.rb
@@ -58,5 +58,65 @@ RSpec.describe RevenueCat::Handlers::BaseHandler do
         expect(handler.yielded_subscription).not_to be_persisted
       end
     end
+
+    context 'ブロックが after_unlock に処理を積んだとき' do
+      # 通知などの外部 I/O をロック内に持ち込まないことを、トランザクションのネスト深さで検証する。
+      # spec 全体が transactional fixture のトランザクション内で走るため、絶対値ではなく
+      # 「ロック中より解放後の方が浅い」という相対比較で判定する。
+      let(:handler_class) do
+        Class.new(described_class) do
+          attr_reader :depth_in_lock, :depth_after_unlock, :executed
+
+          def call
+            with_resolved_subscription do |_user, subscription, after_unlock|
+              @depth_in_lock = ActiveRecord::Base.connection.open_transactions
+              subscription.update!(last_synced_at: Time.current)
+              after_unlock << lambda {
+                @executed = true
+                @depth_after_unlock = ActiveRecord::Base.connection.open_transactions
+              }
+            end
+          end
+        end
+      end
+
+      before do
+        user.subscription.update!(status: 'active', expires_at: 30.days.from_now)
+      end
+
+      it 'ロック（トランザクション）解放後に実行する' do
+        handler = handler_class.new(payload)
+        handler.call
+
+        expect(handler.executed).to be(true)
+        expect(handler.depth_after_unlock).to be < handler.depth_in_lock
+      end
+    end
+
+    context 'ブロックが next でスキップしたとき' do
+      let(:handler_class) do
+        Class.new(described_class) do
+          attr_reader :executed
+
+          def call
+            with_resolved_subscription do |_user, _subscription, after_unlock|
+              after_unlock << -> { @executed = true }
+              next
+            end
+          end
+        end
+      end
+
+      before do
+        user.subscription.update!(status: 'active', expires_at: 30.days.from_now)
+      end
+
+      it 'next 到達前に積まれた処理は実行される（積む位置で制御する契約であることを明示）' do
+        handler = handler_class.new(payload)
+        handler.call
+
+        expect(handler.executed).to be(true)
+      end
+    end
   end
 end

--- a/spec/services/revenue_cat/webhook_processor_spec.rb
+++ b/spec/services/revenue_cat/webhook_processor_spec.rb
@@ -318,7 +318,9 @@ RSpec.describe RevenueCat::WebhookProcessor do
 
     context 'EXPIRATION を受信したとき' do
       let(:user) { create(:user) }
-      let(:payload) { revenuecat_payload_for('expiration', user:) }
+      let(:existing_expires_at) { Time.zone.parse('2026-07-01 12:00 JST') }
+      let(:overrides) { { expiration_at_ms: existing_expires_at.to_i * 1000 } }
+      let(:payload) { revenuecat_payload_for('expiration', user:, **overrides) }
       let(:webhook_event) do
         create(:webhook_event,
                provider: 'revenuecat',
@@ -336,7 +338,7 @@ RSpec.describe RevenueCat::WebhookProcessor do
           revenuecat_user_id: user.id.to_s,
           has_used_trial: true,
           started_at: 60.days.ago,
-          expires_at: 1.day.ago,
+          expires_at: existing_expires_at,
           cancelled_at: 10.days.ago
         )
       end
@@ -354,6 +356,32 @@ RSpec.describe RevenueCat::WebhookProcessor do
         allow(SubscriptionExpiredNotificationJob).to receive(:perform_now)
         process!
         expect(SubscriptionExpiredNotificationJob).to have_received(:perform_now).with(user.id)
+      end
+
+      context '新しい RENEWAL で expires_at が延長された後に古い EXPIRATION が届いたとき（順序逆転）' do
+        let(:existing_expires_at) { Time.zone.parse('2026-09-01 12:00 JST') }
+        let(:overrides) do
+          { expiration_at_ms: Time.zone.parse('2026-07-01 12:00 JST').to_i * 1000 }
+        end
+
+        before do
+          user.subscription.update!(status: 'active', cancelled_at: nil)
+        end
+
+        it 'status を expired に落とさない' do
+          process!
+          expect(user.reload.subscription.status).to eq('active')
+        end
+
+        it 'UserSubscriptionEvent も記録しない（純粋スキップ）' do
+          expect { process! }.not_to(change { user.user_subscription_events.count })
+        end
+
+        it 'SubscriptionExpiredNotificationJob を呼び出さない' do
+          allow(SubscriptionExpiredNotificationJob).to receive(:perform_now)
+          process!
+          expect(SubscriptionExpiredNotificationJob).not_to have_received(:perform_now)
+        end
       end
     end
 


### PR DESCRIPTION
## 関連Issue

関連: ippei-shimizu/buzzbase#450

## 概要

mobile版Pro先行リリースに向けた多角的レビュー（issue #450）で見つかった考慮漏れ・バグのうち、back側の5件に対応する。対応方針は `ISSUE_450_PLAN.md`（ユーザーと1件ずつ合意済み）に基づく。

## 変更内容

- **EXPIRATIONイベントの順序逆転ガード追加**: 新しいRENEWALで `expires_at` が延長された後に古いEXPIRATIONが遅延して届いても、有効なsubscriptionを `expired` に落とさない（RenewalHandlerと同パターン。等しい場合は正規の期限到来として `expired` に進める）
- **webhook処理の排他制御**: `BaseHandler#with_resolved_subscription` で永続化済みsubscriptionを `with_lock` で排他し、二重配信・同時到達時のlost updateを防止。あわせて `SubscriptionEventRecorder` のINSERTをsavepoint（`requires_new: true`）で分離し、監査ログのuniqueness衝突がロック中のトランザクション全体をabortさせないようにした
- **通知ジョブをロック外へ**: 上記 `with_lock` により、メール送信（`deliver_now`）とExpo Push APIへのHTTPリクエストが行ロック＋トランザクション内で実行される状態になっていたため、`BaseHandler` にロック解放後に実行する仕組み（`after_unlock`）を追加し、通知を呼ぶ5ハンドラ（expiration / renewal / refund / cancellation / billing_issue）すべてを修正。ロック内に残るのは `update!` と `event_recorder.record` のみ。通知が同期実行される挙動自体は変えていない
- **活動集計再計算の分離**: `MatchResult#recalculate_activity`（after_commit同期実行）の例外をrescueしてSentry記録に留め、試合結果の保存自体は成功させる
- **Webhookイベント同時到達時の500解消**: `WebhookEvent.find_or_create_pending!` で `RecordNotUnique` をrescueし、先勝ちした既存レコードを返す（Stripe/RevenueCat両webhook共通の入口）。「外側トランザクション内から呼んではならない」前提もコメントに明記
- **コメント修正**: `entitlement.rb` の練習メニュー無料上限コメントを実装値（3件、`PlanLimits::PRACTICE_MENU_FREE_LIMIT`）に修正

### 対応不要と判断した項目（プラン合意済み・レビューで確認済み）

- v1 baseball_notes の `game_result_id` 消失 → front未使用のため実害なし
- グループ招待リンクの1件上限 → mobile側はPaywallModalで対応済み
- Subscriptionバックフィルのrace → Postgres単一statement snapshotのため実質発生しない
- Web決済完了後のPro有効化監視 → 別issueで後日対応
- EXPIRATION の `expiration_at_ms` 欠落時にガードが素通りする点 → 変更前と同じ挙動のため本PRのスコープ外

## マイグレーション

- [x] マイグレーションなし

## 確認手順

1. `docker compose exec back bundle exec rspec spec/services/revenue_cat/ spec/models/match_result_spec.rb spec/models/webhook_event_spec.rb`
2. 順序逆転: RENEWAL（新しいexpires_at）→ 古いEXPIRATIONの順でwebhookを受信させ、statusがexpiredに落ちないこと

## マージ順序の注意

mobile PR ippei-shimizu/buzzbase_mobile#171 の「Pro加入中のアカウント削除ブロック」対応は、本PRを含む back の 422 + `error: "pro_active"` レスポンスに依存します。mobile を先にマージする場合、back 未反映の環境ではPro加入中の削除が素通りするため、**back を先か同時にリリース**してください。

## チェックリスト

- [x] テストが通る (`bundle exec rspec` 全1630例パス)
- [x] `bundle exec rubocop` 指摘なし
- [ ] 動作確認済み

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115WTEwVUPp11UixDW7hHLi