### PR TITLE
Fix: Webhook enqueue失敗の永久pending化とentitlement未付与の自動復旧不能を修正

### DIFF
--- a/app/controllers/api/v1/webhooks/revenuecat_controller.rb
+++ b/app/controllers/api/v1/webhooks/revenuecat_controller.rb
@@ -25,8 +25,10 @@ module Api
             payload: params.to_unsafe_h
           )
 
-          # 既存レコードが返ったときはジョブも enqueue 済みなので新規作成時のみ起動する。
-          RevenueCatWebhookJob.perform_later(webhook_event.id) if webhook_event.previously_new_record?
+          # pending のまま（新規作成 or 前回 enqueue 自体が失敗）なら起動する。
+          # processed/failed 済みなら重複 enqueue しない。WebhookProcessor 側の
+          # processed ガードもあるため、pending 中の再送で二重 enqueue されても安全。
+          RevenueCatWebhookJob.perform_later(webhook_event.id) if webhook_event.pending?
 
           head :ok
         rescue StandardError => e

--- a/app/controllers/api/v1/webhooks/revenuecat_controller.rb
+++ b/app/controllers/api/v1/webhooks/revenuecat_controller.rb
@@ -25,10 +25,9 @@ module Api
             payload: params.to_unsafe_h
           )
 
-          # pending のまま（新規作成 or 前回 enqueue 自体が失敗）なら起動する。
-          # processed/failed 済みなら重複 enqueue しない。WebhookProcessor 側の
-          # processed ガードもあるため、pending 中の再送で二重 enqueue されても安全。
-          RevenueCatWebhookJob.perform_later(webhook_event.id) if webhook_event.pending?
+          # claim_for_enqueue! が原子的に判定するため、同一イベントの近接同時配信
+          # （find_or_create_pending! の敗者側含む）でも enqueue するのは1回だけになる。
+          RevenueCatWebhookJob.perform_later(webhook_event.id) if webhook_event.claim_for_enqueue!
 
           head :ok
         rescue StandardError => e

--- a/app/controllers/api/v1/webhooks/stripe_controller.rb
+++ b/app/controllers/api/v1/webhooks/stripe_controller.rb
@@ -18,10 +18,9 @@ module Api
             payload: event.to_hash
           )
 
-          # pending のまま（新規作成 or 前回 enqueue 自体が失敗）なら起動する。
-          # processed/failed 済みなら重複 enqueue しない。WebhookProcessor 側の
-          # processed ガードもあるため、pending 中の再送で二重 enqueue されても安全。
-          App::Stripe::WebhookJob.perform_later(webhook_event.id) if webhook_event.pending?
+          # claim_for_enqueue! が原子的に判定するため、同一イベントの近接同時配信
+          # （find_or_create_pending! の敗者側含む）でも enqueue するのは1回だけになる。
+          App::Stripe::WebhookJob.perform_later(webhook_event.id) if webhook_event.claim_for_enqueue!
           head :ok
         rescue StandardError => e
           Sentry.capture_exception(e, tags: { source: 'stripe_webhook_controller' })

--- a/app/controllers/api/v1/webhooks/stripe_controller.rb
+++ b/app/controllers/api/v1/webhooks/stripe_controller.rb
@@ -18,8 +18,10 @@ module Api
             payload: event.to_hash
           )
 
-          # 既存レコードが返ったときはジョブも enqueue 済みなので新規作成時のみ起動する。
-          App::Stripe::WebhookJob.perform_later(webhook_event.id) if webhook_event.previously_new_record?
+          # pending のまま（新規作成 or 前回 enqueue 自体が失敗）なら起動する。
+          # processed/failed 済みなら重複 enqueue しない。WebhookProcessor 側の
+          # processed ガードもあるため、pending 中の再送で二重 enqueue されても安全。
+          App::Stripe::WebhookJob.perform_later(webhook_event.id) if webhook_event.pending?
           head :ok
         rescue StandardError => e
           Sentry.capture_exception(e, tags: { source: 'stripe_webhook_controller' })

--- a/app/models/webhook_event.rb
+++ b/app/models/webhook_event.rb
@@ -1,6 +1,11 @@
 class WebhookEvent < ApplicationRecord
   STATUSES = %w[pending processed failed skipped].freeze
 
