### PR TITLE
Fix: Webhookハンドラーが未知データ受信時にサイレントにprocessed扱いになる問題を修正

### DIFF
--- a/app/services/app/stripe/handlers/checkout_session_completed_handler.rb
+++ b/app/services/app/stripe/handlers/checkout_session_completed_handler.rb
@@ -4,12 +4,18 @@ module App
       # checkout.session.completed: Web 加入完了時に Stripe ID 2 つを Subscription に紐付ける。
       # status / plan_type 等の状態遷移は RevenueCat 経由で更新されるため、ここでは Stripe ID のみ保存する。
       class CheckoutSessionCompletedHandler < BaseHandler
+        # metadata.user_idが欠落しているときに投げる。WebhookProcessorがこれをrescueして
+        # webhook_eventをfailedにするため、決済は成立したのにSubscriptionへStripe IDが
+        # 紐付かない状態がprocessed扱いのまま埋もれる（自動復旧できなくなる）のを防ぐ。
+        MissingMetadataError = Class.new(StandardError)
+        UnresolvedUserError = Class.new(StandardError)
+
         def call
           user_id = payload.metadata[:user_id]
-          return notify_missing_user_id if user_id.blank?
+          notify_missing_user_id if user_id.blank?
 
           user = User.find_by(id: user_id)
-          return notify_unknown_user(user_id) unless user
+          notify_unknown_user(user_id) unless user
 
           user.subscription_or_default.update!(
             stripe_customer_id: payload.customer_id,
@@ -24,7 +30,7 @@ module App
             'Stripe checkout.session.completed: metadata.user_id is missing',
             level: :warning
           )
-          nil
+          raise MissingMetadataError, 'checkout.session.completed metadata.user_id is missing'
         end
 
         def notify_unknown_user(user_id)
@@ -32,7 +38,7 @@ module App
             "Stripe checkout.session.completed: user not found for user_id=#{user_id.inspect}",
             level: :warning
           )
-          nil
+          raise UnresolvedUserError, "user_id=#{user_id.inspect} is not resolvable"
         end
       end
     end

--- a/app/services/revenue_cat/handlers/base_handler.rb
+++ b/app/services/revenue_cat/handlers/base_handler.rb
@@ -3,6 +3,11 @@ module RevenueCat
     # 全 event handler の共通基底。user lookup と subscription 取得の共通フローを提供する。
     # 各サブクラスは `call` だけ実装し、本処理を `with_resolved_subscription` ブロックで包む。
     class BaseHandler
+      # PlanCatalogに未登録のproduct_id/storeを受けたときに投げる。WebhookProcessorがこれを
+      # rescueしてwebhook_eventをfailedにするため、課金・プラン変更は成立したのにentitlement
+      # が付与されない状態がprocessed扱いのまま埋もれる（自動復旧できなくなる）のを防ぐ。
+      UnknownProductError = Class.new(StandardError)
+
       # stale_event? の比較対象。加入の有効／無効が往復しうるイベントだけを並べる。
       ORDERING_SENSITIVE_EVENT_TYPES = %w[cancelled uncancelled billing_issue renewed recovered expired refunded].freeze
 
@@ -90,11 +95,16 @@ module RevenueCat
         platform_missing = PlanCatalog.platform_from(payload.store).nil?
         return false unless plan_type_missing || platform_missing
 
+        notify_unknown_product
+      end
+
+      def notify_unknown_product
         Sentry.capture_message(
           "RevenueCat: unknown product_id=#{payload.product_id.inspect} or store=#{payload.store.inspect}",
           level: :warning
         )
-        true
+        raise UnknownProductError,
+              "product_id=#{payload.product_id.inspect} or store=#{payload.store.inspect} is not registered in PlanCatalog"
       end
     end
   end

--- a/app/services/revenue_cat/handlers/base_handler.rb
+++ b/app/services/revenue_cat/handlers/base_handler.rb
@@ -46,7 +46,8 @@ module RevenueCat
 
         subscription = user.subscription_or_default
         return if require_persisted && !subscription.persisted?
-        return if require_known_product && unknown_product?
+
+        guard_known_product! if require_known_product
 
         after_unlock = []
         if subscription.persisted?
@@ -90,15 +91,13 @@ module RevenueCat
 
       # PlanCatalog に未登録の product_id / store が来ると plan_type: nil 等で silent に
       # 保存されてしまうため、書き込み系 handler は事前にガードする。
-      def unknown_product?
+      # 名前に `!` を付けているのは、真偽値を返す述語ではなく「未登録なら例外を投げて
+      # 止める」副作用を持つことを呼び出し側で分かるようにするため。
+      def guard_known_product!
         plan_type_missing = PlanCatalog.plan_type_from(payload.product_id).nil?
         platform_missing = PlanCatalog.platform_from(payload.store).nil?
-        return false unless plan_type_missing || platform_missing
+        return unless plan_type_missing || platform_missing
 
