### PR TITLE
Fix: Pro課金/広告リリース監査で見つかったバックエンド側のバグを修正

### DIFF
--- a/app/controllers/api/v2/media_attachments_controller.rb
+++ b/app/controllers/api/v2/media_attachments_controller.rb
@@ -38,6 +38,8 @@ module Api
         # file_size_bytesはクライアントの自己申告値のため、R2上の実サイズで上書きしてから検証する。
         @media_attachment.file_size_bytes = actual_size
 
+        return unless overwrite_video_metadata!
+
         unless ::MediaAttachments::LimitValidator.new(user: current_api_v1_user, attachment: @media_attachment).valid?
           @media_attachment.update!(status: 'failed')
           return render json: { errors: ['アップロード可能な上限を超えています'] }, status: :unprocessable_entity
@@ -49,6 +51,24 @@ module Api
         else
           render json: { errors: @media_attachment.errors.full_messages }, status: :unprocessable_entity
         end
+      end
+
+      # duration_seconds / width / height もfile_size_bytesと同じくクライアントの自己申告値なので、
+      # R2上の実ファイルから読み直した値で上書きしてから無料枠判定にかける。
+      # 解析できない動画は上限を検証できないため、素通しさせずアップロードを失敗させる。
+      # @return [Boolean] 処理を継続してよいか（falseのときは既にrender済み）
+      def overwrite_video_metadata!
+        return true unless @media_attachment.video?
+
+        metadata = ::MediaAttachments::VideoMetadataFetcher.new(r2_key: @media_attachment.r2_key).call
+        if metadata.nil?
+          @media_attachment.update!(status: 'failed')
+          render json: { errors: ['動画の形式を確認できませんでした'] }, status: :unprocessable_entity
+          return false
+        end
+
+        @media_attachment.assign_attributes(metadata.to_h)
+        true
       end
 
       def update_memo

--- a/app/controllers/api/v2/menu_sets_controller.rb
+++ b/app/controllers/api/v2/menu_sets_controller.rb
@@ -29,13 +29,16 @@ module Api
       end
 
       def update
-        @menu_set.assign_attributes(menu_set_params)
-        assign_items(@menu_set) if params[:menu_set].key?(:items)
-        if @menu_set.save
-          render json: @menu_set, serializer: ::V2::MenuSetSerializer, status: :ok
-        else
-          render json: { errors: @menu_set.errors.full_messages }, status: :unprocessable_entity
+        # assign_items の destroy_all は即時実行されるため、save 失敗時に既存アイテムだけ
+        # 消えて残らないよう、属性更新・アイテム再構築・保存を1トランザクションに包む。
+        ActiveRecord::Base.transaction do
+          @menu_set.assign_attributes(menu_set_params)
+          assign_items(@menu_set) if params[:menu_set].key?(:items)
+          @menu_set.save!
         end
+        render json: @menu_set, serializer: ::V2::MenuSetSerializer, status: :ok
+      rescue ActiveRecord::RecordInvalid
+        render json: { errors: @menu_set.errors.full_messages }, status: :unprocessable_entity
       end
 
       def destroy

--- a/app/controllers/api/v2/schedules_controller.rb
+++ b/app/controllers/api/v2/schedules_controller.rb
@@ -12,14 +12,14 @@ module Api
                                                  { menu_set: { menu_set_items: :practice_menu } },
                                                  { schedule_menus: :practice_menu })
                                        .order(:scheduled_time)
-        render json: schedules, each_serializer: ::V2::ScheduleSerializer, status: :ok
+        render json: schedules, each_serializer: ::V2::ScheduleSerializer, status: :ok, **serializer_options
       end
 
       def create
         schedule = current_api_v1_user.schedules.build(schedule_params)
         assign_menus(schedule)
         if schedule.save
-          render json: schedule, serializer: ::V2::ScheduleSerializer, status: :created
+          render json: schedule, serializer: ::V2::ScheduleSerializer, status: :created, **serializer_options
         else
           render json: { errors: schedule.errors.full_messages }, status: :unprocessable_entity
         end
@@ -33,7 +33,7 @@ module Api
           assign_menus(@schedule) if params[:schedule].key?(:menus)
           @schedule.save!
         end
-        render json: @schedule, serializer: ::V2::ScheduleSerializer, status: :ok
+        render json: @schedule, serializer: ::V2::ScheduleSerializer, status: :ok, **serializer_options
       rescue ActiveRecord::RecordInvalid
         render json: { errors: @schedule.errors.full_messages }, status: :unprocessable_entity
       end
@@ -47,6 +47,12 @@ module Api
 
       def load_schedule
         @schedule = current_api_v1_user.schedules.find(params[:id])
+      end
+
+      # entitlement 判定は全レコードで同じ結果になるため、シリアライザ内で個別に引かず
+      # 1回だけ解決して渡す（index の N+1 回避）。
+      def serializer_options
+        { custom_notification_messages: current_api_v1_user.has_entitlement?('custom_notification_messages') }
       end
 
       # カスタム通知文は Pro 限定。無料ユーザーの指定は無視する。

--- a/app/controllers/api/v2/shadow_swing_sessions_controller.rb
+++ b/app/controllers/api/v2/shadow_swing_sessions_controller.rb
@@ -9,8 +9,7 @@ module Api
       # POST /api/v2/shadow_swing_sessions
       def create
         session = current_api_v1_user.shadow_swing_sessions.build(
-          target_count: params.require(:shadow_swing_session).permit(:target_count)[:target_count],
-          logged_on: Time.find_zone('Asia/Tokyo').today
+          create_params.merge(logged_on: Time.find_zone('Asia/Tokyo').today)
         )
         if session.save
           render json: session, serializer: ::V2::ShadowSwingSessionSerializer, status: :created
@@ -51,6 +50,14 @@ module Api
         return if current_api_v1_user.has_entitlement?('practice_menu_trend_detail')
 
         render json: { error: 'メニュー推移の詳細表示は Pro プラン限定です' }, status: :forbidden
+      end
+
+      # インターバル・バイブ等の Pro 限定設定は ShadowSwingSession のバリデーションで検証する。
+      # カウンター画面はここで保存した値を読むため、クライアント側のロック表示を回避しても
+      # サーバーが許可した設定でしか実行できない。
+      def create_params
+        params.require(:shadow_swing_session)
+              .permit(:target_count, :interval_seconds, :vibration_enabled, :sound_enabled, :voice_enabled)
       end
 
       def complete_params

--- a/app/jobs/finalize_goals_job.rb
+++ b/app/jobs/finalize_goals_job.rb
@@ -14,7 +14,8 @@ class FinalizeGoalsJob < ApplicationJob
         goal.update!(
           achieved_value: calculator.current_value,
           is_achieved: achieved,
-          achieved_at: achieved ? Time.current : nil,
+          # 定性目標はユーザーが達成ボタンを押した時刻が既に入っているため、ジョブ実行時刻で上書きしない。
+          achieved_at: achieved ? (goal.achieved_at || Time.current) : nil,
           is_finalized: true
         )
         award_badge(goal) if achieved
@@ -31,6 +32,8 @@ class FinalizeGoalsJob < ApplicationJob
       user: goal.user,
       badge_type:,
       badge_name:,
+      # 目標が後から削除されてもバッジ一覧に何の目標だったか出せるようスナップショットする。
+      goal_title: goal.title,
       awarded_at: Time.current
     )
   end

--- a/app/jobs/purge_stale_media_attachments_job.rb
+++ b/app/jobs/purge_stale_media_attachments_job.rb
@@ -1,0 +1,14 @@
+class PurgeStaleMediaAttachmentsJob < ApplicationJob
+  queue_as :default
+
+  # presign 後にアプリのクラッシュ・通信断で完了通知が来なかったアップロードは、
+  # DB の pending 行と R2 のオブジェクトが残り続ける。無料枠のカウントからは既に
+  # 除外しているが、ストレージ費用は増え続けるため定期的に回収する。
+  # failed も R2 側にオブジェクトが残っている可能性があるため同じく対象にする。
+  #
+  # 削除は destroy 経由にして、R2 オブジェクトの削除は既存の after_commit
+  # （MediaAttachmentDeletionJob）に委ねる。
+  def perform
+    MediaAttachment.incomplete_and_stale.find_each(&:destroy)
+  end
+end

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -3,7 +3,8 @@ class Goal < ApplicationRecord
   belongs_to :season, optional: true
   belongs_to :tournament, optional: true
   belongs_to :practice_menu, optional: true
-  has_many :goal_badges, dependent: :destroy
+  # 獲得済みバッジは達成の記念として恒久保存する。目標を削除しても道連れにしない。
+  has_many :goal_badges, dependent: :nullify
 
   PERIOD_TYPES = %w[season monthly tournament weekly yearly custom].freeze
   # 個人の期間目標（試合エンティティに紐づかない日付レンジ系）。無料枠を共有する。

--- a/app/models/goal_badge.rb
+++ b/app/models/goal_badge.rb
@@ -1,4 +1,7 @@
 class GoalBadge < ApplicationRecord
   belongs_to :user
-  belongs_to :goal
+  # 元の目標が削除されてもバッジは残す。goal は削除後 nil になる。
+  belongs_to :goal, optional: true
+
+  validates :goal_title, presence: true
 end

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -4,6 +4,14 @@ class MediaAttachment < ApplicationRecord
 
   MEDIA_TYPES = %w[image video].freeze
   STATUSES = %w[pending ready failed].freeze