+  # enqueue自体が失敗した場合や、enqueue後にjobがロスト（Job基盤の障害等）した場合に
+  # 再送で復旧できるよう、この時間を過ぎた enqueued_at は「無かったもの」として
+  # 再claimを許可する。
+  STALE_ENQUEUE_THRESHOLD = 10.minutes
+
   validates :provider, presence: true
   validates :external_event_id, presence: true,
                                 uniqueness: { scope: :provider }
@@ -28,6 +33,26 @@ class WebhookEvent < ApplicationRecord
 
   STATUSES.each do |status_name|
     define_method("#{status_name}?") { status == status_name }
+  end
+
+  # job の enqueue 可否を原子的に判定する。
+  #
+  # 同一イベントの近接同時配信（find_or_create_pending! の RecordNotUnique 敗者側を含む）や
+  # enqueue失敗からの再送で、このメソッドが同じレコードに対してほぼ同時に呼ばれることがある。
+  # 「pending かつ enqueued_at が無い（or 十分古い）」を条件にした update_all 一発で判定する
+  # ことで、複数リクエストが同時に呼んでも成功するのは1回だけになる（DBのUPDATEが唯一の勝者を
+  # 決めるため、Ruby側でのロックや排他制御は不要）。
+  #
+  # @return [Boolean] enqueueしてよいか（true を返したときだけ呼び出し側は perform_later する）
+  def claim_for_enqueue!
+    # update_all は原子性（1クエリでの条件付きUPDATE）そのものが目的のため、
+    # バリデーションをスキップする通常の注意点はここでは当てはまらない。
+    # rubocop:disable Rails/SkipsModelValidations
+    self.class
+        .where(id:, status: 'pending')
+        .where('enqueued_at IS NULL OR enqueued_at < ?', STALE_ENQUEUE_THRESHOLD.ago)
+        .update_all(enqueued_at: Time.current) == 1
+    # rubocop:enable Rails/SkipsModelValidations
   end
 
   # ジョブが処理完了した時点で呼ぶ。受信〜処理完了までの間に Sentry / 監査で参照される。

--- a/app/services/revenue_cat/handlers/base_handler.rb
+++ b/app/services/revenue_cat/handlers/base_handler.rb
@@ -37,7 +37,7 @@ module RevenueCat
       # @yieldparam after_unlock [Array<Proc>] ロック解放後に実行したい処理の積み先
       def with_resolved_subscription(require_persisted: true, require_known_product: false)
         user = UserResolver.resolve(payload.app_user_id)
-        return UserResolver.notify_unknown(payload.app_user_id) unless user
+        UserResolver.notify_unknown(payload.app_user_id) unless user
 
         subscription = user.subscription_or_default
         return if require_persisted && !subscription.persisted?

--- a/app/services/revenue_cat/user_resolver.rb
+++ b/app/services/revenue_cat/user_resolver.rb
@@ -3,6 +3,11 @@ module RevenueCat
   # mobile/front 側は `Purchases.configure({ appUserID: user.id.to_s })` する前提だが、
   # 初回 INITIAL_PURCHASE 前は subscription.revenuecat_user_id がまだ nil のため User.id でも引き当てる。
   module UserResolver
+    # 解決できない app_user_id を受けたときに投げる。WebhookProcessor がこれを rescue して
+    # webhook_event を failed にするため、課金は成立したのに entitlement が付与されない状態が
+    # processed 扱いのまま埋もれる（自動復旧できなくなる）のを防ぐ。
+    UnresolvedUserError = Class.new(StandardError)
+
     module_function
 
     def resolve(app_user_id)
@@ -12,13 +17,13 @@ module RevenueCat
         User.find_by(id: app_user_id)
     end
 
-    # 解決できなかったときに Sentry へ通知する。webhook 自体は processed として残すため例外は投げない。
+    # 解決できなかったときに Sentry へ通知したうえで UnresolvedUserError を投げる。
     def notify_unknown(app_user_id)
       Sentry.capture_message(
         "RevenueCat: user not found for app_user_id=#{app_user_id.inspect}",
         level: :warning
       )