-        notify_unknown_product
-      end
-
-      def notify_unknown_product
         Sentry.capture_message(
           "RevenueCat: unknown product_id=#{payload.product_id.inspect} or store=#{payload.store.inspect}",
           level: :warning

--- a/spec/services/app/stripe/handlers/checkout_session_completed_handler_spec.rb
+++ b/spec/services/app/stripe/handlers/checkout_session_completed_handler_spec.rb
@@ -30,9 +30,11 @@ RSpec.describe App::Stripe::Handlers::CheckoutSessionCompletedHandler do
     context 'metadata に user_id が無いとき' do
       before { fixture['data']['object']['metadata'] = {} }
 
-      it 'Sentry warning + 処理スキップ' do
+      it 'Sentry warning を残し MissingMetadataError を投げる（processed扱いで埋もれさせない）' do
         allow(Sentry).to receive(:capture_message)
-        handler.call
+
+        expect { handler.call }.to raise_error(described_class::MissingMetadataError)
+
         expect(Sentry).to have_received(:capture_message).with(
           a_string_including('user_id'),
           hash_including(level: :warning)
@@ -43,9 +45,11 @@ RSpec.describe App::Stripe::Handlers::CheckoutSessionCompletedHandler do
     context '未知の user_id のとき' do
       before { fixture['data']['object']['metadata']['user_id'] = '99999999' }
 
-      it 'Sentry warning + Subscription 更新せず' do
+      it 'Sentry warning を残し UnresolvedUserError を投げる（Subscription は更新しない）' do
         allow(Sentry).to receive(:capture_message)
-        handler.call
+
+        expect { handler.call }.to raise_error(described_class::UnresolvedUserError)
+
         expect(Sentry).to have_received(:capture_message).with(
           a_string_including('user not found'),
           hash_including(level: :warning)

--- a/spec/services/revenue_cat/webhook_processor_spec.rb
+++ b/spec/services/revenue_cat/webhook_processor_spec.rb
@@ -8,7 +8,10 @@ RSpec.describe RevenueCat::WebhookProcessor do
       'event' => {
         'id' => event_id,
         'type' => 'INITIAL_PURCHASE',
-        'app_user_id' => default_user.id.to_s
+        'app_user_id' => default_user.id.to_s,
+        'product_id' => 'jp.buzzbase.mobile.pro.monthly',
+        'store' => 'APP_STORE',
+        'event_timestamp_ms' => Time.current.to_i * 1000
       }
     }
   end
@@ -181,15 +184,18 @@ RSpec.describe RevenueCat::WebhookProcessor do
       context 'PlanCatalog に未登録の product_id を受信したとき' do
         let(:overrides) { { product_id: 'buzzbase_pro_unknown' } }
 
-        it 'Sentry に warning を残し、Subscription を更新しない（silent corruption を防ぐ）' do
+        it 'Sentry に warning を残し、Subscription を更新せず webhook_event を failed にする（processed 扱いで埋もれさせない）' do
           allow(Sentry).to receive(:capture_message)
-          process!
+          allow(Sentry).to receive(:capture_exception)
+
+          expect { process! }.to raise_error(RevenueCat::Handlers::BaseHandler::UnknownProductError)
+
           expect(Sentry).to have_received(:capture_message).with(
             a_string_including('unknown product_id'),
             hash_including(level: :warning)
           )
           expect(user.reload.subscription.status).to eq('free')
-          expect(webhook_event.reload.status).to eq('processed')
+          expect(webhook_event.reload.status).to eq('failed')
         end
       end
     end


### PR DESCRIPTION
## 概要

`ippei-shimizu/buzzbase#526` の対応（`ippei-shimizu/buzzbase#532`を統合）。

RevenueCat・Stripeどちらのwebhookハンドラーも、想定外のデータ（未登録のproduct_id/store、metadata.user_id欠落、未知のuser_id）を受けたときSentry警告のみを出して処理をスキップし、`WebhookProcessor`からは正常終了として扱われ`processed`にされていた。課金・プラン変更は成立しているのに、こちらの実装の登録漏れ・不具合でSubscriptionが更新されない状態が、`processed`扱いのまま再送されても二度と拾われず埋もれてしまう問題を修正する。

## 変更内容

`ippei-shimizu/buzzbase_back#338`で`RevenueCat::UserResolver.notify_unknown`に導入済みの「Sentry通知 + 例外化」パターンを、以下2箇所にも適用した。

- `app/services/revenue_cat/handlers/base_handler.rb#unknown_product?`: `UnknownProductError`を投げる（`InitialPurchaseHandler` / `ProductChangeHandler`が対象）
- `app/services/app/stripe/handlers/checkout_session_completed_handler.rb`: `notify_missing_user_id` / `notify_unknown_user`がそれぞれ`MissingMetadataError` / `UnresolvedUserError`を投げる

両者とも`WebhookProcessor#process`が`rescue StandardError`で`webhook_event`を`failed`に遷移させ、再送（手動re-enqueue）で復旧できるようにする既存の仕組みに乗る。

## スコープ外（意図的に対象外）

`app/services/revenue_cat/subscriber_sync.rb#unknown_product?`は対象外とした。こちらは`/api/v1/pro/sync`（ユーザー操作による同期リクエスト）から同期的に呼ばれるため、例外化すると未対応の500エラーとしてユーザーに即座に返ってしまう。Webhookの「誰も見ていないバックグラウンド処理」とは性質が異なるため、現状のSentry警告＋silent skipのままとする。

## 動作確認

- [x] 既存テストの修正: `webhook_processor_spec.rb`のデフォルトpayload fixtureが`product_id`/`store`/`event_timestamp_ms`を持たない不完全なものだったため、今回の変更で`UnknownProductError`（さらに修正後は`TrialDaysCalculator.in_early_window?`のnil起因エラー）が新たに顕在化した。これも今回の変更が炙り出した「不完全なfixtureで実際には検証できていなかった」ケースのため、fixtureを実在するproduct_idを使う完全な形に修正した
- [x] `bundle exec rspec` 全件成功（1708 examples, 0 failures）
- [x] `bundle exec rubocop` 検出0件