+  # 完了しなかったアップロードを回収するまでの猶予。署名URLの有効期限（10分）に対して
+  # 十分長く取り、極端に遅い回線のアップロード中に消してしまわないようにする。
+  INCOMPLETE_RETENTION = 24.hours
+
+  # 完了通知が来ないまま放置され、R2 オブジェクトだけが残っている可能性のあるレコード。
+  scope :incomplete_and_stale, lambda {
+    where(status: %w[pending failed]).where(created_at: ...INCOMPLETE_RETENTION.ago)
+  }
 
   validates :media_type, inclusion: { in: MEDIA_TYPES }
   validates :status, inclusion: { in: STATUSES }

--- a/app/models/shadow_swing_session.rb
+++ b/app/models/shadow_swing_session.rb
@@ -45,7 +45,10 @@ class ShadowSwingSession < ApplicationRecord
     return nil if swing_count <= 0
 
     log = user.practice_logs.find_by(logged_on:, source: 'shadow_swing')
-    return log.tap { log.update!(amount: log.amount.to_i + swing_count) } if log
+    if log
+      log.update!(amount: log.amount.to_i + swing_count)
+      return log
+    end
 
     menu = linked_menu
     user.practice_logs.create!(

--- a/app/models/shadow_swing_session.rb
+++ b/app/models/shadow_swing_session.rb
@@ -5,14 +5,26 @@ class ShadowSwingSession < ApplicationRecord
   MENU_NAME = '素振り'.freeze
   UNIT_LABEL = '本'.freeze
 
+  # カウンターのインターバル（秒）。無料プランは FREE_INTERVAL_RANGE の範囲のみ選べる。
+  INTERVAL_RANGE = (1.0..20.0)
+  FREE_INTERVAL_RANGE = (5.0..10.0)
+
   validates :logged_on, presence: true
   validates :target_count, numericality: { greater_than: 0 }
   validates :swing_count, numericality: { greater_than_or_equal_to: 0 }
+  validates :interval_seconds,
+            numericality: { greater_than_or_equal_to: INTERVAL_RANGE.first, less_than_or_equal_to: INTERVAL_RANGE.last }
+  # 設定値はクライアント側でもロック表示しているが、直接 API を叩けば回避できるためサーバーでも検証する。
+  validate :pro_settings_within_entitlements, on: :create
 
   # セッションを完了し、素振り由来の練習ログへ本数を記録する。
   # 同じ日に既存の素振りログがあれば加算し、無ければ新規作成する（セット別に
   # 分けず、同日は1レコードへまとめる）。練習ログの after_commit で当日の
   # activity_logs（草・Streak）が再計算される。
+  #
+  # 0本での完了は「開始してすぐ終了した」ケースで、練習実績ではないため練習ログを作らない。
+  # 作ってしまうと amount 0 のログが1件分の活動として草・Streak を water down させる。
+  # セッション自体は完了扱いにし、開始したまま残らないようにする。
   # @param swing_count [Integer] 実際に振った本数
   # @return [self]
   def complete!(swing_count:)
@@ -20,26 +32,45 @@ class ShadowSwingSession < ApplicationRecord
     return self if completed_at.present?
 
     transaction do
-      log = user.practice_logs.find_by(logged_on:, source: 'shadow_swing')
-      if log
-        log.update!(amount: log.amount.to_i + swing_count)
-      else
-        menu = linked_menu
-        log = user.practice_logs.create!(
-          practice_menu: menu,
-          logged_on:,
-          amount: swing_count,
-          menu_name: MENU_NAME,
-          unit_label: menu&.unit_label || UNIT_LABEL,
-          source: 'shadow_swing'
-        )
-      end
+      log = practice_log_for(swing_count)
       update!(swing_count:, completed_at: Time.current, practice_log: log)
     end
     self
   end
 
   private
+
+  # @return [PracticeLog, nil] 0本のときは記録すべき実績が無いので nil
+  def practice_log_for(swing_count)
+    return nil if swing_count <= 0
+
+    log = user.practice_logs.find_by(logged_on:, source: 'shadow_swing')
+    return log.tap { log.update!(amount: log.amount.to_i + swing_count) } if log
+
+    menu = linked_menu
+    user.practice_logs.create!(
+      practice_menu: menu,
+      logged_on:,
+      amount: swing_count,
+      menu_name: MENU_NAME,
+      unit_label: menu&.unit_label || UNIT_LABEL,
+      source: 'shadow_swing'
+    )
+  end
+
+  def pro_settings_within_entitlements
+    return if user.blank?
+
+    if interval_seconds.present? && !FREE_INTERVAL_RANGE.cover?(interval_seconds) &&
+       !user.has_entitlement?('shadow_swing_custom_interval')
+      errors.add(:interval_seconds,
+                 "は無料プランでは#{FREE_INTERVAL_RANGE.first.to_i}〜#{FREE_INTERVAL_RANGE.last.to_i}秒のみ選べます")
+    end
+
+    return unless vibration_enabled? && !user.has_entitlement?('shadow_swing_vibration')
+
+    errors.add(:vibration_enabled, 'は Pro プラン限定です')
+  end
 
   # 「素振り」という名前の練習メニューが既にあれば紐付け、積み上げ・推移を一本化する。
   # 単位が「回数」以外の既存メニューは統合すると数値の意味が壊れるため紐付けない

--- a/app/serializers/v2/goal_badge_serializer.rb
+++ b/app/serializers/v2/goal_badge_serializer.rb
@@ -1,9 +1,6 @@
 module V2
   class GoalBadgeSerializer < ActiveModel::Serializer
+    # goal_title は付与時のスナップショット。元の目標が削除されても表示できる。
     attributes :id, :badge_type, :badge_name, :awarded_at, :goal_id, :goal_title
-
-    def goal_title
-      object.goal.title
-    end
   end
 end

--- a/app/serializers/v2/schedule_serializer.rb
+++ b/app/serializers/v2/schedule_serializer.rb
@@ -12,7 +12,7 @@ module V2
     # カスタム通知文は Pro 限定。解約しても DB には過去に設定した値が残るため、
     # 保存値ではなく参照時点の entitlement で出し分ける（無料なら端末側の既定文が使われる）。
     def notification_message
-      instance_options[:custom_notification_messages] ? object.notification_message : nil
+      custom_messages_allowed? ? object.notification_message : nil
     end
 
     def scheduled_time
@@ -36,6 +36,17 @@ module V2
     # 該当メニューを編集不可にする目印としてクライアントへ返す。
     def logged_practice_menu_ids
       object.practice_logs.filter_map(&:practice_menu_id).uniq
+    end
+
+    private
+
+    # 判定結果は同一ユーザーなら同じなので、一覧系は instance_options で 1 回だけ
+    # 解決した値を渡して N+1 を避ける。渡されなかった場合はレコードの所有者から引く
+    # （呼び出し側の渡し忘れで Pro ユーザーの通知文が消えないようにするため）。
+    def custom_messages_allowed?
+      return instance_options[:custom_notification_messages] if instance_options.key?(:custom_notification_messages)
+
+      object.user.has_entitlement?('custom_notification_messages')
     end
   end
 end

--- a/app/serializers/v2/schedule_serializer.rb
+++ b/app/serializers/v2/schedule_serializer.rb
@@ -9,6 +9,12 @@ module V2
       object.display_title
     end
 
+    # カスタム通知文は Pro 限定。解約しても DB には過去に設定した値が残るため、
+    # 保存値ではなく参照時点の entitlement で出し分ける（無料なら端末側の既定文が使われる）。
+    def notification_message
+      instance_options[:custom_notification_messages] ? object.notification_message : nil
+    end
+
     def scheduled_time
       object.scheduled_time&.strftime('%H:%M')
     end

--- a/app/serializers/v2/shadow_swing_session_serializer.rb
+++ b/app/serializers/v2/shadow_swing_session_serializer.rb
@@ -1,5 +1,11 @@
 module V2
   class ShadowSwingSessionSerializer < ActiveModel::Serializer
-    attributes :id, :logged_on, :target_count, :swing_count, :completed_at, :practice_log_id
+    attributes :id, :logged_on, :target_count, :swing_count, :completed_at, :practice_log_id,
+               :interval_seconds, :vibration_enabled, :sound_enabled, :voice_enabled
+
+    # decimal のままだと JSON に文字列で出るため、クライアントがそのまま数値として扱えるようにする。
+    def interval_seconds
+      object.interval_seconds.to_f
+    end
   end
 end

--- a/app/services/activities/daily_activity_recalculator.rb
+++ b/app/services/activities/daily_activity_recalculator.rb
@@ -48,8 +48,11 @@ module Activities
 
     # その日の練習ログの distinct メニュー数。
     # メニュー削除済みでも menu_name スナップショットで識別する。
+    # amount が明示的に 0 のログは「やっていない」の記録なので活動に数えない
+    # （amount nil は数値を伴わないメニューの実施記録なので数える）。
     def practice_menu_count
       PracticeLog.where(user_id: @user_id, logged_on: @date)
+                 .where('amount IS NULL OR amount <> 0')
                  .distinct
                  .count(Arel.sql('COALESCE(practice_menu_id::text, menu_name)'))
     end

--- a/app/services/media_attachments/video_metadata_fetcher.rb
+++ b/app/services/media_attachments/video_metadata_fetcher.rb
@@ -65,7 +65,8 @@ module MediaAttachments
       return [nil, nil] if header.nil? || header.bytesize < 8
 
       size = header.unpack1('N')
-      return [size, 8] if size > 8
+      # 中身が空のボックス（size == 8）も規格上は正当なので、解析を打ち切らず読み飛ばす。
+      return [size, 8] if size >= 8
       return [nil, nil] unless size == 1 && header.bytesize >= BOX_HEADER_BYTES
 
       large_size = header.byteslice(8, 8).unpack1('Q>')

--- a/app/services/media_attachments/video_metadata_fetcher.rb
+++ b/app/services/media_attachments/video_metadata_fetcher.rb
@@ -1,0 +1,162 @@
+module MediaAttachments
+  # R2 上の実オブジェクトから動画の再生時間・解像度を読み取る。
+  #
+  # クライアント申告の duration_seconds / width / height は file_size_bytes と同様に改ざん可能で、
+  # そのまま無料枠判定に使うと長時間・高解像度の動画を「30秒 / 480p」と偽って保存できてしまう。
+  # ffprobe を導入するとイメージへの ffmpeg 同梱とファイル全体のダウンロードが必要になるため、
+  # MP4 / MOV（ISO BMFF）のヘッダだけを Range GET で取得して解析する。
+  #
+  # moov ボックスの位置は端末・エンコーダによって先頭にも末尾にも来るため、トップレベルの
+  # ボックスヘッダ（8〜16バイト）だけを辿って moov を探し、見つけたボックスの範囲のみ取得する。
+  # mdat 本体は一切ダウンロードしない。
+  class VideoMetadataFetcher
+    Metadata = Struct.new(:duration_seconds, :width, :height, keyword_init: true)
+
+    # 壊れた・想定外の構造のファイルで無限に Range GET を繰り返さないための保険。
+    MAX_TOP_LEVEL_BOXES = 32
+    # moov は長尺・多トラックでも通常は数百KB。極端に大きい値は解析対象外にする。
+    MAX_MOOV_BYTES = 16 * 1024 * 1024
+    # duration が未定義のとき全ビット 1 が入る仕様のため、非現実的な長さは解析失敗として扱う。
+    MAX_DURATION_SECONDS = 24 * 60 * 60
+    BOX_HEADER_BYTES = 16
+
+    def initialize(r2_key:)
+      @r2_key = r2_key
+    end
+
+    # @return [Metadata, nil] 解析できなかった場合は nil
+    def call
+      moov = fetch_moov
+      return nil if moov.nil?
+
+      duration = parse_duration(moov)
+      dimensions = parse_dimensions(moov)
+      return nil if duration.nil? || dimensions.nil?
+
+      Metadata.new(duration_seconds: duration, width: dimensions.first, height: dimensions.last)
+    rescue Aws::S3::Errors::NoSuchKey, Aws::S3::Errors::InvalidRange
+      nil
+    rescue Aws::S3::Errors::ServiceError => e
+      Sentry.capture_exception(e, tags: { source: 'video_metadata_fetcher' }, extra: { r2_key: @r2_key })
+      nil
+    end
+
+    private
+
+    # トップレベルのボックスを順に辿り、moov ボックスの中身を返す。
+    def fetch_moov
+      offset = 0
+      MAX_TOP_LEVEL_BOXES.times do
+        header = read_range(offset, offset + BOX_HEADER_BYTES - 1)
+        size, header_size = box_size(header)
+        return nil if size.nil?
+
+        return read_moov(offset + header_size, size - header_size) if header.byteslice(4, 4) == 'moov'
+
+        offset += size
+      end
+      nil
+    end
+
+    # size == 1 は 64bit largesize、size == 0 は「以降ファイル終端まで」を意味する。
+    # 後者は mdat が最後に置かれたケースで、その先にボックスは無いので解析を打ち切る。
+    # @return [Array(Integer, Integer), Array(nil, nil)] [ボックス全体のバイト数, ヘッダのバイト数]
+    def box_size(header)
+      return [nil, nil] if header.nil? || header.bytesize < 8
+
+      size = header.unpack1('N')
+      return [size, 8] if size > 8
+      return [nil, nil] unless size == 1 && header.bytesize >= BOX_HEADER_BYTES
+
+      large_size = header.byteslice(8, 8).unpack1('Q>')
+      large_size > BOX_HEADER_BYTES ? [large_size, BOX_HEADER_BYTES] : [nil, nil]
+    end
+
+    def read_moov(offset, length)
+      return nil if length <= 0 || length > MAX_MOOV_BYTES
+
+      body = read_range(offset, offset + length - 1)
+      body.bytesize == length ? body : nil
+    end
+
+    def read_range(from, to)
+      PresignedUrlService.client.get_object(
+        bucket: ENV.fetch('R2_BUCKET_NAME'),
+        key: @r2_key,
+        range: "bytes=#{from}-#{to}"
+      ).body.read.b
+    end
+
+    # mvhd の timescale / duration から秒数を求める。
+    # 端数は切り上げる（30.4秒の動画を 30秒として無料枠に通さない）。
+    def parse_duration(moov)
+      mvhd = find_box(moov, 'mvhd')
+      return nil if mvhd.nil? || mvhd.bytesize < 32
+
+      timescale, duration = mvhd.getbyte(0) == 1 ? mvhd.byteslice(20, 12).unpack('NQ>') : mvhd.byteslice(12, 8).unpack('N2')
+      return nil if timescale.nil? || timescale.zero? || duration.nil?
+
+      seconds = (duration.to_f / timescale).ceil
+      seconds <= MAX_DURATION_SECONDS ? seconds : nil
+    end
+
+    # 映像トラックの tkhd から表示サイズを求める。音声トラックは 0x0 なので自然に除外される。
+    # 複数の映像トラックがある場合は最大の解像度を採用する（上限判定を甘くしないため）。
+    def parse_dimensions(moov)
+      dimensions = each_box(moov).select { |type, _| type == 'trak' }
+                                 .filter_map { |_, trak| track_dimensions(trak) }
+      return nil if dimensions.empty?
+
+      [dimensions.map(&:first).max, dimensions.map(&:last).max]
+    end
+
+    def track_dimensions(trak)
+      tkhd = find_box(trak, 'tkhd')
+      return nil if tkhd.nil?
+
+      # version + flags(4) + creation/modification/track_ID/reserved/duration + reserved(8) + layer〜volume(8)
+      matrix_offset = tkhd.getbyte(0) == 1 ? 52 : 40
+      width, height = display_size(tkhd.byteslice(matrix_offset + 36, 8))
+      return nil if width.nil?
+
+      rotated?(tkhd.byteslice(matrix_offset, 36)) ? [height, width] : [width, height]
+    end
+
+    # tkhd の width / height は 16.16 固定小数点。0x0 は映像を持たないトラック（音声など）。
+    def display_size(bytes)
+      width, height = bytes&.unpack('N2')
+      return nil if width.nil? || height.nil?
+
+      width /= 65_536
+      height /= 65_536
+      [width, height] unless width.zero? || height.zero?
+    end
+
+    # 表示マトリクスが 90 / 270 度回転（a=d=0, b・c が非ゼロ）なら、tkhd の width / height は
+    # 回転前の値なので入れ替える。縦持ち撮影の動画でクライアント申告値と揃える。
+    def rotated?(matrix)
+      return false if matrix.nil? || matrix.bytesize < 36
+
+      a, b, _u, c, d = matrix.unpack('l>5')
+      a.zero? && d.zero? && !b.zero? && !c.zero?
+    end
+
+    def find_box(container, target_type)
+      each_box(container).find { |type, _| type == target_type }&.last
+    end
+
+    # コンテナ直下のボックスを [type, payload] として列挙する。
+    def each_box(container)
+      Enumerator.new do |yielder|
+        offset = 0
+        while offset + 8 <= container.bytesize
+          size, header_size = box_size(container.byteslice(offset, BOX_HEADER_BYTES))
+          break if size.nil? || offset + size > container.bytesize
+
+          yielder << [container.byteslice(offset + 4, 4), container.byteslice(offset + header_size, size - header_size)]
+          offset += size
+        end
+      end
+    end
+  end
+end

--- a/app/services/revenue_cat/handlers/base_handler.rb
+++ b/app/services/revenue_cat/handlers/base_handler.rb
@@ -49,6 +49,28 @@ module RevenueCat
         after_unlock.each(&:call)
       end
 
+      # RevenueCat Webhook の到達順序は保証されない。解約→解約撤回のように短時間で
+      # 状態が往復すると、後発イベントを適用した後に先発イベントが遅れて届き、
+      # 無条件に上書きする handler は有効な状態を巻き戻してしまう（誤った通知メールも飛ぶ）。
+      #
+      # RenewalHandler / ExpirationHandler は expires_at という「イベント固有の比較軸」を
+      # 持つためそれで判定できるが、CANCELLATION / UNCANCELLATION / BILLING_ISSUE は
+      # expires_at を変えないため比較軸がない。そこで監査ログ（UserSubscriptionEvent）の
+      # occurred_at 最大値を「適用済みイベント時刻」のマーカーとして使う。
+      #
+      # 同時刻は再配信の冪等な再適用とみなし stale としない。
+      # event_timestamp を持たない payload はマーカーと比較できないため素通しする。
+      #
+      # @param user [User]
+      # @return [Boolean] 適用済みより古いイベントなら true
+      def stale_event?(user)
+        event_at = payload.event_timestamp
+        return false if event_at.blank?
+
+        latest_applied_at = user.user_subscription_events.maximum(:occurred_at)
+        latest_applied_at.present? && event_at < latest_applied_at
+      end
+
       private
 
       # PlanCatalog に未登録の product_id / store が来ると plan_type: nil 等で silent に

--- a/app/services/revenue_cat/handlers/base_handler.rb
+++ b/app/services/revenue_cat/handlers/base_handler.rb
@@ -3,6 +3,9 @@ module RevenueCat
     # 全 event handler の共通基底。user lookup と subscription 取得の共通フローを提供する。
     # 各サブクラスは `call` だけ実装し、本処理を `with_resolved_subscription` ブロックで包む。
     class BaseHandler
+      # stale_event? の比較対象。加入の有効／無効が往復しうるイベントだけを並べる。
+      ORDERING_SENSITIVE_EVENT_TYPES = %w[cancelled uncancelled billing_issue renewed recovered expired refunded].freeze
+
       def initialize(payload)
         @payload = payload
         @event_recorder = SubscriptionEventRecorder.new(payload)
@@ -58,6 +61,11 @@ module RevenueCat
       # expires_at を変えないため比較軸がない。そこで監査ログ（UserSubscriptionEvent）の
       # occurred_at 最大値を「適用済みイベント時刻」のマーカーとして使う。
       #
+      # マーカーは加入状態の遷移を表すイベントに限る。initial_purchase / trial_started /
+      # purchased / product_changed は解約状態と競合せず、これらを含めると
+      # 「プラン変更が先に処理され、実際には先行していた解約が遅れて届く」ケースで
+      # 正当な解約を stale と誤判定してしまう。
+      #
       # 同時刻は再配信の冪等な再適用とみなし stale としない。
       # event_timestamp を持たない payload はマーカーと比較できないため素通しする。
       #
@@ -67,7 +75,9 @@ module RevenueCat
         event_at = payload.event_timestamp
         return false if event_at.blank?
 
-        latest_applied_at = user.user_subscription_events.maximum(:occurred_at)
+        latest_applied_at = user.user_subscription_events
+                                .where(event_type: ORDERING_SENSITIVE_EVENT_TYPES)
+                                .maximum(:occurred_at)
         latest_applied_at.present? && event_at < latest_applied_at
       end
 

--- a/app/services/revenue_cat/handlers/billing_issue_handler.rb
+++ b/app/services/revenue_cat/handlers/billing_issue_handler.rb
@@ -1,9 +1,13 @@
 module RevenueCat
   module Handlers
     # BILLING_ISSUE は課金失敗。Grace Period 中は Pro 機能利用可なので expires_at は変えない。
+    # 決済復旧（RENEWAL）の後に遅延した BILLING_ISSUE が届くと正常課金中のユーザーへ
+    # 誤って督促通知が飛ぶため、適用済みより古いイベントは捨てる。
     class BillingIssueHandler < BaseHandler
       def call
         with_resolved_subscription do |user, subscription, after_unlock|
+          next if stale_event?(user)
+
           # Job リトライによる時刻ズレを避けるため、billing_issue_at は Webhook payload のイベント時刻を採用する。
           subscription.update!(
             status: 'billing_issue',

--- a/app/services/revenue_cat/handlers/cancellation_handler.rb
+++ b/app/services/revenue_cat/handlers/cancellation_handler.rb
@@ -1,9 +1,13 @@
 module RevenueCat
   module Handlers
     # CANCELLATION は解約申請。期限まで Pro 機能利用可なので expires_at は変えない。
+    # 解約撤回（UNCANCELLATION）との到達順序が逆転すると有効な課金を cancelled へ
+    # 巻き戻すため、適用済みより古いイベントは捨てる。
     class CancellationHandler < BaseHandler
       def call
         with_resolved_subscription do |user, subscription, after_unlock|
+          next if stale_event?(user)
+
           # Job リトライによる時刻ズレを避けるため、cancelled_at は Webhook payload のイベント時刻を採用する。
           subscription.update!(
             status: 'cancelled',

--- a/app/services/revenue_cat/handlers/uncancellation_handler.rb
+++ b/app/services/revenue_cat/handlers/uncancellation_handler.rb
@@ -1,9 +1,12 @@
 module RevenueCat
   module Handlers
     # UNCANCELLATION は「自動更新 ON に戻す」操作。cancelled でないときは何もしない（冪等性）。
+    # 再解約（CANCELLATION）との到達順序が逆転したときに解約状態を active へ戻さないよう、
+    # 適用済みより古いイベントは捨てる。
     class UncancellationHandler < BaseHandler
       def call
         with_resolved_subscription do |user, subscription|
+          next if stale_event?(user)
           next unless subscription.cancelled?
 
           subscription.update!(status: 'active', cancelled_at: nil, last_synced_at: Time.current)

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -24,3 +24,6 @@ production:
   finalize_goals:
     class: FinalizeGoalsJob
     schedule: every day at 12:10am
+  purge_stale_media_attachments:
+    class: PurgeStaleMediaAttachmentsJob
+    schedule: every day at 4am

--- a/db/migrate/20260802010001_add_settings_to_shadow_swing_sessions.rb
+++ b/db/migrate/20260802010001_add_settings_to_shadow_swing_sessions.rb
@@ -1,0 +1,8 @@
+class AddSettingsToShadowSwingSessions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :shadow_swing_sessions, :interval_seconds, :decimal, precision: 4, scale: 1, null: false, default: 5.0
+    add_column :shadow_swing_sessions, :vibration_enabled, :boolean, null: false, default: false
+    add_column :shadow_swing_sessions, :sound_enabled, :boolean, null: false, default: true
+    add_column :shadow_swing_sessions, :voice_enabled, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20260802010002_preserve_goal_badges_on_goal_deletion.rb
+++ b/db/migrate/20260802010002_preserve_goal_badges_on_goal_deletion.rb
@@ -1,0 +1,21 @@
+class PreserveGoalBadgesOnGoalDeletion < ActiveRecord::Migration[7.1]
+  # バッジは「達成の記念」として恒久保存する想定だが、元の目標を削除すると
+  # dependent: :destroy で一緒に消えていた。goal_id を nullify できるようにし、
+  # 目標が消えても一覧に出せるよう表示名をスナップショットする。
+  def up
+    add_column :goal_badges, :goal_title, :string
+    execute <<~SQL.squish
+      UPDATE goal_badges
+      SET goal_title = goals.title
+      FROM goals
+      WHERE goal_badges.goal_id = goals.id
+    SQL
+    change_column_null :goal_badges, :goal_title, false
+    change_column_null :goal_badges, :goal_id, true
+  end
+
+  def down
+    change_column_null :goal_badges, :goal_id, false
+    remove_column :goal_badges, :goal_title
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_07_21_150618) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_02_010002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -261,12 +261,13 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_21_150618) do
 
   create_table "goal_badges", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.bigint "goal_id", null: false
+    t.bigint "goal_id"
     t.string "badge_type", null: false
     t.string "badge_name", null: false
     t.datetime "awarded_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "goal_title", null: false
     t.index ["goal_id"], name: "index_goal_badges_on_goal_id"
     t.index ["user_id"], name: "index_goal_badges_on_user_id"
   end
@@ -794,6 +795,10 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_21_150618) do
     t.bigint "practice_log_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.decimal "interval_seconds", precision: 4, scale: 1, default: "5.0", null: false