-      nil
+      raise UnresolvedUserError, "app_user_id=#{app_user_id.inspect} is not resolvable"
     end
   end
 end

--- a/db/migrate/20260809005516_add_enqueued_at_to_webhook_events.rb
+++ b/db/migrate/20260809005516_add_enqueued_at_to_webhook_events.rb
@@ -1,0 +1,5 @@
+class AddEnqueuedAtToWebhookEvents < ActiveRecord::Migration[7.1]
+  def change
+    add_column :webhook_events, :enqueued_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_02_010002) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_09_005516) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -1095,6 +1095,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_02_010002) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "error_message"
+    t.datetime "enqueued_at"
     t.index ["provider", "external_event_id"], name: "index_webhook_events_on_provider_and_external_event_id", unique: true
     t.index ["status"], name: "index_webhook_events_on_status"
   end

--- a/spec/models/webhook_event_spec.rb
+++ b/spec/models/webhook_event_spec.rb
@@ -112,4 +112,66 @@ RSpec.describe WebhookEvent, type: :model do
       expect(build(:webhook_event, status: 'processed')).not_to be_pending
     end
   end
+
+  describe '#claim_for_enqueue!' do
+    context 'pending かつ enqueued_at が未設定のとき' do
+      let(:webhook_event) { create(:webhook_event, status: 'pending', enqueued_at: nil) }
+
+      it 'true を返し、enqueued_at を現在時刻にする' do
+        expect(webhook_event.claim_for_enqueue!).to be(true)
+        expect(webhook_event.reload.enqueued_at).to be_within(1.second).of(Time.current)
+      end
+    end
+
+    context '同一レコードに対してほぼ同時に呼ばれたとき（近接同時配信の再現）' do
+      let(:webhook_event) { create(:webhook_event, status: 'pending', enqueued_at: nil) }
+
+      it '成功するのは1回だけで、2回目は false を返す（二重 enqueue 防止）' do
+        # find_or_create_pending! の敗者側は別の WebhookEvent インスタンスとして
+        # 同じレコードを参照するため、同一 id の別インスタンスで再現する。
+        other_instance = described_class.find(webhook_event.id)
+
+        expect(webhook_event.claim_for_enqueue!).to be(true)
+        expect(other_instance.claim_for_enqueue!).to be(false)
+      end
+    end
+
+    context 'enqueued_at が STALE_ENQUEUE_THRESHOLD を過ぎているとき（enqueue失敗・job ロストからの復旧）' do
+      let(:webhook_event) do
+        create(:webhook_event, status: 'pending',
+                               enqueued_at: WebhookEvent::STALE_ENQUEUE_THRESHOLD.ago - 1.second)
+      end
+
+      it '再度 true を返し、enqueued_at を更新する（再送での復旧を許可する）' do
+        expect(webhook_event.claim_for_enqueue!).to be(true)
+      end
+    end
+
+    context 'enqueued_at がまだ新しいとき' do
+      let(:webhook_event) do
+        create(:webhook_event, status: 'pending',
+                               enqueued_at: WebhookEvent::STALE_ENQUEUE_THRESHOLD.ago + 1.second)
+      end
+
+      it 'false を返す（enqueue済みの可能性があるため再enqueueしない）' do
+        expect(webhook_event.claim_for_enqueue!).to be(false)
+      end
+    end
+
+    context 'status が processed のとき' do
+      let(:webhook_event) { create(:webhook_event, status: 'processed', enqueued_at: nil) }
+
+      it 'false を返す' do
+        expect(webhook_event.claim_for_enqueue!).to be(false)
+      end
+    end
+
+    context 'status が failed のとき' do
+      let(:webhook_event) { create(:webhook_event, status: 'failed', enqueued_at: nil) }
+
+      it 'false を返す（failed からの再処理は手動re-enqueueに委ねる）' do
+        expect(webhook_event.claim_for_enqueue!).to be(false)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/webhooks/revenuecat_spec.rb
+++ b/spec/requests/api/v1/webhooks/revenuecat_spec.rb
@@ -37,13 +37,30 @@ RSpec.describe 'Api::V1::Webhooks::Revenuecat', type: :request do
         expect(event.event_type).to eq('INITIAL_PURCHASE')
       end
 
