### PR TITLE
Fix: Web決済完了時にstripe_customer_id/stripe_subscription_idが紐付かない不具合を修正

### DIFF
--- a/app/services/app/stripe/checkout_session_builder.rb
+++ b/app/services/app/stripe/checkout_session_builder.rb
@@ -32,10 +32,19 @@ module App
           mode: 'subscription',
           customer_email: @user.email,
           line_items: [{ price: stripe_price_id, quantity: 1 }],
+          # checkout.session.completed の data.object は Checkout Session 自体であり、
+          # subscription_data.metadata（Subscription オブジェクト側）とは別物。
+          # CheckoutSessionCompletedHandler は Session 側の metadata.user_id を読むため、
+          # ここにも同じ値を明示的に持たせる必要がある。
+          metadata: session_metadata,
           subscription_data:,
           success_url: @success_url,
           cancel_url: @cancel_url
         }
+      end
+
+      def session_metadata
+        { user_id: @user.id.to_s, plan: @plan }
       end
 
       # trial_period_days は 0 なら Stripe に渡さない（compact で除去）。
@@ -44,7 +53,7 @@ module App
         trial_days = TrialDaysCalculator.for(@user)
         {
           trial_period_days: trial_days.positive? ? trial_days : nil,
-          metadata: { user_id: @user.id.to_s, plan: @plan }
+          metadata: session_metadata
         }.compact
       end
 

--- a/app/services/app/stripe/webhook_payload.rb
+++ b/app/services/app/stripe/webhook_payload.rb
@@ -23,6 +23,10 @@ module App
 
       # data.object.metadata を HashWithIndifferentAccess として返す。
       # Stripe 直送（Symbol キー）と DB 経由（JSON → String キー）の両方を統一して扱えるようにする。
+      # data.object は event_type によって Checkout Session / Subscription / Invoice 等、
+      # 異なる Stripe API オブジェクトになり、metadata もオブジェクトごとに別々に持てる
+      # （例: checkout.session.completed は Session 側、customer.subscription.* は
+      # Subscription 側）。呼び出し側は対象イベントでどちらの metadata が乗るか要確認。
       def metadata
         meta = data_object.respond_to?(:metadata) ? data_object.metadata : nil
         (meta.respond_to?(:to_h) ? meta.to_h : {}).with_indifferent_access

--- a/spec/services/app/stripe/checkout_session_builder_spec.rb
+++ b/spec/services/app/stripe/checkout_session_builder_spec.rb
@@ -19,14 +19,24 @@ RSpec.describe App::Stripe::CheckoutSessionBuilder do
     context '通常ケース（has_used_trial=false）' do
       it 'Stripe::Checkout::Session.create を期待値で呼び出す' do
         builder.call
+        # checkout.session.completed の data.object は Session 自体のため、
+        # CheckoutSessionCompletedHandler が読む metadata.user_id は Session 直下に必要
+        # （subscription_data.metadata だけでは Handler から参照できない）。
+        expected_metadata = { user_id: user.id.to_s, plan: 'monthly' }
+
         expect(Stripe::Checkout::Session).to have_received(:create) do |args|
-          expect(args[:mode]).to eq('subscription')
-          expect(args[:customer_email]).to eq(user.email)
-          expect(args[:line_items]).to eq([{ price: 'price_monthly_test_123', quantity: 1 }])
-          expect(args[:subscription_data][:trial_period_days]).to eq(7)
-          expect(args[:subscription_data][:metadata]).to eq(user_id: user.id.to_s, plan: 'monthly')
-          expect(args[:success_url]).to eq(success_url)
-          expect(args[:cancel_url]).to eq(cancel_url)
+          expect(args).to include(
+            mode: 'subscription',
+            customer_email: user.email,
+            line_items: [{ price: 'price_monthly_test_123', quantity: 1 }],
+            metadata: expected_metadata,
+            success_url:,
+            cancel_url:
+          )
+          expect(args[:subscription_data]).to include(
+            trial_period_days: 7,
+            metadata: expected_metadata
+          )
         end
       end
 


### PR DESCRIPTION
## 概要

ippei-shimizu/buzzbase#530 に対応する。

Stripeサンドボックスで実際にWeb決済のCheckoutフローを一通りテストしたところ、決済完了後に`Subscription`へ`stripe_customer_id`/`stripe_subscription_id`が一切紐付かないバグを発見した。

## 原因

`checkout_session_builder.rb`が`user_id`を`subscription_data.metadata`（Subscriptionオブジェクト側）にしか設定しておらず、`checkout.session.completed`イベントのdata.objectはCheckout Session自体のため、`CheckoutSessionCompletedHandler`が読むmetadataは常に空だった。結果、Web加入者は解約・プラン変更がアプリのUIから一切できなくなる状態だった。

## 変更内容

`checkout_params`にSession直下の`metadata`を追加し、Handlerが実際に参照する場所へ`user_id`を渡すようにした。

## テスト

- `bundle exec rspec spec/services/app/stripe/checkout_session_builder_spec.rb`（8 examples, 0 failures）
- `bundle exec rubocop` 該当ファイル 0 offenses
- 実際にStripeサンドボックスでCheckoutを完了させ、`Subscription`に`stripe_customer_id`/`stripe_subscription_id`が正しく保存されることを確認済み