+    t.boolean "vibration_enabled", default: false, null: false
+    t.boolean "sound_enabled", default: true, null: false
+    t.boolean "voice_enabled", default: false, null: false
     t.index ["practice_log_id"], name: "index_shadow_swing_sessions_on_practice_log_id"
     t.index ["user_id", "logged_on"], name: "index_shadow_swing_sessions_on_user_id_and_logged_on"
     t.index ["user_id"], name: "index_shadow_swing_sessions_on_user_id"

--- a/spec/factories/goal_badges.rb
+++ b/spec/factories/goal_badges.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     goal
     badge_type { 'monthly_achieved' }
     badge_name { '月間目標達成' }
+    goal_title { goal&.title || '目標' }
     awarded_at { Time.current }
   end
 end

--- a/spec/jobs/purge_stale_media_attachments_job_spec.rb
+++ b/spec/jobs/purge_stale_media_attachments_job_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe PurgeStaleMediaAttachmentsJob do
+  let(:user) { create(:user) }
+  let(:note) { create(:baseball_note, user:) }
+
+  describe '#perform' do
+    it '猶予を過ぎた pending / failed を削除し、R2 オブジェクトの削除も予約する' do
+      stale_pending = create(:media_attachment, user:, baseball_note: note, created_at: 25.hours.ago)
+      stale_failed = create(:media_attachment, user:, baseball_note: note, status: 'failed', created_at: 25.hours.ago)
+
+      expect { described_class.perform_now }.to change(MediaAttachment, :count).by(-2)
+      expect(MediaAttachment.where(id: [stale_pending.id, stale_failed.id])).to be_empty
+      expect(MediaAttachmentDeletionJob).to have_been_enqueued.twice
+    end
+
+    it 'アップロード中かもしれない直近の pending は残す' do
+      recent = create(:media_attachment, user:, baseball_note: note, created_at: 10.minutes.ago)
+
+      expect { described_class.perform_now }.not_to change(MediaAttachment, :count)
+      expect(recent.reload).to be_persisted
+    end
+
+    it '完了済み（ready）は古くても消さない' do
+      create(:media_attachment, :ready, user:, baseball_note: note, created_at: 1.year.ago)
+
+      expect { described_class.perform_now }.not_to change(MediaAttachment, :count)
+    end
+  end
+end