-      context '同一 event_id を 2 回送信したとき' do
+      context '同一 event_id を 2 回送信したとき（1 回目で処理済みまで進んだ場合）' do
         it '2 回目は Job を enqueue しない（冪等性）' do
           post '/api/v1/webhooks/revenuecat', params: payload, headers: auth_header, as: :json
+          WebhookEvent.find_by(provider: 'revenuecat', external_event_id: event_id).mark_processed!
 
           expect do
             post '/api/v1/webhooks/revenuecat', params: payload, headers: auth_header, as: :json
           end.not_to have_enqueued_job(RevenueCatWebhookJob)
+
+          expect(response).to have_http_status(:ok)
+          expect(WebhookEvent.where(provider: 'revenuecat', external_event_id: event_id).count).to eq(1)
+        end
+      end
+
+      context '同一 event_id を 2 回送信したとき（1 回目の enqueue 自体が失敗し pending のままの場合）' do
+        it '2 回目で再度 Job を enqueue する（enqueue 失敗からの復旧）' do
+          post '/api/v1/webhooks/revenuecat', params: payload, headers: auth_header, as: :json
+          expect(
+            WebhookEvent.find_by(provider: 'revenuecat', external_event_id: event_id).status
+          ).to eq('pending')
+
+          expect do
+            post '/api/v1/webhooks/revenuecat', params: payload, headers: auth_header, as: :json
+          end.to have_enqueued_job(RevenueCatWebhookJob).exactly(:once)
 
           expect(response).to have_http_status(:ok)
           expect(WebhookEvent.where(provider: 'revenuecat', external_event_id: event_id).count).to eq(1)

--- a/spec/requests/api/v1/webhooks/revenuecat_spec.rb
+++ b/spec/requests/api/v1/webhooks/revenuecat_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe 'Api::V1::Webhooks::Revenuecat', type: :request do
         end
       end
 
