### PR TITLE
Fix: RevenueCatがStripe決済のProduct IDを認識できずWeb加入者のstatusが更新されない

### DIFF
--- a/app/services/revenue_cat/plan_catalog.rb
+++ b/app/services/revenue_cat/plan_catalog.rb
@@ -26,7 +26,10 @@ module RevenueCat
 
     # StripeのProduct IDはモバイルの固定文字列product_idと異なり、test/liveモードで値が
     # 変わるため、定数ではなくENVで環境ごとに切り替える。
+    # product_idがblankの場合に先に弾かないと、STRIPE_PRODUCT_ID_MONTHLY/YEARLYが未設定の
+    # 環境ではENV.fetchもnilを返すため、nil == nilで誤って'monthly'と判定してしまう。
     def stripe_plan_type_from(product_id)
+      return nil if product_id.blank?
       return 'monthly' if product_id == ENV.fetch('STRIPE_PRODUCT_ID_MONTHLY', nil)
       return 'yearly' if product_id == ENV.fetch('STRIPE_PRODUCT_ID_YEARLY', nil)
 

--- a/app/services/revenue_cat/plan_catalog.rb
+++ b/app/services/revenue_cat/plan_catalog.rb
@@ -17,11 +17,20 @@ module RevenueCat
     module_function
 
     def plan_type_from(product_id)
-      PRODUCT_ID_TO_PLAN_TYPE[product_id]
+      PRODUCT_ID_TO_PLAN_TYPE[product_id] || stripe_plan_type_from(product_id)
     end
 
     def platform_from(store)
       STORE_TO_PLATFORM[store]
+    end
+
+    # StripeのProduct IDはモバイルの固定文字列product_idと異なり、test/liveモードで値が
+    # 変わるため、定数ではなくENVで環境ごとに切り替える。
+    def stripe_plan_type_from(product_id)
+      return 'monthly' if product_id == ENV.fetch('STRIPE_PRODUCT_ID_MONTHLY', nil)
+      return 'yearly' if product_id == ENV.fetch('STRIPE_PRODUCT_ID_YEARLY', nil)
+
+      nil
     end
   end
 end

--- a/spec/services/revenue_cat/plan_catalog_spec.rb
+++ b/spec/services/revenue_cat/plan_catalog_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe RevenueCat::PlanCatalog do
+  describe '.plan_type_from' do
+    context 'モバイルの固定文字列product_idのとき' do
+      it '月額product_idからmonthlyを返す' do
+        expect(described_class.plan_type_from('jp.buzzbase.mobile.pro.monthly')).to eq('monthly')
+      end
+
+      it '年額product_idからyearlyを返す' do
+        expect(described_class.plan_type_from('jp.buzzbase.mobile.pro.yearly')).to eq('yearly')
+      end
+    end
+
+    context 'StripeのProduct IDのとき' do
+      before do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with('STRIPE_PRODUCT_ID_MONTHLY', nil).and_return('prod_monthly_test')
+        allow(ENV).to receive(:fetch).with('STRIPE_PRODUCT_ID_YEARLY', nil).and_return('prod_yearly_test')
+      end
+
+      it 'STRIPE_PRODUCT_ID_MONTHLYと一致するproduct_idからmonthlyを返す' do
+        expect(described_class.plan_type_from('prod_monthly_test')).to eq('monthly')
+      end
+
+      it 'STRIPE_PRODUCT_ID_YEARLYと一致するproduct_idからyearlyを返す' do
+        expect(described_class.plan_type_from('prod_yearly_test')).to eq('yearly')
+      end
+    end
+
+    context 'product_idがnilで、STRIPE_PRODUCT_ID_MONTHLY/YEARLYが未設定のとき' do
+      before do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with('STRIPE_PRODUCT_ID_MONTHLY', nil).and_return(nil)
+        allow(ENV).to receive(:fetch).with('STRIPE_PRODUCT_ID_YEARLY', nil).and_return(nil)
+      end
+
+      it 'nil同士の一致で誤ってmonthlyと判定せずnilを返す' do
+        expect(described_class.plan_type_from(nil)).to be_nil
+      end
+    end
+
+    context '未知のproduct_idのとき' do
+      it 'nilを返す' do
+        expect(described_class.plan_type_from('unknown_product')).to be_nil
+      end
+    end
+  end
+
+  describe '.platform_from' do
+    it 'APP_STOREからiosを返す' do
+      expect(described_class.platform_from('APP_STORE')).to eq('ios')
+    end
+
+    it 'MAC_APP_STOREからiosを返す' do
+      expect(described_class.platform_from('MAC_APP_STORE')).to eq('ios')
+    end
+
+    it 'PLAY_STOREからandroidを返す' do
+      expect(described_class.platform_from('PLAY_STORE')).to eq('android')
+    end
+
+    it 'STRIPEからwebを返す' do
+      expect(described_class.platform_from('STRIPE')).to eq('web')
+    end
+
+    it '未知のstoreのときnilを返す' do
+      expect(described_class.platform_from('UNKNOWN_STORE')).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## 概要

`ippei-shimizu/buzzbase#534` の対応。

Stripe決済完了後、RevenueCatは購入を正しく認識しているにもかかわらず、うちのバックエンド側の`Subscription.status`が更新されずWeb加入者がいつまでも無料プラン表示のままになる不具合を修正する。

## 原因

RevenueCatから届くStripe決済の`product_id`はStripeの内部Product ID（`prod_...`）だが、`PlanCatalog::PRODUCT_ID_TO_PLAN_TYPE`にはモバイル用の固定文字列product_id（`jp.buzzbase.mobile.pro.monthly`等）しか登録されていなかった。そのため`RevenueCat::Handlers::BaseHandler#unknown_product?`が常に「未知の商品」と判定し、`Subscription`の更新がSentry警告のみでサイレントにスキップされていた。

## 変更内容

`app/services/revenue_cat/plan_catalog.rb`の`plan_type_from`に、`STRIPE_PRODUCT_ID_MONTHLY` / `STRIPE_PRODUCT_ID_YEARLY`環境変数によるStripe Product IDのマッピングを追加した。

StripeのProduct IDはtest/liveモードで値が変わるため、モバイルの固定文字列product_idと異なり定数ではなく環境変数化している。

## 動作確認

- [x] 既存の（サイレントスキップされていた）`WebhookEvent`を再処理し、`Subscription`が`status=trial` `plan_type=yearly` `platform=web` `expires_at`ありに正しく更新されることを確認
- [x] front側の`/account/subscription`画面で「無料トライアル中」「年額プラン」「次回更新日」が正しく表示されることを確認
- [x] `bundle exec rspec` 全件成功（1696 examples, 0 failures）
- [x] `bundle exec rubocop` 検出0件

## 本番反映にあたって（ユーザー対応事項）

`ippei-shimizu/buzzbase#506` に記載済みだが、本番Herokuでも以下の対応が別途必要。

1. `STRIPE_PRODUCT_ID_MONTHLY` / `STRIPE_PRODUCT_ID_YEARLY`（本番Stripeアカウントの実際のProduct ID）をHerokuの環境変数に設定する
2. RevenueCatダッシュボードで、本番Stripeアカウントに対しても同様にWebhook連携（Connect Stripe → Add Stripe config → External purchase tracking）を設定する（サンドボックスでの接続は本番に引き継がれない）

## スコープ外

- `REVENUECAT_SECRET_API_KEY`が403を返す別問題（`/api/v1/pro/sync`の「状態を再同期」機能）。今回のWebhook経由の更新とは別経路のため、別途調査が必要