--- a/spec/requests/api/v2/goal_badges_spec.rb
+++ b/spec/requests/api/v2/goal_badges_spec.rb
@@ -37,5 +37,20 @@ RSpec.describe 'Api::V2::GoalBadges', type: :request do
       get('/api/v2/goal_badges', headers:)
       expect(response.parsed_body.first['goal_title']).to eq('今月20日練習')
     end
+
+    # バッジは達成の記念として恒久保存する。元の目標を消しても失われてはいけない。
+    context '元になった目標が削除されたとき' do
+      it 'バッジは残り、付与時のタイトルを表示できる' do
+        goal = create(:goal, user:, title: '今月20日練習')
+        create(:goal_badge, user:, goal:)
+
+        goal.destroy!
+
+        get('/api/v2/goal_badges', headers:)
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body.size).to eq(1)
+        expect(response.parsed_body.first).to include('goal_id' => nil, 'goal_title' => '今月20日練習')
+      end
+    end
   end
 end

--- a/spec/requests/api/v2/goals_spec.rb
+++ b/spec/requests/api/v2/goals_spec.rb
@@ -286,5 +286,25 @@ RSpec.describe 'Api::V2::Goals', type: :request do
       expect(goal.reload.is_finalized).to be(true)
       expect(goal.is_achieved).to be(true)
     end
