### PR TITLE
Fix: RevenueCat Webhook QAで発見した2件の不具合を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,12 @@ docker compose exec back bundle exec rails routes  # ルーティング確認
 - 特定のマイグレーションだけを戻したい場合は `rails db:rollback` または `rails db:migrate:down VERSION=xxxxx` を使う。これなら他のテーブル・データには影響しない
 - データを削除しうるDB操作（`schema:load`、`db:reset`、`db:drop` 等）を実行する前は、必ず内容を説明してユーザーに確認する
 
+## Heroku本番環境
+
+- **ユーザーの明示的な指示がない限り、Heroku CLI・Herokuダッシュボードへのアクセスや操作を一切行わない**（`heroku config`, `heroku run`, `heroku ps`, `heroku logs` 等のコマンドも含む）
+- 本番環境変数の確認・設定、`rails console`の実行、dyno操作等、Heroku側の操作はすべてユーザー自身が行う
+- 本番の状態を確認したい場合は、ユーザーに確認を依頼するか、リストアップして issue に残す
+
 ## テスト
 
 ```bash

--- a/app/services/revenue_cat/plan_catalog.rb
+++ b/app/services/revenue_cat/plan_catalog.rb
@@ -10,8 +10,8 @@ module RevenueCat
     }.freeze
 
     PRODUCT_ID_TO_PLAN_TYPE = {
-      'buzzbase_pro_monthly' => 'monthly',
-      'buzzbase_pro_yearly' => 'yearly'
+      'jp.buzzbase.mobile.pro.monthly' => 'monthly',
+      'jp.buzzbase.mobile.pro.yearly' => 'yearly'
     }.freeze
 
     module_function

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,6 +68,7 @@ Rails.application.configure do
   config.hosts << 'api'
   config.hosts << 'back'
   # ngrokの無料プランはセッションごとにURLが変わるため、個別ドメインではなくサブドメインパターンで許可する
-  config.hosts << /.*\.ngrok-free\.(app|dev)/
-  config.hosts << /.*\.ngrok\.io/
+  # 非アンカーの正規表現だと `ngrok-free.app.evil.com` のような偽装ホストも一致してしまうため \A...\z で固定する
+  config.hosts << /\A[a-z0-9-]+\.ngrok-free\.(app|dev)\z/
+  config.hosts << /\A[a-z0-9-]+\.ngrok\.io\z/
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,4 +67,7 @@ Rails.application.configure do
   # config.action_cable.disable_request_forgery_protection = true
   config.hosts << 'api'
   config.hosts << 'back'
+  # ngrokの無料プランはセッションごとにURLが変わるため、個別ドメインではなくサブドメインパターンで許可する
+  config.hosts << /.*\.ngrok-free\.(app|dev)/
+  config.hosts << /.*\.ngrok\.io/
 end

--- a/spec/fixtures/revenuecat/billing_issue.json
+++ b/spec/fixtures/revenuecat/billing_issue.json
@@ -5,7 +5,7 @@
     "app_user_id": "1",
     "event_timestamp_ms": 1751000000000,
     "expiration_at_ms": 1751353200000,
-    "product_id": "buzzbase_pro_monthly",
+    "product_id": "jp.buzzbase.mobile.pro.monthly",
     "store": "APP_STORE",
     "period_type": "NORMAL"
   }

--- a/spec/fixtures/revenuecat/cancellation.json
+++ b/spec/fixtures/revenuecat/cancellation.json
@@ -5,7 +5,7 @@
     "app_user_id": "1",
     "event_timestamp_ms": 1750000000000,
     "expiration_at_ms": 1751353200000,
-    "product_id": "buzzbase_pro_monthly",
+    "product_id": "jp.buzzbase.mobile.pro.monthly",
     "store": "APP_STORE",
     "period_type": "NORMAL"
   }

--- a/spec/fixtures/revenuecat/expiration.json
+++ b/spec/fixtures/revenuecat/expiration.json
@@ -5,7 +5,7 @@
     "app_user_id": "1",
     "event_timestamp_ms": 1751353200000,
     "expiration_at_ms": 1751353200000,
-    "product_id": "buzzbase_pro_monthly",
+    "product_id": "jp.buzzbase.mobile.pro.monthly",
     "store": "APP_STORE",
     "period_type": "NORMAL"
   }

--- a/spec/fixtures/revenuecat/initial_purchase_normal.json
+++ b/spec/fixtures/revenuecat/initial_purchase_normal.json
@@ -5,7 +5,7 @@
     "app_user_id": "1",
     "event_timestamp_ms": 1748761200000,
     "expiration_at_ms": 1751353200000,
-    "product_id": "buzzbase_pro_monthly",
+    "product_id": "jp.buzzbase.mobile.pro.monthly",
     "store": "APP_STORE",
     "period_type": "NORMAL"
   }

--- a/spec/fixtures/revenuecat/initial_purchase_trial.json
+++ b/spec/fixtures/revenuecat/initial_purchase_trial.json
@@ -5,7 +5,7 @@
     "app_user_id": "1",
     "event_timestamp_ms": 1748761200000,
     "expiration_at_ms": 1749366000000,
-    "product_id": "buzzbase_pro_monthly",
+    "product_id": "jp.buzzbase.mobile.pro.monthly",
     "store": "APP_STORE",
     "period_type": "TRIAL"
   }

--- a/spec/fixtures/revenuecat/product_change.json
+++ b/spec/fixtures/revenuecat/product_change.json
@@ -5,7 +5,7 @@
     "app_user_id": "1",
     "event_timestamp_ms": 1751000000000,
     "expiration_at_ms": 1782967600000,
-    "product_id": "buzzbase_pro_yearly",
+    "product_id": "jp.buzzbase.mobile.pro.yearly",
     "store": "APP_STORE",
     "period_type": "NORMAL"
   }

--- a/spec/fixtures/revenuecat/refund.json
+++ b/spec/fixtures/revenuecat/refund.json
@@ -5,7 +5,7 @@
     "app_user_id": "1",
     "event_timestamp_ms": 1750500000000,
     "expiration_at_ms": 1751353200000,
-    "product_id": "buzzbase_pro_monthly",
+    "product_id": "jp.buzzbase.mobile.pro.monthly",
     "store": "APP_STORE",
     "period_type": "NORMAL"
   }

--- a/spec/fixtures/revenuecat/renewal.json
+++ b/spec/fixtures/revenuecat/renewal.json
@@ -5,7 +5,7 @@
     "app_user_id": "1",
     "event_timestamp_ms": 1751353200000,
     "expiration_at_ms": 1753945200000,
-    "product_id": "buzzbase_pro_monthly",
+    "product_id": "jp.buzzbase.mobile.pro.monthly",
     "store": "APP_STORE",
     "period_type": "NORMAL"
   }

--- a/spec/fixtures/revenuecat/trial_started.json
+++ b/spec/fixtures/revenuecat/trial_started.json
@@ -5,7 +5,7 @@
     "app_user_id": "1",
     "event_timestamp_ms": 1748761200000,
     "expiration_at_ms": 1749366000000,
-    "product_id": "buzzbase_pro_yearly",
+    "product_id": "jp.buzzbase.mobile.pro.yearly",
     "store": "APP_STORE",
     "period_type": "TRIAL"
   }

--- a/spec/fixtures/revenuecat/uncancellation.json
+++ b/spec/fixtures/revenuecat/uncancellation.json
@@ -5,7 +5,7 @@
     "app_user_id": "1",
     "event_timestamp_ms": 1750200000000,
     "expiration_at_ms": 1751353200000,
-    "product_id": "buzzbase_pro_monthly",
+    "product_id": "jp.buzzbase.mobile.pro.monthly",
     "store": "APP_STORE",
     "period_type": "NORMAL"
   }

--- a/spec/requests/api/v1/pro_spec.rb
+++ b/spec/requests/api/v1/pro_spec.rb
@@ -70,13 +70,13 @@ RSpec.describe 'Api::V1::Pro', type: :request do
         allow(RevenueCat::SubscriberClient).to receive(:fetch_subscriber).with(user.id.to_s).and_return(
           'entitlements' => {
             'pro' => {
-              'product_identifier' => 'buzzbase_pro_monthly',
+              'product_identifier' => 'jp.buzzbase.mobile.pro.monthly',
               'purchase_date' => 1.day.ago.iso8601,
               'expires_date' => 29.days.from_now.iso8601
             }
           },
           'subscriptions' => {
-            'buzzbase_pro_monthly' => { 'store' => 'app_store', 'period_type' => 'NORMAL' }
+            'jp.buzzbase.mobile.pro.monthly' => { 'store' => 'app_store', 'period_type' => 'NORMAL' }
           }
         )
 

--- a/spec/services/revenue_cat/subscriber_sync_spec.rb
+++ b/spec/services/revenue_cat/subscriber_sync_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe RevenueCat::SubscriberSync do
     stub_subscriber(
       'entitlements' => {
         'pro' => {
-          'product_identifier' => 'buzzbase_pro_monthly',
+          'product_identifier' => 'jp.buzzbase.mobile.pro.monthly',
           'purchase_date' => 10.days.ago.iso8601,
           'expires_date' => 20.days.from_now.iso8601
         }.merge(entitlement_overrides)
       },
       'subscriptions' => {
-        'buzzbase_pro_monthly' => { 'store' => 'app_store', 'period_type' => 'NORMAL' }.merge(subscription_overrides)
+        'jp.buzzbase.mobile.pro.monthly' => { 'store' => 'app_store', 'period_type' => 'NORMAL' }.merge(subscription_overrides)
       }
     )
   end
@@ -32,7 +32,7 @@ RSpec.describe RevenueCat::SubscriberSync do
       end
 
       it '過去に加入していれば expired にする' do
-        user.subscription.update!(status: 'active', product_id: 'buzzbase_pro_monthly')
+        user.subscription.update!(status: 'active', product_id: 'jp.buzzbase.mobile.pro.monthly')
         stub_subscriber({})
         subscription = described_class.new(user).call
         expect(subscription.status).to eq('expired')
@@ -48,7 +48,7 @@ RSpec.describe RevenueCat::SubscriberSync do
           expect(subscription.status).to eq('active')
           expect(subscription.plan_type).to eq('monthly')
           expect(subscription.platform).to eq('ios')
-          expect(subscription.product_id).to eq('buzzbase_pro_monthly')
+          expect(subscription.product_id).to eq('jp.buzzbase.mobile.pro.monthly')
           expect(subscription.last_synced_at).to be_present
         end
       end

--- a/spec/services/revenue_cat/webhook_processor_spec.rb
+++ b/spec/services/revenue_cat/webhook_processor_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe RevenueCat::WebhookProcessor do
             status: 'active',
             plan_type: 'monthly',
             platform: 'ios',
-            product_id: 'buzzbase_pro_monthly'
+            product_id: 'jp.buzzbase.mobile.pro.monthly'
           )
           expect(subscription.started_at).to be_within(1.second).of(Time.zone.at(payload['event']['event_timestamp_ms'] / 1000))
           expect(subscription.expires_at).to be_within(1.second).of(Time.zone.at(payload['event']['expiration_at_ms'] / 1000))
@@ -208,7 +208,7 @@ RSpec.describe RevenueCat::WebhookProcessor do
           status: 'active',
           plan_type: 'monthly',
           platform: 'ios',
-          product_id: 'buzzbase_pro_monthly',
+          product_id: 'jp.buzzbase.mobile.pro.monthly',
           revenuecat_user_id: user.id.to_s,
           has_used_trial: true,
           started_at: 30.days.ago,
@@ -289,7 +289,7 @@ RSpec.describe RevenueCat::WebhookProcessor do
           status: 'active',
           plan_type: 'monthly',
           platform: 'ios',
-          product_id: 'buzzbase_pro_monthly',
+          product_id: 'jp.buzzbase.mobile.pro.monthly',
           revenuecat_user_id: user.id.to_s,
           has_used_trial: true,
           started_at: 30.days.ago,
@@ -334,7 +334,7 @@ RSpec.describe RevenueCat::WebhookProcessor do
           status: 'cancelled',
           plan_type: 'monthly',
           platform: 'ios',
-          product_id: 'buzzbase_pro_monthly',
+          product_id: 'jp.buzzbase.mobile.pro.monthly',
           revenuecat_user_id: user.id.to_s,
           has_used_trial: true,
           started_at: 60.days.ago,
@@ -402,7 +402,7 @@ RSpec.describe RevenueCat::WebhookProcessor do
           status: 'active',
           plan_type: 'monthly',
           platform: 'ios',
-          product_id: 'buzzbase_pro_monthly',
+          product_id: 'jp.buzzbase.mobile.pro.monthly',
           revenuecat_user_id: user.id.to_s,
           has_used_trial: true,
           started_at: 30.days.ago,
@@ -445,7 +445,7 @@ RSpec.describe RevenueCat::WebhookProcessor do
           status: 'active',
           plan_type: 'monthly',
           platform: 'ios',
-          product_id: 'buzzbase_pro_monthly',
+          product_id: 'jp.buzzbase.mobile.pro.monthly',
           revenuecat_user_id: user.id.to_s,
           has_used_trial: true,
           started_at: 30.days.ago,
@@ -489,7 +489,7 @@ RSpec.describe RevenueCat::WebhookProcessor do
             status: 'cancelled',
             plan_type: 'monthly',
             platform: 'ios',
-            product_id: 'buzzbase_pro_monthly',
+            product_id: 'jp.buzzbase.mobile.pro.monthly',
             revenuecat_user_id: user.id.to_s,
             has_used_trial: true,
             started_at: 30.days.ago,
@@ -544,7 +544,7 @@ RSpec.describe RevenueCat::WebhookProcessor do
           status: 'active',
           plan_type: 'monthly',
           platform: 'ios',
-          product_id: 'buzzbase_pro_monthly',
+          product_id: 'jp.buzzbase.mobile.pro.monthly',
           revenuecat_user_id: user.id.to_s,
           has_used_trial: true,
           started_at: 30.days.ago,
@@ -556,7 +556,7 @@ RSpec.describe RevenueCat::WebhookProcessor do
         process!
         subscription = user.reload.subscription
         expect(subscription.plan_type).to eq('yearly')
-        expect(subscription.product_id).to eq('buzzbase_pro_yearly')
+        expect(subscription.product_id).to eq('jp.buzzbase.mobile.pro.yearly')
       end
 
       it 'UserSubscriptionEvent に product_changed を記録する' do


### PR DESCRIPTION
## 概要

`docs/local-qa-revenuecat-sandbox.md`（ローカルRevenueCat Sandbox QAフロー）を実施中に見つかった2件の不具合を修正する。

## 変更内容

### 1. development環境でngrok経由のWebhookが403になる問題

ngrok経由でlocalhost:3100にWebhookを転送すると、`config.hosts`に未登録のHostヘッダーとして`ActionDispatch::HostAuthorization`に弾かれていた。ngrokの無料URLはセッションごとに変わるため、個別ドメインではなくサブドメインパターン（`*.ngrok-free.app` / `*.ngrok-free.dev` / `*.ngrok.io`）で許可するようにした。

### 2. PlanCatalogのproduct_idが実際のApp Store Connect側の値と不一致

`PlanCatalog::PRODUCT_ID_TO_PLAN_TYPE`が`buzzbase_pro_monthly` / `buzzbase_pro_yearly`という架空の値になっており、実際にApp Store Connect / mobile側で使われているproduct_id（`jp.buzzbase.mobile.pro.monthly` / `jp.buzzbase.mobile.pro.yearly`）と一致していなかった。

このため`INITIAL_PURCHASE` / `PRODUCT_CHANGE`イベント受信時に`unknown_product?`ガードで弾かれ、Webhookは200・`processed`を返しつつ`Subscription`テーブルが一切更新されない状態になっていた（Sentry警告のみでエラーにはならないため気づきにくい）。同じ`PlanCatalog`を参照する`SubscriberSync`（`/pro/status`同期）も同様の影響を受けていた。

ローカルQAで実際のproduct_idを使った疑似Webhookを送信し、修正前は`Subscription`が更新されないこと、修正後は正しく更新されることをRailsコンソールで確認済み。

既存のRSpecも同じ架空のproduct_id値をフィクスチャに使っており、この不一致を検出できていなかったため、実際のproduct_idに合わせて修正した。

## 動作確認

- [x] `docker compose exec back bundle exec rspec spec/services/revenue_cat/ spec/requests/api/v1/pro_spec.rb` — 79 examples, 0 failures
- [x] `docker compose exec back bundle exec rubocop` — 対象ファイルでoffenseなし
- [x] 実際のproduct_idで疑似`INITIAL_PURCHASE` Webhookを送信し、修正前後で`Subscription` / `UserSubscriptionEvent`の反映を確認
