### PR TITLE
Fix: 試合日付・年フィルタのJSTタイムゾーン変換漏れを修正

### DIFF
--- a/app/controllers/api/v2/dashboards_controller.rb
+++ b/app/controllers/api/v2/dashboards_controller.rb
@@ -162,7 +162,7 @@ module Api
       def build_available_years(user)
         MatchResult.joins(:game_result)
                    .where(game_results: { user_id: user.id })
-                   .select('EXTRACT(YEAR FROM date_and_time) AS year')
+                   .select(Arel.sql("#{Stats::JstDateSql::YEAR_JST_INT_SQL} AS year"))
                    .distinct.order(Arel.sql('year DESC'))
                    .map { |r| r.year.to_i }
       end

--- a/app/models/batting_average.rb
+++ b/app/models/batting_average.rb
@@ -131,7 +131,12 @@ class BattingAverage < ApplicationRecord
   end
 
   def self.apply_filters(scope, year, match_type, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
-    scope = scope.where(match_results: { date_and_time: Date.new(year.to_i, 1, 1)..Date.new(year.to_i, 12, 31) }) if year.present? && year.to_s != '通算'
+    if year.present? && year.to_s != '通算'
+      # Date レンジは default_timezone(:local) 下では JST 変換されず UTC 値と素で比較されるため、
+      # JST 早朝(0:00-8:59)の試合が年フィルタから漏れる。Time.zone.local で明示的に JST 境界を作る。
+      year_range = Time.zone.local(year.to_i, 1, 1).beginning_of_day..Time.zone.local(year.to_i, 12, 31).end_of_day
+      scope = scope.where(match_results: { date_and_time: year_range })
+    end
     scope = scope.where(match_results: { match_type: }) if match_type.present? && match_type != '全て'
     scope = scope.where(game_results: { season_id: }) if season_id.present?
     scope = scope.where(match_results: { tournament_id: }) if tournament_id.present?

--- a/app/models/match_result.rb
+++ b/app/models/match_result.rb
@@ -23,11 +23,12 @@ class MatchResult < ApplicationRecord
   validates :appearance_type, presence: true, inclusion: { in: APPEARANCE_TYPES }
 
   # 指定ユーザーの試合データに紐づく年度を新しい順で返す
+  # date_and_time は UTC 保存のため JST に揃えて抽出し、元日早朝の試合が前年に流れないようにする。
   # @param user [User]
   # @return [Array<Integer>]
   def self.available_years_for(user)
     where(user_id: user.id)
-      .pluck(Arel.sql('DISTINCT EXTRACT(YEAR FROM date_and_time)::int'))
+      .pluck(Arel.sql("DISTINCT #{Stats::JstDateSql::YEAR_JST_INT_SQL}"))
       .sort
       .reverse
   end

--- a/app/models/pitching_result.rb
+++ b/app/models/pitching_result.rb
@@ -83,7 +83,12 @@ class PitchingResult < ApplicationRecord
   end
 
   def self.apply_filters(scope, year, match_type, season_id: nil, tournament_id: nil, start_month: nil, end_month: nil)
-    scope = scope.where(match_results: { date_and_time: Date.new(year.to_i, 1, 1)..Date.new(year.to_i, 12, 31) }) if year.present? && year.to_s != '通算'
+    if year.present? && year.to_s != '通算'
+      # Date レンジは default_timezone(:local) 下では JST 変換されず UTC 値と素で比較されるため、
+      # JST 早朝(0:00-8:59)の試合が年フィルタから漏れる。Time.zone.local で明示的に JST 境界を作る。
+      year_range = Time.zone.local(year.to_i, 1, 1).beginning_of_day..Time.zone.local(year.to_i, 12, 31).end_of_day
+      scope = scope.where(match_results: { date_and_time: year_range })
+    end
     scope = scope.where(match_results: { match_type: }) if match_type.present? && match_type != '全て'
     scope = scope.where(game_results: { season_id: }) if season_id.present?
     scope = scope.where(match_results: { tournament_id: }) if tournament_id.present?

--- a/app/services/groups/stats_builder.rb
+++ b/app/services/groups/stats_builder.rb
@@ -49,7 +49,7 @@ module Groups
 
     def available_years
       MatchResult.where(user_id: user_ids)
-                 .select('EXTRACT(YEAR FROM date_and_time) AS year')
+                 .select(Arel.sql("#{Stats::JstDateSql::YEAR_JST_INT_SQL} AS year"))
                  .distinct.order(Arel.sql('year DESC'))
                  .map { |r| r.year.to_i }
     end

--- a/app/services/stats/game_summary_service.rb
+++ b/app/services/stats/game_summary_service.rb
@@ -83,7 +83,7 @@ module Stats
               .joins('INNER JOIN teams ON teams.id = match_results.opponent_team_id')
               .select(Arel.sql(
                         'game_results.id AS game_result_id, ' \
-                        "#{Stats::JstDateSql::DATE_AND_TIME_JST_SQL} AS date_and_time, " \
+                        "#{Stats::JstDateSql::DATE_AND_TIME_JST_SQL} AS date_and_time_jst, " \
                         'match_results.match_type, ' \
                         'teams.name AS opponent_name, ' \
                         'match_results.my_team_score, ' \
@@ -102,7 +102,7 @@ module Stats
                  end
         {
           game_result_id: g.game_result_id,
-          date: g.date_and_time.strftime('%m/%d'),
+          date: g.date_and_time_jst.strftime('%m/%d'),
           match_type: g.match_type,
           opponent: g.opponent_name,
           result:,

--- a/app/services/stats/game_summary_service.rb
+++ b/app/services/stats/game_summary_service.rb
@@ -83,7 +83,7 @@ module Stats
               .joins('INNER JOIN teams ON teams.id = match_results.opponent_team_id')
               .select(Arel.sql(
                         'game_results.id AS game_result_id, ' \
-                        'match_results.date_and_time, ' \
+                        "#{Stats::JstDateSql::DATE_AND_TIME_JST_SQL} AS date_and_time, " \
                         'match_results.match_type, ' \
                         'teams.name AS opponent_name, ' \
                         'match_results.my_team_score, ' \

--- a/spec/models/batting_average_spec.rb
+++ b/spec/models/batting_average_spec.rb
@@ -68,6 +68,24 @@ RSpec.describe BattingAverage, type: :model do
       result = described_class.filtered_aggregate_for_user(user.id, year: '2022').take
       expect(result).to be_nil
     end
+
+    context 'when a game is recorded at JST early morning on New Year’s Day' do
+      let!(:game_jst_new_year) do
+        gr = create(:game_result, user:)
+        # UTC 2025-12-31 18:00 = JST 2026-01-01 03:00。UTCのままだと年フィルタから漏れる
+        gr.match_result.update!(date_and_time: Time.zone.parse('2026-01-01 03:00:00 +0900'))
+        create(:batting_average, game_result: gr, user:, hit: 1, at_bats: 3, home_run: 0, times_at_bat: 4)
+        gr
+      end
+
+      it 'includes it in the JST year (2026), not the UTC year (2025)' do
+        result_jst_year = described_class.filtered_aggregate_for_user(user.id, year: '2026').take
+        result_utc_year = described_class.filtered_aggregate_for_user(user.id, year: '2025').take
+
+        expect(result_jst_year.hit.to_i).to eq(1)
+        expect(result_utc_year).to be_nil
+      end
+    end
   end
 
   describe '.filtered_stats_for_user' do

--- a/spec/models/match_result_spec.rb
+++ b/spec/models/match_result_spec.rb
@@ -97,6 +97,20 @@ RSpec.describe MatchResult, type: :model do
     end
   end
 
+  describe '.available_years_for' do
+    it 'returns years based on JST, not UTC' do
+      user = create(:user)
+      game_result = create(:game_result, user:)
+      # UTC 2025-12-31 18:00 = JST 2026-01-01 03:00。UTCのままEXTRACTすると前年(2025)にずれる
+      game_result.match_result.update!(date_and_time: Time.zone.parse('2026-01-01 03:00:00 +0900'))
+
+      years = described_class.available_years_for(user)
+
+      expect(years).to include(2026)
+      expect(years).not_to include(2025)
+    end
+  end
+
   describe 'APPEARANCE_TYPES' do
     # 値ごとの挙動はバリデーション spec で網羅しているので、ここでは件数だけ守る。
     it 'has 5 entries' do

--- a/spec/models/pitching_result_spec.rb
+++ b/spec/models/pitching_result_spec.rb
@@ -75,6 +75,26 @@ RSpec.describe PitchingResult, type: :model do
       result = described_class.filtered_pitching_aggregate_for_user(user.id, year: '2022').take
       expect(result).to be_nil
     end
+
+    context 'when a game is recorded at JST early morning on New Year’s Day' do
+      let!(:game_jst_new_year) do
+        gr = create(:game_result, user:)
+        # UTC 2025-12-31 18:00 = JST 2026-01-01 03:00。UTCのままだと年フィルタから漏れる
+        gr.match_result.update!(date_and_time: Time.zone.parse('2026-01-01 03:00:00 +0900'))
+        create(:pitching_result, game_result: gr, user:,
+                                 win: 1, loss: 0, innings_pitched: 6.0, earned_run: 1, strikeouts: 5,
+                                 base_on_balls: 0, hits_allowed: 2, number_of_pitches: 70)
+        gr
+      end
+
+      it 'includes it in the JST year (2026), not the UTC year (2025)' do
+        result_jst_year = described_class.filtered_pitching_aggregate_for_user(user.id, year: '2026').take
+        result_utc_year = described_class.filtered_pitching_aggregate_for_user(user.id, year: '2025').take
+
+        expect(result_jst_year.strikeouts.to_i).to eq(5)
+        expect(result_utc_year).to be_nil
+      end
+    end
   end
 
   describe '.filtered_pitching_stats_for_user' do

--- a/spec/requests/api/v2/dashboards_spec.rb
+++ b/spec/requests/api/v2/dashboards_spec.rb
@@ -67,6 +67,23 @@ RSpec.describe 'Api::V2::Dashboards', type: :request do
       end
     end
 
+    context 'when a game is recorded at JST early morning on New Year’s Day' do
+      # UTC 2025-12-31 18:00 = JST 2026-01-01 03:00。UTCのままEXTRACTすると前年(2025)にずれる
+      let!(:game_result) do
+        gr = create(:game_result, user:)
+        gr.match_result.update!(date_and_time: Time.zone.parse('2026-01-01 03:00:00 +0900'))
+        gr
+      end
+
+      it 'returns available_years based on JST, not UTC' do
+        get '/api/v2/dashboard', headers: auth_headers_for(user)
+
+        json = response.parsed_body
+        expect(json['available_years']).to include(2026)
+        expect(json['available_years']).not_to include(2025)
+      end
+    end
+
     context 'when user has pitching data' do
       let!(:game_result) do
         gr = create(:game_result, user:)

--- a/spec/services/groups/stats_builder_spec.rb
+++ b/spec/services/groups/stats_builder_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Groups::StatsBuilder, type: :service do
+  describe '#call' do
+    describe 'available_years' do
+      it 'returns years based on JST, not UTC' do
+        user = create(:user)
+        game_result = create(:game_result, user:)
+        # UTC 2025-12-31 18:00 = JST 2026-01-01 03:00。UTCのままEXTRACTすると前年(2025)にずれる
+        game_result.match_result.update!(date_and_time: Time.zone.parse('2026-01-01 03:00:00 +0900'))
+
+        result = described_class.new(accepted_users: [user]).call
+
+        expect(result[:available_years]).to include(2026)
+        expect(result[:available_years]).not_to include(2025)
+      end
+    end
+  end
+end

--- a/spec/services/stats/game_summary_service_spec.rb
+++ b/spec/services/stats/game_summary_service_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Stats::GameSummaryService, type: :service do
+  let(:user) { create(:user) }
+
+  describe '#call' do
+    describe 'recent_form date' do
+      it 'formats date_and_time in JST, not UTC' do
+        game_result = create(:game_result, user:)
+        # UTC 2026-07-14 17:00 = JST 2026-07-15 02:00。UTCのままだと前日(07/14)にずれる
+        game_result.match_result.update!(date_and_time: Time.zone.parse('2026-07-15 02:00:00 +0900'))
+
+        result = described_class.new(user_id: user.id).call
+        recent = result[:recent_form].find { |g| g[:game_result_id] == game_result.id }
+
+        expect(recent[:date]).to eq('07/15')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## issue
close ippei-shimizu/buzzbase#516

## 実装概要
試合結果サマリー・年フィルタ関連で、UTC保存の `date_and_time` をJST変換せずに日付/年を算出・比較していた箇所を6件修正。

## 背景
「試合結果サマリーの試合日付が1日ずれて表示される」という問い合わせを受けて調査したところ、`GameSummaryService#recent_form`（サマリー画面「直近の試合」のデータ生成元）が、タイムゾーン変換の効かない生SQL select（`Arel.sql`）で `match_results.date_and_time` を取得し、UTCのまま `strftime('%m/%d')` していたことが判明。JST 0:00〜9:00（UTC前日15:00〜23:59）に記録された試合が前日の日付として表示されていた。

同じ `Stats` 名前空間の `jst_date_sql.rb` に既にこの問題への対策（`AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo'`）が用意されており、`monthly_games` メソッドは対策済みだったが、`recent_form` だけが対策から漏れていた。

このバグを起点に同種の対策漏れがないか横断調査したところ、「年フィルタの選択肢生成」で `EXTRACT(YEAR FROM date_and_time)` をUTCのまま実行している箇所が3件見つかった（`MatchResult.available_months_for` は既にJST対策済みなのに、対になる年取得系だけ対策漏れだった）。

さらに `@claude` にコードレビューを依頼したところ、`PitchingResult.apply_filters` / `BattingAverage.apply_filters` の年フィルタにも同種の懸念があるとの指摘を受けた。実機検証したところ、こちらは表示日付のずれではなく、**JST 0:00〜8:59台に記録された試合が年フィルタの対象から完全に除外される**（成績集計から漏れる）より深刻な実バグと確認できたため、同じPRでまとめて修正した。

## やらなかったこと
特になし。既存の `Stats::JstDateSql::DATE_AND_TIME_JST_SQL` / `YEAR_JST_INT_SQL` 定数、および既存の `PeriodRange` が採用している `Time.zone.local` ベースの境界パターンを再利用しただけで、新規のタイムゾーン変換ロジックは追加していない。

## 受入基準
- [ ] JST 0:00〜9:00に記録された試合が、サマリー画面「直近の試合」で正しい日付（当日）として表示される
- [ ] JST元日早朝（0:00〜8:59）に記録された試合が、年フィルタの候補年・グループ統計・ダッシュボードで正しい年（当年）として扱われる
- [ ] JST元日早朝（0:00〜8:59）に記録された試合が、打撃/投球成績の年フィルタで正しい年（当年）の集計に含まれる
- [ ] 既存の日中の試合の日付・年表示・集計に影響がない

## 実装詳細
- `app/services/stats/game_summary_service.rb`: `recent_form` の select句で `match_results.date_and_time` をそのまま取得していた箇所を、`Stats::JstDateSql::DATE_AND_TIME_JST_SQL` を使ったJST変換済みの値に変更。alias名も `date_and_time_jst` に変更し、生のUTCカラム値と誤解されないようにした（レビュー指摘対応）。ORDER BYは元のUTC値（`match_results.date_and_time`）を参照しており、単調変換のため並び順に影響なし
- `app/models/match_result.rb`: `available_years_for` の `EXTRACT(YEAR FROM date_and_time)` を `Stats::JstDateSql::YEAR_JST_INT_SQL` に変更
- `app/services/groups/stats_builder.rb`: `available_years` の `EXTRACT(YEAR FROM date_and_time)` を `Stats::JstDateSql::YEAR_JST_INT_SQL` に変更
- `app/controllers/api/v2/dashboards_controller.rb`: `build_available_years` の `EXTRACT(YEAR FROM date_and_time)` を `Stats::JstDateSql::YEAR_JST_INT_SQL` に変更
- `app/models/pitching_result.rb`, `app/models/batting_average.rb`: `apply_filters` の年フィルタを `Date.new(year,1,1)..Date.new(year,12,31)` から `Time.zone.local(...).beginning_of_day..Time.zone.local(...).end_of_day` に変更。`config.active_record.default_timezone = :local` 下では `Date` レンジがJST変換されずDB上のUTC生値と素で比較されるため、`PeriodRange`（月フィルタ）で既に採用済みの `Time.zone.local` パターンに統一した
- 上記6件それぞれに、JST早朝（UTC前日夕方〜深夜）の日時が正しく扱われることを検証する回帰テストを追加
  - `spec/services/stats/game_summary_service_spec.rb`（新規）
  - `spec/models/match_result_spec.rb`（`.available_years_for` セクション追加）
  - `spec/services/groups/stats_builder_spec.rb`（新規）
  - `spec/requests/api/v2/dashboards_spec.rb`（JST元日早朝のcontext追加）
  - `spec/models/pitching_result_spec.rb`（JST元日早朝のcontext追加）
  - `spec/models/batting_average_spec.rb`（JST元日早朝のcontext追加）

## スクリーンショット
なし（バックエンドのみの修正）

## 確認手順
1. `docker compose exec back bundle exec rspec spec/services/stats/game_summary_service_spec.rb spec/models/match_result_spec.rb spec/services/groups/stats_builder_spec.rb spec/requests/api/v2/dashboards_spec.rb spec/models/pitching_result_spec.rb spec/models/batting_average_spec.rb` でテストがパスすることを確認
2. サマリーAPI（`GET /api/v2/stats`）・ダッシュボードAPI（`GET /api/v2/dashboard`）・グループ統計API（`GET /api/v1/groups/:id`）・打撃/投球成績API（年フィルタ）を、JST 0:00〜9:00に日時を設定した試合データで呼び出し、日付・年・集計結果が正しいことを確認

## 影響範囲
`GameSummaryService#recent_form` / `MatchResult.available_years_for` / `Groups::StatsBuilder#available_years` / `DashboardsController#build_available_years` / `PitchingResult.apply_filters` / `BattingAverage.apply_filters` の6箇所。既存データへの書き込み・マイグレーションは発生しない（いずれも読み取り時にリアルタイム集計・フィルタする値のため、デプロイ後は次回リクエストから即座に修正される）。

## コード上の懸念点
特になし。

## その他
- 横断調査は`Stats`名前空間内・`Arel.sql`を使った生SQL select全般を対象に実施。`pluck`経由の取得はモデル属性型のTZ変換が効くため対象外、`created_at`/`updated_at`等の監査系カラムは通常のARアクセスのみで対象外
- `@claude` によるコードレビューを実施済み。ブロッカーなし。指摘のうち「alias名の分かりやすさ」と「`PitchingResult`/`BattingAverage`の年フィルタ横展開候補」の2点に対応した