+
+    it 'バッジに目標タイトルをスナップショットする' do
+      create(:goal, user:, title: '今月20日練習', deadline: today - 1, target_value: 1, metric_key: 'practice_days',
+                    month_start: (today - 1).beginning_of_month)
+      create(:activity_log, user:, activity_date: today - 1, intensity_level: 2)
+
+      FinalizeGoalsJob.new.perform
+      expect(user.goal_badges.last.goal_title).to eq('今月20日練習')
+    end
+
+    # 定性目標はユーザーが達成ボタンを押した時刻が achieved_at に入っているため、
+    # 確定ジョブの実行時刻（深夜バッチ）で塗り潰さない。
+    it '達成済みの achieved_at をジョブ実行時刻で上書きしない' do
+      achieved_at = Time.zone.parse('2026-07-15 21:30 JST')
+      goal = create(:goal, user:, kind: 'qualitative', target_value: nil, deadline: today - 1,
+                           month_start: (today - 1).beginning_of_month, is_achieved: true, achieved_at:)
+
+      FinalizeGoalsJob.new.perform
+      expect(goal.reload.achieved_at).to be_within(1.second).of(achieved_at)
+    end
   end
 end

--- a/spec/requests/api/v2/media_attachments_spec.rb
+++ b/spec/requests/api/v2/media_attachments_spec.rb
@@ -19,8 +19,17 @@ RSpec.describe 'Api::V2::MediaAttachments', type: :request do
         .and_return(instance_double(Aws::S3::Types::HeadObjectOutput, content_length:))
     end
 
-    def complete(attachment, params, headers: auth_headers_for(user), actual_size: params[:file_size_bytes])
+    # 動画のduration/解像度はR2上の実ファイルから読み直されるため、既定では
+    # 申告値と一致する動画が置かれているものとしてスタブする。改ざんのテストでは
+    # actual_video に実ファイル側の値を渡して申告値と食い違わせる。
+    def complete(attachment, params, headers: auth_headers_for(user), actual_size: params[:file_size_bytes],
+                 actual_video: params)
       stub_r2_head_object(content_length: actual_size) if actual_size
+      if attachment.media_type == 'video'
+        stub_r2_video_object(build_mp4(duration_seconds: actual_video[:duration_seconds] || 0,
+                                       width: actual_video[:width] || 640,
+                                       height: actual_video[:height] || 480))
+      end
       patch "/api/v2/media_attachments/#{attachment.id}", params: { media_attachment: params }, headers:
     end
 
@@ -73,6 +82,29 @@ RSpec.describe 'Api::V2::MediaAttachments', type: :request do
       expect(response).to have_http_status(:unprocessable_entity)
       expect(image_attachment.reload.status).to eq 'failed'
       expect(image_attachment.file_size_bytes).to eq 8_000_000
+    end
+
+    it 'ignores spoofed video duration and resolution and validates against the real R2 object' do
+      # 3分/1080pの動画を「10秒/480p」と偽っても、R2上の実ファイルのヘッダで検証される。
+      complete(attachment,
+               { duration_seconds: 10, width: 640, height: 480, file_size_bytes: 8_000_000 },
+               actual_video: { duration_seconds: 180, width: 1920, height: 1080 })
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(attachment.reload).to have_attributes(status: 'failed', duration_seconds: 180, height: 1080)
+    end
+
+    it 'marks as failed when the uploaded video cannot be parsed' do
+      stub_r2_head_object(content_length: 8_000_000)
+      allow(MediaAttachments::PresignedUrlService.client).to receive(:get_object)
+        .and_return(instance_double(Aws::S3::Types::GetObjectOutput, body: StringIO.new('not a video')))
+
+      patch "/api/v2/media_attachments/#{attachment.id}",
+            params: { media_attachment: { duration_seconds: 10, width: 640, height: 480, file_size_bytes: 8_000_000 } },
+            headers: auth_headers_for(user)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(attachment.reload.status).to eq 'failed'
     end
 
     it 'marks as failed when the object cannot be found on R2' do

--- a/spec/requests/api/v2/menu_sets_spec.rb
+++ b/spec/requests/api/v2/menu_sets_spec.rb
@@ -80,6 +80,23 @@ RSpec.describe 'Api::V2::MenuSets', type: :request do
       expect(body['name']).to eq('新')
       expect(body['items'].size).to eq(1)
     end
+
+    # items の差し替えは destroy_all → build → save の順で走るため、save が失敗すると
+    # 既存アイテムだけが消えた状態が残りうる。ロールバックされることを保証する。
+    it 'バリデーション失敗時に既存の items を巻き戻す' do
+      menu_set = create(:menu_set, user:, name: '旧')
+      menu = create(:practice_menu, user:)
+      existing_menu = create(:practice_menu, user:)
+      menu_set.menu_set_items.create!(practice_menu: existing_menu, target_value: 10, sort_order: 0)
+
+      patch "/api/v2/menu_sets/#{menu_set.id}",
+            params: { menu_set: { name: 'あ' * 51, items: [{ practice_menu_id: menu.id, target_value: 50 }] } },
+            headers: auth_headers_for(user)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(menu_set.reload.name).to eq('旧')
+      expect(menu_set.menu_set_items.pluck(:practice_menu_id)).to eq([existing_menu.id])
+    end
   end
 
   describe 'DELETE /api/v2/menu_sets/:id' do

--- a/spec/requests/api/v2/schedules/week_copies_spec.rb
+++ b/spec/requests/api/v2/schedules/week_copies_spec.rb
@@ -15,6 +15,18 @@ RSpec.describe 'Api::V2::Schedules::WeekCopies', type: :request do
       end
     end
 
+    # 週コピー自体が Pro 限定機能のため、複製結果からカスタム通知文が落ちてはいけない。
+    it 'Proユーザーの複製結果にカスタム通知文を含める' do
+      make_pro(user)
+      create(:schedule, user:, title: '朝練', days_of_week: nil, planned_on: '2026-07-06',
+                        scheduled_time: '06:00', notification_message: '頑張れ')
+
+      post '/api/v2/schedules/week_copy', params: { week_start: '2026-07-06' }, headers: auth_headers_for(user)
+
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body.first['notification_message']).to eq('頑張れ')
+    end
+
     it '無料ユーザーは403（Pro限定機能）' do
       create(:schedule, user:, title: '朝練', days_of_week: nil, planned_on: '2026-07-06', scheduled_time: '06:00')
       post '/api/v2/schedules/week_copy', params: { week_start: '2026-07-06' }, headers: auth_headers_for(user)

--- a/spec/requests/api/v2/schedules_spec.rb
+++ b/spec/requests/api/v2/schedules_spec.rb
@@ -75,6 +75,16 @@ RSpec.describe 'Api::V2::Schedules', type: :request do
         post '/api/v2/schedules', params: custom_params, headers: auth_headers_for(user)
         expect(response.parsed_body['notification_message']).to eq('頑張れ')
       end
+
+      # 解約しても DB には過去に設定した通知文が残るため、参照時点の entitlement で出し分ける。
+      it 'Pro 期間中に設定した通知文は、解約後は返さない' do
+        make_pro(user)
+        post '/api/v2/schedules', params: custom_params, headers: auth_headers_for(user)
+        user.subscription.update!(status: 'expired', expires_at: 1.day.ago)
+
+        get '/api/v2/schedules', headers: auth_headers_for(user)
+        expect(response.parsed_body.first['notification_message']).to be_nil
+      end
     end
   end
 

--- a/spec/requests/api/v2/shadow_swing_sessions_spec.rb
+++ b/spec/requests/api/v2/shadow_swing_sessions_spec.rb
@@ -20,6 +20,48 @@ RSpec.describe 'Api::V2::ShadowSwingSessions', type: :request do
       expect(response).to have_http_status(:created)
       expect(response.parsed_body['target_count']).to eq(200)
     end
