### PR TITLE
Fix: RevenueCat同期API(GET /v1/subscribers)のperiod_typeが小文字でtrial判定に失敗する

### DIFF
--- a/app/services/revenue_cat/subscriber_sync.rb
+++ b/app/services/revenue_cat/subscriber_sync.rb
@@ -54,7 +54,9 @@ module RevenueCat
     def attributes_for(subscription, product_id, subscription_detail, entitlement)
       expires_at = parse_time(entitlement['expires_date'])
       effective_expires_at = grace_expires_at(entitlement, subscription_detail) || expires_at
-      is_trial = subscription_detail['period_type'] == 'TRIAL'
+      # RevenueCat REST API (GET /v1/subscribers) は period_type を小文字("trial")で返すが、
+      # Webhookペイロードは大文字("TRIAL")のため、大文字小文字を無視して判定する。
+      is_trial = subscription_detail['period_type'].to_s.casecmp('TRIAL').zero?
 
       {
         status: status_for(subscription_detail, effective_expires_at, is_trial),

--- a/app/services/revenue_cat/subscriber_sync.rb
+++ b/app/services/revenue_cat/subscriber_sync.rb
@@ -56,7 +56,7 @@ module RevenueCat
       effective_expires_at = grace_expires_at(entitlement, subscription_detail) || expires_at
       # RevenueCat REST API (GET /v1/subscribers) は period_type を小文字("trial")で返すが、
       # Webhookペイロードは大文字("TRIAL")のため、大文字小文字を無視して判定する。
-      is_trial = subscription_detail['period_type'].to_s.casecmp('TRIAL').zero?
+      is_trial = subscription_detail['period_type'].to_s.casecmp?('TRIAL')
 
       {
         status: status_for(subscription_detail, effective_expires_at, is_trial),

--- a/spec/services/revenue_cat/subscriber_sync_spec.rb
+++ b/spec/services/revenue_cat/subscriber_sync_spec.rb
@@ -63,6 +63,16 @@ RSpec.describe RevenueCat::SubscriberSync do
         end
       end
 
+      it 'period_type が小文字の trial（GET /v1/subscribers の実レスポンス形式）でもtrialとして反映する' do
+        stub_entitlement(subscription_overrides: { 'period_type' => 'trial' })
+        subscription = described_class.new(user).call
+
+        aggregate_failures do
+          expect(subscription.status).to eq('trial')
+          expect(subscription.has_used_trial).to be true
+        end
+      end
+
       it '期限切れ(グレース期間もなし)なら expired にする' do
         stub_entitlement(entitlement_overrides: { 'expires_date' => 1.day.ago.iso8601 })
         subscription = described_class.new(user).call


### PR DESCRIPTION
## 概要

`ippei-shimizu/buzzbase#536` の対応。

`/api/v1/pro/sync`（「状態を再同期」ボタン）が、trial中のWeb加入者を誤って`active`と判定してしまう不具合を修正する。

## 原因

`RevenueCat::SubscriberSync#attributes_for`の`is_trial`判定が`subscription_detail['period_type'] == 'TRIAL'`という大文字決め打ちの比較になっていた。RevenueCatのREST API（`GET /v1/subscribers/{app_user_id}`）は`period_type`を**小文字**（`"trial"`）で返すため、この比較が常に`false`になり、trial中のユーザーが`active`と誤判定されていた。

Webhookペイロードでは`period_type`が大文字（`"TRIAL"`）で届くため、Webhook経由の処理（`InitialPurchaseHandler`）は元々正しく動作していた。既存のspecも大文字`'TRIAL'`のみでスタブしており、実際のAPIレスポンス形式との乖離に気づけなかった。

## 併せて発見した別要因（コード変更なし、ダッシュボード設定で対応済み）

上記バグの発見過程で、StripeのProduct（`prod_V2R1akzjuK2SRi`=monthly, `prod_V2R25sBCN9a1Iv`=yearly）がRevenueCat側の`pro` Entitlementに紐付けられていなかったことも判明した。Entitlement未紐付けの状態では、Webhookは購入を認識してもRevenueCat APIの`entitlements`が常に空になり、`SubscriberSync`が「一度も加入していない」と誤判定して`expired`に上書きしてしまっていた。RevenueCatダッシュボードの「Products」画面でStripe商品を`pro` Entitlementに「Attach」することで解消済み。

## 変更内容

`is_trial`の判定を`casecmp`による大文字小文字を無視した比較に修正する。

## 動作確認

- [x] 実機チェックアウト後のtrial中ユーザーに対して`SubscriberSync`を実行し、`status: trial`と正しく判定されることを確認（修正前は`active`と誤判定されていた）
- [x] `bundle exec rspec` 全件成功（1697 examples, 0 failures、小文字ケースのテストを追加）
- [x] `bundle exec rubocop` 検出0件

## 本番反映にあたって（ユーザー対応事項）

`ippei-shimizu/buzzbase#506`に追記済みだが、本番Stripeアカウントの商品も同様にRevenueCatダッシュボードで`pro` Entitlementへの紐付けが必要（このPRの修正だけでは、Entitlement未紐付けだと引き続き`entitlements`が空になり同期が機能しない）。