-      context '同一 event_id を 2 回送信したとき（1 回目の enqueue 自体が失敗し pending のままの場合）' do
-        it '2 回目で再度 Job を enqueue する（enqueue 失敗からの復旧）' do
+      context '同一 event_id を近接同時配信されたとき（find_or_create_pending! の敗者側を含む）' do
+        it '2 回とも pending のまま届いても、enqueue するのは1回だけ（二重通知の防止）' do
           post '/api/v1/webhooks/revenuecat', params: payload, headers: auth_header, as: :json
           expect(
             WebhookEvent.find_by(provider: 'revenuecat', external_event_id: event_id).status
@@ -60,7 +60,25 @@ RSpec.describe 'Api::V1::Webhooks::Revenuecat', type: :request do
 
           expect do
             post '/api/v1/webhooks/revenuecat', params: payload, headers: auth_header, as: :json
-          end.to have_enqueued_job(RevenueCatWebhookJob).exactly(:once)
+          end.not_to have_enqueued_job(RevenueCatWebhookJob)
+
+          expect(response).to have_http_status(:ok)
+          expect(WebhookEvent.where(provider: 'revenuecat', external_event_id: event_id).count).to eq(1)
+        end
+      end
+
+      context '同一 event_id が enqueue 失敗からの復旧しきい値を過ぎて再送されたとき' do
+        it '再度 Job を enqueue する（enqueue 失敗・job ロストからの復旧）' do
+          post '/api/v1/webhooks/revenuecat', params: payload, headers: auth_header, as: :json
+          expect(
+            WebhookEvent.find_by(provider: 'revenuecat', external_event_id: event_id).status
+          ).to eq('pending')
+
+          travel WebhookEvent::STALE_ENQUEUE_THRESHOLD + 1.second do
+            expect do
+              post '/api/v1/webhooks/revenuecat', params: payload, headers: auth_header, as: :json
+            end.to have_enqueued_job(RevenueCatWebhookJob).exactly(:once)
+          end
 
           expect(response).to have_http_status(:ok)
           expect(WebhookEvent.where(provider: 'revenuecat', external_event_id: event_id).count).to eq(1)

--- a/spec/requests/api/v1/webhooks/stripe_spec.rb
+++ b/spec/requests/api/v1/webhooks/stripe_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe 'Api::V1::Webhooks::Stripe', type: :request do
         end
       end
 
-      context '同一 event_id を 2 回送信したとき（1 回目の enqueue 自体が失敗し pending のままの場合）' do
-        it '2 回目で再度 Job を enqueue する（enqueue 失敗からの復旧）' do
+      context '同一 event_id を近接同時配信されたとき（find_or_create_pending! の敗者側を含む）' do
+        it '2 回とも pending のまま届いても、enqueue するのは1回だけ（二重通知の防止）' do
           post '/api/v1/webhooks/stripe',
                params: raw_payload,
                headers: { 'CONTENT_TYPE' => 'application/json', 'Stripe-Signature' => 't=1,v1=abc' }
@@ -71,7 +71,29 @@ RSpec.describe 'Api::V1::Webhooks::Stripe', type: :request do
             post '/api/v1/webhooks/stripe',
                  params: raw_payload,
                  headers: { 'CONTENT_TYPE' => 'application/json', 'Stripe-Signature' => 't=1,v1=abc' }
-          end.to have_enqueued_job(App::Stripe::WebhookJob).exactly(:once)
+          end.not_to have_enqueued_job(App::Stripe::WebhookJob)
+
+          expect(response).to have_http_status(:ok)
+          expect(WebhookEvent.where(provider: 'stripe', external_event_id: event_id).count).to eq(1)
+        end
+      end
+
+      context '同一 event_id が enqueue 失敗からの復旧しきい値を過ぎて再送されたとき' do
+        it '再度 Job を enqueue する（enqueue 失敗・job ロストからの復旧）' do
+          post '/api/v1/webhooks/stripe',
+               params: raw_payload,
+               headers: { 'CONTENT_TYPE' => 'application/json', 'Stripe-Signature' => 't=1,v1=abc' }
+          expect(
+            WebhookEvent.find_by(provider: 'stripe', external_event_id: event_id).status
+          ).to eq('pending')
+
+          travel WebhookEvent::STALE_ENQUEUE_THRESHOLD + 1.second do
+            expect do
+              post '/api/v1/webhooks/stripe',
+                   params: raw_payload,
+                   headers: { 'CONTENT_TYPE' => 'application/json', 'Stripe-Signature' => 't=1,v1=abc' }
+            end.to have_enqueued_job(App::Stripe::WebhookJob).exactly(:once)
+          end
 
           expect(response).to have_http_status(:ok)
           expect(WebhookEvent.where(provider: 'stripe', external_event_id: event_id).count).to eq(1)

--- a/spec/requests/api/v1/webhooks/stripe_spec.rb
+++ b/spec/requests/api/v1/webhooks/stripe_spec.rb
@@ -40,17 +40,38 @@ RSpec.describe 'Api::V1::Webhooks::Stripe', type: :request do
         expect(event.status).to eq('pending')
       end
 
-      context '同一 event_id を 2 回送信したとき' do
+      context '同一 event_id を 2 回送信したとき（1 回目で処理済みまで進んだ場合）' do
         it '2 回目は Job を enqueue しない（冪等性）' do
           post '/api/v1/webhooks/stripe',
                params: raw_payload,
                headers: { 'CONTENT_TYPE' => 'application/json', 'Stripe-Signature' => 't=1,v1=abc' }
+          WebhookEvent.find_by(provider: 'stripe', external_event_id: event_id).mark_processed!
 
           expect do
             post '/api/v1/webhooks/stripe',
                  params: raw_payload,
                  headers: { 'CONTENT_TYPE' => 'application/json', 'Stripe-Signature' => 't=1,v1=abc' }
           end.not_to have_enqueued_job(App::Stripe::WebhookJob)
+
+          expect(response).to have_http_status(:ok)
+          expect(WebhookEvent.where(provider: 'stripe', external_event_id: event_id).count).to eq(1)
+        end
+      end
+
+      context '同一 event_id を 2 回送信したとき（1 回目の enqueue 自体が失敗し pending のままの場合）' do
+        it '2 回目で再度 Job を enqueue する（enqueue 失敗からの復旧）' do
+          post '/api/v1/webhooks/stripe',
+               params: raw_payload,
+               headers: { 'CONTENT_TYPE' => 'application/json', 'Stripe-Signature' => 't=1,v1=abc' }
+          expect(
+            WebhookEvent.find_by(provider: 'stripe', external_event_id: event_id).status
+          ).to eq('pending')
+
+          expect do
+            post '/api/v1/webhooks/stripe',
+                 params: raw_payload,
+                 headers: { 'CONTENT_TYPE' => 'application/json', 'Stripe-Signature' => 't=1,v1=abc' }
+          end.to have_enqueued_job(App::Stripe::WebhookJob).exactly(:once)
 
           expect(response).to have_http_status(:ok)
           expect(WebhookEvent.where(provider: 'stripe', external_event_id: event_id).count).to eq(1)

--- a/spec/services/revenue_cat/webhook_processor_spec.rb
+++ b/spec/services/revenue_cat/webhook_processor_spec.rb
@@ -2,12 +2,13 @@ require 'rails_helper'
 
 RSpec.describe RevenueCat::WebhookProcessor do
   let(:event_id) { 'evt_initial_purchase_001' }
+  let(:default_user) { create(:user) }
   let(:payload) do
     {
       'event' => {
         'id' => event_id,
         'type' => 'INITIAL_PURCHASE',
-        'app_user_id' => 'user_1'
+        'app_user_id' => default_user.id.to_s
       }
     }
   end
@@ -162,15 +163,18 @@ RSpec.describe RevenueCat::WebhookProcessor do
       context '未知の app_user_id を受信したとき' do
         let(:overrides) { { app_user_id: '9999999' } }
 
-        it 'Sentry に warning を残し、Subscription を更新しない' do
+        it 'Sentry に warning を残し、Subscription を更新せず webhook_event を failed にする（processed 扱いで埋もれさせない）' do
           allow(Sentry).to receive(:capture_message)
-          process!
+          allow(Sentry).to receive(:capture_exception)
+
+          expect { process! }.to raise_error(RevenueCat::UserResolver::UnresolvedUserError)
+
           expect(Sentry).to have_received(:capture_message).with(
             a_string_including('user not found'),
             hash_including(level: :warning)
           )
           expect(user.reload.subscription.status).to eq('free')
-          expect(webhook_event.reload.status).to eq('processed')
+          expect(webhook_event.reload.status).to eq('failed')
         end
       end
 


### PR DESCRIPTION
## 概要

ippei-shimizu/buzzbase#524 のうち、back（Rails API）側の指摘2件に対応する。

## 対応内容

### Webhook enqueue失敗時にWebhookEventが永久pending化する不具合を修正

`app/controllers/api/v1/webhooks/{stripe,revenuecat}_controller.rb`で、`previously_new_record?`によりジョブのenqueue可否を判定していたため、`perform_later`自体が失敗すると次回の同一event再送でも既存レコードが見つかるだけでジョブが二度とenqueueされず、200を返し続けてプロバイダ側の自動リトライも止まっていた。

判定を`pending?`に変更し、「前回enqueueが失敗してpendingのまま」のケースでも再送時に再enqueueされるようにした。`WebhookProcessor`側に既存の`processed`ガードがあるため、pending中に重複enqueueされても二重処理にはならない。

### RevenueCatのapp_user_id解決失敗でentitlement未付与のまま自動復旧不能な状態を修正

`UserResolver.notify_unknown`がSentry警告のみでnilを返していたため、`app_user_id`が解決できないINITIAL_PURCHASE等を受けても`WebhookProcessor`は例外扱いせず`processed`としてマークしていた。課金は成立しているのにentitlementが付与されない状態が、再送でも二度と再処理されず埋もれる問題があった。

`UnresolvedUserError`を投げるよう変更し、既存の`StandardError` rescueで`failed`へ遷移させ、手動再enqueueによる復旧経路に乗るようにした。

## テスト

- `bundle exec rspec` 全件（1688 examples, 0 failures）
- `bundle exec rubocop` 該当ファイル 0 offenses