+
+    # クライアントのロック表示は直接 API を叩けば回避できるため、サーバー側で弾く。
+    context 'Pro 限定の設定を無料ユーザーが指定したとき' do
+      it '無料枠外のインターバルを 422 で拒否する' do
+        post '/api/v2/shadow_swing_sessions',
+             params: { shadow_swing_session: { target_count: 200, interval_seconds: 1.0 } },
+             headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(user.shadow_swing_sessions).to be_empty
+      end
+
+      it 'バイブレーションの有効化を 422 で拒否する' do
+        post '/api/v2/shadow_swing_sessions',
+             params: { shadow_swing_session: { target_count: 200, interval_seconds: 5.0, vibration_enabled: true } },
+             headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it '無料枠内のインターバルは受け付ける' do
+        post '/api/v2/shadow_swing_sessions',
+             params: { shadow_swing_session: { target_count: 200, interval_seconds: 10.0 } },
+             headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body['interval_seconds']).to eq(10.0)
+      end
+    end
+
+    context 'Pro ユーザーのとき' do
+      before { user.subscription.update!(status: 'active', expires_at: 30.days.from_now) }
+
+      it '全範囲のインターバルとバイブレーションを保存して返す' do
+        post '/api/v2/shadow_swing_sessions',
+             params: { shadow_swing_session: { target_count: 200, interval_seconds: 1.0, vibration_enabled: true } },
+             headers: auth_headers_for(user)
+
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body).to include('interval_seconds' => 1.0, 'vibration_enabled' => true)
+      end
+    end
   end
 
   describe 'POST /api/v2/shadow_swing_sessions/:id/complete' do
@@ -55,6 +97,29 @@ RSpec.describe 'Api::V2::ShadowSwingSessions', type: :request do
            headers: auth_headers_for(user)
 
       expect(user.activity_logs.find_by(activity_date: today).total_swing_count).to eq(150)
+    end
+
+    # 開始してすぐ「終了」を押すだけで草・Streak を水増しできてしまうのを防ぐ。
+    context '0本で完了したとき' do
+      it '練習ログを作らず、当日を活動ありにしない' do
+        expect do
+          post "/api/v2/shadow_swing_sessions/#{session.id}/complete",
+               params: { shadow_swing_session: { swing_count: 0 } },
+               headers: auth_headers_for(user)
+        end.not_to(change { user.practice_logs.count })
+
+        expect(response).to have_http_status(:ok)
+        expect(user.activity_logs.find_by(activity_date: today)).to be_nil
+      end
+
+      it 'セッション自体は完了扱いにする（開始したまま残さない）' do
+        post "/api/v2/shadow_swing_sessions/#{session.id}/complete",
+             params: { shadow_swing_session: { swing_count: 0 } },
+             headers: auth_headers_for(user)
+
+        expect(session.reload).to have_attributes(swing_count: 0, practice_log_id: nil)
+        expect(session.completed_at).to be_present
+      end
     end
   end
 

--- a/spec/services/activities/daily_activity_recalculator_spec.rb
+++ b/spec/services/activities/daily_activity_recalculator_spec.rb
@@ -90,6 +90,21 @@ RSpec.describe Activities::DailyActivityRecalculator do
       end
     end
 
+    context '他ユーザー・他日付の練習ログが同居しているとき' do
+      before do
+        create(:practice_log, user:, practice_menu: create(:practice_menu, user:), logged_on: today, amount: 10)
+
+        other_user = create(:user)
+        create(:practice_log, user: other_user, practice_menu: create(:practice_menu, user: other_user),
+                              logged_on: today, amount: 10)
+        create(:practice_log, user:, practice_menu: create(:practice_menu, user:), logged_on: today - 1, amount: 10)
+      end
+
+      it '対象ユーザー・対象日のメニューだけを数える' do
+        expect(recalc.practice_menu_count).to eq(1)
+      end
+    end
+
     context 'コンディションのみ記録した日' do
       before { create(:condition_log, user:, logged_on: today) }
 

--- a/spec/services/activities/daily_activity_recalculator_spec.rb
+++ b/spec/services/activities/daily_activity_recalculator_spec.rb
@@ -72,6 +72,24 @@ RSpec.describe Activities::DailyActivityRecalculator do
       end
     end
 
+    # 素振り0本のような「量ゼロ」のログを1メニュー分の活動として数えると、
+    # 実際には何もしていない日が草・Streak に載ってしまう。
+    context 'amount 0 の練習ログだけがある日' do
+      before { create(:practice_log, user:, practice_menu: create(:practice_menu, user:), logged_on: today, amount: 0) }
+
+      it '活動としてカウントしない（activity_log は作られない）' do
+        expect(recalc).to be_nil
+      end
+    end
+
+    context 'amount 未入力の練習ログがある日' do
+      before { create(:practice_log, user:, practice_menu: create(:practice_menu, user:), logged_on: today, amount: nil) }
+
+      it '数値を伴わないメニューの実施として活動にカウントする' do
+        expect(recalc.practice_menu_count).to eq(1)
+      end
+    end
+
     context 'コンディションのみ記録した日' do
       before { create(:condition_log, user:, logged_on: today) }
 

--- a/spec/services/media_attachments/video_metadata_fetcher_spec.rb
+++ b/spec/services/media_attachments/video_metadata_fetcher_spec.rb
@@ -43,6 +43,16 @@ RSpec.describe MediaAttachments::VideoMetadataFetcher do
     end
   end
 
+  context '中身が空のボックスが挟まっているとき' do
+    before do
+      stub_r2_video_object(build_mp4(duration_seconds: 10, width: 640, height: 480, empty_box: true))
+    end
+
+    it '読み飛ばして解析を続ける' do
+      expect(metadata).to have_attributes(duration_seconds: 10, width: 640, height: 480)
+    end
+  end
+
   context 'MP4 として解析できないファイルのとき' do
     before { stub_r2_video_object('this is not a video'.b * 8) }
 

--- a/spec/services/media_attachments/video_metadata_fetcher_spec.rb
+++ b/spec/services/media_attachments/video_metadata_fetcher_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe MediaAttachments::VideoMetadataFetcher do
+  subject(:metadata) { described_class.new(r2_key: 'user/1/video.mp4').call }
+
+  context 'moov が先頭側にあるとき（iOS の faststart 配置）' do
+    before { stub_r2_video_object(build_mp4(duration_seconds: 42, width: 1920, height: 1080)) }
+
+    it '実ファイルの再生時間と解像度を返す' do
+      expect(metadata).to have_attributes(duration_seconds: 42, width: 1920, height: 1080)
+    end
+  end
+
+  context 'moov が mdat の後ろにあるとき（Android の典型配置）' do
+    before { stub_r2_video_object(build_mp4(duration_seconds: 12, width: 640, height: 480, moov_last: true)) }
+
+    it 'mdat を読み飛ばして解析できる' do
+      expect(metadata).to have_attributes(duration_seconds: 12, width: 640, height: 480)
+    end
+  end
+
+  context '再生時間に端数があるとき' do
+    before { stub_r2_video_object(build_mp4(duration_seconds: 30.4, width: 640, height: 480)) }
+
+    it '切り上げて返す（上限ぴったりに丸めて無料枠を通さない）' do
+      expect(metadata.duration_seconds).to eq 31
+    end
+  end
+
+  context '縦持ち撮影で90度回転のマトリクスが入っているとき' do
+    before { stub_r2_video_object(build_mp4(duration_seconds: 10, width: 1920, height: 1080, rotated: true)) }
+
+    it '表示サイズに合わせて幅と高さを入れ替える' do
+      expect(metadata).to have_attributes(width: 1080, height: 1920)
+    end
+  end
+
+  context '音声トラックを含むとき' do
+    before { stub_r2_video_object(build_mp4(duration_seconds: 10, width: 1280, height: 720, audio_track: true)) }
+
+    it '0x0 の音声トラックではなく映像トラックの解像度を返す' do
+      expect(metadata).to have_attributes(width: 1280, height: 720)
+    end
+  end
+
+  context 'MP4 として解析できないファイルのとき' do
+    before { stub_r2_video_object('this is not a video'.b * 8) }
+
+    it 'nil を返す' do
+      expect(metadata).to be_nil
+    end
+  end
+
+  context 'moov ボックスが存在しないとき' do
+    before { stub_r2_video_object(build_mp4(duration_seconds: 10, width: 640, height: 480).sub('moov', 'free')) }
+
+    it 'nil を返す' do
+      expect(metadata).to be_nil
+    end
+  end
+
+  context 'R2 にオブジェクトが無いとき' do
+    before do
+      allow(MediaAttachments::PresignedUrlService.client).to receive(:get_object)
+        .and_raise(Aws::S3::Errors::NoSuchKey.new(nil, 'no such key'))
+    end
+
+    it 'nil を返す' do
+      expect(metadata).to be_nil
+    end
+  end
+end

--- a/spec/services/revenue_cat/webhook_processor_spec.rb
+++ b/spec/services/revenue_cat/webhook_processor_spec.rb
@@ -564,6 +564,125 @@ RSpec.describe RevenueCat::WebhookProcessor do
       end
     end
 
+    # RevenueCat は Webhook の到達順序を保証しない。短時間で状態が往復する操作
+    # （解約→解約撤回、課金失敗→復旧）で先発イベントが遅れて届いても、
+    # 適用済みの新しい状態を巻き戻さないことを結合で確認する。
+    context 'Webhook が順序逆転して届いたとき' do
+      let(:user) { create(:user) }
+
+      # 指定 payload を webhook_event 経由で処理する。順序逆転の再現に使う。
+      def process_payload(payload)
+        webhook_event = create(:webhook_event,
+                               provider: 'revenuecat',
+                               external_event_id: payload['event']['id'],
+                               event_type: payload['event']['type'],
+                               payload:)
+        described_class.new(webhook_event).process
+      end
+
+      before do
+        user.subscription.update!(
+          status: 'active',
+          plan_type: 'monthly',
+          platform: 'ios',
+          product_id: 'jp.buzzbase.mobile.pro.monthly',
+          revenuecat_user_id: user.id.to_s,
+          has_used_trial: true,
+          started_at: 30.days.ago,
+          expires_at: 30.days.from_now
+        )
+      end
+
+      context 'UNCANCELLATION の後に古い CANCELLATION が届いたとき' do
+        let(:uncancellation_at) { Time.zone.parse('2026-06-20 10:00 JST') }
+        let(:stale_cancellation_at) { uncancellation_at - 1.hour }
+
+        before do
+          user.subscription.update!(status: 'cancelled', cancelled_at: 2.days.ago)
+          process_payload(revenuecat_payload_for('uncancellation', user:,
+                                                                   event_timestamp_ms: uncancellation_at.to_i * 1000))
+        end
+
+        it 'active のまま巻き戻さない' do
+          allow(SubscriptionCancelledNotificationJob).to receive(:perform_now)
+
+          process_payload(revenuecat_payload_for('cancellation', user:,
+                                                                 event_timestamp_ms: stale_cancellation_at.to_i * 1000))
+
+          subscription = user.reload.subscription
+          expect(subscription.status).to eq('active')
+          expect(subscription.cancelled_at).to be_nil
+        end
+
+        it '誤った解約受付メールを送らない' do
+          allow(SubscriptionCancelledNotificationJob).to receive(:perform_now)
+
+          process_payload(revenuecat_payload_for('cancellation', user:,
+                                                                 event_timestamp_ms: stale_cancellation_at.to_i * 1000))
+
+          expect(SubscriptionCancelledNotificationJob).not_to have_received(:perform_now)
+        end
+      end
+
+      context 'RENEWAL による復旧の後に古い BILLING_ISSUE が届いたとき' do
+        let(:renewal_at) { Time.zone.parse('2026-06-20 10:00 JST') }
+        let(:stale_billing_issue_at) { renewal_at - 1.hour }
+
+        before do
+          user.subscription.update!(status: 'billing_issue', billing_issue_at: 2.days.ago)
+          process_payload(revenuecat_payload_for('renewal', user:,
+                                                            event_timestamp_ms: renewal_at.to_i * 1000,
+                                                            expiration_at_ms: 60.days.from_now.to_i * 1000))
+        end
+
+        it 'active のまま billing_issue に戻さず、督促通知も送らない' do
+          allow(BillingIssueNotificationJob).to receive(:perform_now)
+
+          process_payload(revenuecat_payload_for('billing_issue', user:,
+                                                                  event_timestamp_ms: stale_billing_issue_at.to_i * 1000))
+
+          expect(user.reload.subscription.status).to eq('active')
+          expect(BillingIssueNotificationJob).not_to have_received(:perform_now)
+        end
+      end
+
+      context 'CANCELLATION の後に古い UNCANCELLATION が届いたとき' do
+        let(:cancellation_at) { Time.zone.parse('2026-06-20 10:00 JST') }
+        let(:stale_uncancellation_at) { cancellation_at - 1.hour }
+
+        before do
+          allow(SubscriptionCancelledNotificationJob).to receive(:perform_now)
+          process_payload(revenuecat_payload_for('cancellation', user:,
+                                                                 event_timestamp_ms: cancellation_at.to_i * 1000))
+        end
+
+        it 'cancelled のまま active へ戻さない' do
+          process_payload(revenuecat_payload_for('uncancellation', user:,
+                                                                   event_timestamp_ms: stale_uncancellation_at.to_i * 1000))
+
+          subscription = user.reload.subscription
+          expect(subscription.status).to eq('cancelled')
+          expect(subscription.cancelled_at).to be_within(1.second).of(cancellation_at)
+        end
+      end
+
+      context '正しい順序で届いたとき' do
+        let(:cancellation_at) { Time.zone.parse('2026-06-20 10:00 JST') }
+
+        it 'ガードは後発イベントの適用を妨げない' do
+          allow(SubscriptionCancelledNotificationJob).to receive(:perform_now)
+          process_payload(revenuecat_payload_for('cancellation', user:,
+                                                                 event_timestamp_ms: cancellation_at.to_i * 1000))
+          process_payload(revenuecat_payload_for('uncancellation', user:,
+                                                                   event_timestamp_ms: (cancellation_at + 1.hour).to_i * 1000))
+
+          subscription = user.reload.subscription
+          expect(subscription.status).to eq('active')
+          expect(subscription.cancelled_at).to be_nil
+        end
+      end
+    end
+
     context '未知の event_type を受信したとき' do
       let(:payload) do
         {

--- a/spec/services/revenue_cat/webhook_processor_spec.rb
+++ b/spec/services/revenue_cat/webhook_processor_spec.rb
@@ -681,6 +681,29 @@ RSpec.describe RevenueCat::WebhookProcessor do
           expect(subscription.cancelled_at).to be_nil
         end
       end
+
+      # プラン変更は解約状態と競合しないため、順序判定のマーカーに含めてはいけない。
+      context 'PRODUCT_CHANGE の後に、それより古い CANCELLATION が遅れて届いたとき' do
+        let(:product_change_at) { Time.zone.parse('2026-06-20 10:00 JST') }
+        let(:delayed_cancellation_at) { product_change_at - 1.hour }
+
+        before do
+          process_payload(revenuecat_payload_for('product_change', user:,
+                                                                   event_timestamp_ms: product_change_at.to_i * 1000))
+        end
+
+        it '解約を stale 扱いせず適用し、解約受付メールも送る' do
+          allow(SubscriptionCancelledNotificationJob).to receive(:perform_now)
+
+          process_payload(revenuecat_payload_for('cancellation', user:,
+                                                                 event_timestamp_ms: delayed_cancellation_at.to_i * 1000))
+
+          subscription = user.reload.subscription
+          expect(subscription.status).to eq('cancelled')
+          expect(subscription.cancelled_at).to be_within(1.second).of(delayed_cancellation_at)
+          expect(SubscriptionCancelledNotificationJob).to have_received(:perform_now).with(user.id)
+        end
+      end
     end
 
     context '未知の event_type を受信したとき' do

--- a/spec/support/mp4_builder.rb
+++ b/spec/support/mp4_builder.rb
@@ -9,20 +9,25 @@ module Mp4Builder
   # @param duration_seconds [Numeric] mvhd に書き込む再生時間
   # @param width [Integer] tkhd の表示幅（回転時は入れ替え前の値）
   # @param height [Integer] tkhd の表示高さ
-  # @param timescale [Integer] mvhd の timescale
-  # @param rotated [Boolean] 90度回転の表示マトリクスを書き込むか
-  # @param moov_last [Boolean] moov を mdat の後ろに置くか（Android 端末の典型配置）
-  # @param audio_track [Boolean] 0x0 サイズの音声トラックを混ぜるか
+  # @param options [Hash] 端末・エンコーダごとの構造差を再現するオプション
+  # @option options [Integer] :timescale mvhd の timescale（既定 600）
+  # @option options [Boolean] :rotated 90度回転の表示マトリクスを書き込むか
+  # @option options [Boolean] :moov_last moov を mdat の後ろに置くか（Android 端末の典型配置）
+  # @option options [Boolean] :audio_track 0x0 サイズの音声トラックを混ぜるか
+  # @option options [Boolean] :empty_box 中身が空のトップレベルボックス（free）を先頭に挟むか
   # @return [String] ASCII-8BIT のバイト列
-  def build_mp4(duration_seconds:, width:, height:, timescale: 600, rotated: false, moov_last: false, audio_track: false)
+  def build_mp4(duration_seconds:, width:, height:, **options)
+    timescale = options.fetch(:timescale, 600)
+
     traks = []
-    traks << trak(width: 0, height: 0, duration_seconds:, timescale:) if audio_track
-    traks << trak(width:, height:, duration_seconds:, timescale:, rotated:)
+    traks << trak(width: 0, height: 0, duration_seconds:, timescale:) if options[:audio_track]
+    traks << trak(width:, height:, duration_seconds:, timescale:, rotated: options[:rotated])
 
     moov = box('moov', mvhd(duration_seconds:, timescale:) + traks.join)
     mdat = box('mdat', "\x00".b * 512)
 
-    parts = moov_last ? [ftyp, mdat, moov] : [ftyp, moov, mdat]
+    parts = options[:moov_last] ? [ftyp, mdat, moov] : [ftyp, moov, mdat]
+    parts.unshift(box('free', '')) if options[:empty_box]
     parts.join.b
   end
 

--- a/spec/support/mp4_builder.rb
+++ b/spec/support/mp4_builder.rb
@@ -1,0 +1,73 @@
+# VideoMetadataFetcher の検証用に、最小構成の ISO BMFF（MP4）バイト列を組み立てる。
+# 実ファイルを fixture に置くと解像度・長さのバリエーションごとにバイナリが増えるため、
+# 解析対象のボックス（ftyp / moov(mvhd + trak(tkhd)) / mdat）だけをその場で生成する。
+module Mp4Builder
+  IDENTITY_MATRIX = [0x0001_0000, 0, 0, 0, 0x0001_0000, 0, 0, 0, 0x4000_0000].freeze
+  # 90度回転（縦持ち撮影）。a = d = 0 で b / c が非ゼロ。
+  ROTATED_MATRIX = [0, 0x0001_0000, 0, -0x0001_0000, 0, 0, 0, 0, 0x4000_0000].freeze
+
+  # @param duration_seconds [Numeric] mvhd に書き込む再生時間
+  # @param width [Integer] tkhd の表示幅（回転時は入れ替え前の値）
+  # @param height [Integer] tkhd の表示高さ
+  # @param timescale [Integer] mvhd の timescale
+  # @param rotated [Boolean] 90度回転の表示マトリクスを書き込むか
+  # @param moov_last [Boolean] moov を mdat の後ろに置くか（Android 端末の典型配置）
+  # @param audio_track [Boolean] 0x0 サイズの音声トラックを混ぜるか
+  # @return [String] ASCII-8BIT のバイト列
+  def build_mp4(duration_seconds:, width:, height:, timescale: 600, rotated: false, moov_last: false, audio_track: false)
+    traks = []
+    traks << trak(width: 0, height: 0, duration_seconds:, timescale:) if audio_track
+    traks << trak(width:, height:, duration_seconds:, timescale:, rotated:)
+
+    moov = box('moov', mvhd(duration_seconds:, timescale:) + traks.join)
+    mdat = box('mdat', "\x00".b * 512)
+
+    parts = moov_last ? [ftyp, mdat, moov] : [ftyp, moov, mdat]
+    parts.join.b
+  end
+
+  # 指定バイト列を Range GET で返す R2 クライアントをスタブする。
+  # 範囲外の要求は実際の S3 / R2 と同じく InvalidRange で失敗させる。
+  def stub_r2_video_object(bytes)
+    allow(MediaAttachments::PresignedUrlService.client).to receive(:get_object) do |args|
+      from, to = args[:range].delete_prefix('bytes=').split('-').map(&:to_i)
+      raise Aws::S3::Errors::InvalidRange.new(nil, 'range not satisfiable') if from >= bytes.bytesize
+
+      instance_double(Aws::S3::Types::GetObjectOutput, body: StringIO.new(bytes.byteslice(from, to - from + 1)))
+    end
+  end
+
+  private
+
+  def box(type, payload)
+    [8 + payload.bytesize].pack('N') + type.b + payload
+  end
+
+  def ftyp
+    box('ftyp', "isom\x00\x00\x02\x00isomiso2avc1mp41".b)
+  end
+
+  def mvhd(duration_seconds:, timescale:)
+    payload = [0].pack('N')                                   # version 0 + flags
+    payload += [0, 0, timescale, (duration_seconds * timescale).round].pack('N4')
+    payload += [0x0001_0000].pack('N')                        # rate
+    payload += [0x0100].pack('n')                             # volume
+    payload += "\x00".b * 10                                  # reserved
+    payload += IDENTITY_MATRIX.pack('l>9')
+    payload += "\x00".b * 24                                  # pre_defined
+    box('mvhd', payload + [2].pack('N'))                      # next_track_ID
+  end
+
+  def trak(width:, height:, duration_seconds:, timescale:, rotated: false)
+    payload = [0x0000_0003].pack('N')                         # version 0 + flags(enabled / in movie)
+    payload += [0, 0, 1, 0, (duration_seconds * timescale).round].pack('N5')
+    payload += "\x00".b * 8                                   # reserved
+    payload += [0, 0, 0, 0].pack('n4')                        # layer / alternate_group / volume / reserved
+    payload += (rotated ? ROTATED_MATRIX : IDENTITY_MATRIX).pack('l>9')
+    box('trak', box('tkhd', payload + [width * 65_536, height * 65_536].pack('N2')))
+  end
+end
+
+RSpec.configure do |config|
+  config.include Mp4Builder
+end


### PR DESCRIPTION
## 関連Issue

ippei-shimizu/buzzbase#508（back 側の対応分）

## 概要

`release/pro-202605` の並行レビュー監査で見つかったバグのうち、バックエンド側 8 件と「その他（実害小）」2 件を修正しました。mobile 側は ippei-shimizu/buzzbase_mobile#(別PR) で対応しています。

## 変更内容

### 🔴 マネタイズ・データ整合性

**1. Webhook 順序逆転で状態が巻き戻る（issue #1）**

`RenewalHandler` / `ExpirationHandler` は `expires_at` という「イベント固有の比較軸」を持つためそれで順序判定できますが、`CANCELLATION` / `UNCANCELLATION` / `BILLING_ISSUE` は `expires_at` を変えないため比較軸がありません。そこで監査ログ（`UserSubscriptionEvent#occurred_at`）の最大値を「適用済みイベント時刻」のマーカーとして使うガードを `BaseHandler#stale_event?` に追加し、3 ハンドラで適用しました。

- 新規カラムを足さずに済み、既に全ハンドラが記録している値を再利用できるため
- 同時刻は再配信の冪等な再適用とみなして通す
- `event_timestamp` を持たない payload は比較不能なので素通し（従来動作）

**2. 動画の duration / 解像度がクライアント申告値のまま（issue #2）**

`MediaAttachments::VideoMetadataFetcher` を追加し、R2 上の実オブジェクトから ISO BMFF（MP4 / MOV）ヘッダを解析して実際の値を取得、`file_size_bytes` と同様に上書きしてから無料枠を判定するようにしました。

- ffprobe を導入するとイメージへの ffmpeg 同梱とファイル全体のダウンロードが必要になるため、**Range GET でヘッダだけ取得**する方式にしています（`mdat` 本体は一切ダウンロードしない）
- `moov` の位置は端末・エンコーダによって先頭にも末尾にも来るため、トップレベルのボックスヘッダ（8〜16 バイト）だけを辿って探索
- 縦持ち撮影の回転マトリクスを考慮して表示サイズに揃える
- 解析できない動画は上限を検証できないため、素通しさせず失敗扱い（fail-closed）

**3. 素振りの Pro 限定設定が back 未検証（issue #3）**

`shadow_swing_sessions` に `interval_seconds` / `vibration_enabled` / `sound_enabled` / `voice_enabled` を追加し、作成時に entitlement を検証するようにしました。カウンター画面はこの保存値を読むため、クライアント側のロック表示を回避しても許可された設定でしか実行できません。

**4. 0 本セッションで活動記録・Streak が不正加算（issue #4）**

- `ShadowSwingSession#complete!` は 0 本のとき `PracticeLog` を作らない（セッション自体は完了扱いにして開始したまま残さない）
- `DailyActivityRecalculator#practice_menu_count` は `amount = 0` のログを活動に数えない（`amount IS NULL` は「数値を伴わないメニューの実施」なので数える）

### 🟠 データ消失

**5. 目標削除でバッジが道連れ（issue #5）**

`dependent: :destroy` → `:nullify` にし、`goal_badges.goal_title` を付与時スナップショットとして持たせました（`PracticeLog#menu_name` と同じ方式）。目標を消してもバッジ一覧に何の目標だったか表示できます。

**6. メニューセット編集でバリデーション失敗時に既存アイテムが消える（issue #6）**

`assign_items` + `save` を 1 トランザクションに包みました（同 PR 内の `SchedulesController#update` と同じ形に揃えています）。

### 🟢 軽微

**10. アップロード中断時の孤立レコード（issue #10）**

`PurgeStaleMediaAttachmentsJob` を追加し、24 時間経過した `pending` / `failed` を毎日 4 時に回収します。R2 オブジェクトの削除は既存の `after_commit`（`MediaAttachmentDeletionJob`）に委ねています。

**その他 2 件**

- `achieved_at` を確定ジョブ実行時刻で上書きしない（定性目標でユーザーが押した時刻を保持）
- カスタム通知文を参照時点の entitlement で出し分け（Pro 解約後に過去の設定値が使われない）。index の N+1 を避けるため判定はコントローラで 1 回だけ解決して serializer へ渡しています

## マイグレーション

- [x] マイグレーションあり → `bundle exec rails db:migrate`
- [ ] マイグレーションなし

| ファイル | 内容 |
| --- | --- |
| `20260802010001_add_settings_to_shadow_swing_sessions` | 素振り設定 4 カラム追加（既定値あり・後方互換） |
| `20260802010002_preserve_goal_badges_on_goal_deletion` | `goal_badges.goal_title` 追加 + 既存行バックフィル、`goal_id` を nullable 化 |

## 確認手順

1. `docker compose exec back bundle exec rails db:migrate`
2. `docker compose exec back bundle exec rspec`
3. 素振り: 無料アカウントで `POST /api/v2/shadow_swing_sessions` に `interval_seconds: 1.0` を投げて 422 が返ること
4. 素振り: `swing_count: 0` で complete して `practice_logs` / `activity_logs` が増えないこと
5. 目標: 達成確定済みの目標を `DELETE /api/v2/goals/:id` した後、`GET /api/v2/goal_badges` にバッジが残り `goal_title` が返ること
6. メニューセット: 51 文字の name で `PATCH /api/v2/menu_sets/:id` を投げて 422 になり、既存 items が残っていること

## チェックリスト

- [x] テストが通る (`bundle exec rspec` — 1669 examples, 0 failures)
- [x] RuboCop が通る (`bundle exec rubocop` — 601 files, no offenses)
- [x] 動作確認済み（追加した spec で再現 → 修正を確認。修正を stash した状態でテストが落ちることも確認済み）

---
_Generated by [Claude Code](https://claude.ai/code/session_01XrYEbxJe7CsnGrcWBd6P41)_