### PR TITLE
Refactor: RevenueCatのperiod_type大文字小文字判定をPeriodTypeモジュールに一元化

### DIFF
--- a/app/services/revenue_cat/period_type.rb
+++ b/app/services/revenue_cat/period_type.rb
@@ -1,0 +1,13 @@
+module RevenueCat
+  # RevenueCatのperiod_typeは、Webhookペイロードでは大文字("TRIAL")、
+  # REST API（GET /v1/subscribers）レスポンスでは小文字("trial")で届く。
+  # データソースごとに独立して比較ロジックを持つと表記ゆれを見落としやすいため、
+  # 判定をここに集約する（WebhookPayload#trial? / SubscriberSync双方から参照する）。
+  module PeriodType
+    module_function
+
+    def trial?(raw_value)
+      raw_value.to_s.casecmp?('TRIAL')
+    end
+  end
+end

--- a/app/services/revenue_cat/subscriber_sync.rb
+++ b/app/services/revenue_cat/subscriber_sync.rb
@@ -54,9 +54,7 @@ module RevenueCat
     def attributes_for(subscription, product_id, subscription_detail, entitlement)
       expires_at = parse_time(entitlement['expires_date'])
       effective_expires_at = grace_expires_at(entitlement, subscription_detail) || expires_at
-      # RevenueCat REST API (GET /v1/subscribers) は period_type を小文字("trial")で返すが、
-      # Webhookペイロードは大文字("TRIAL")のため、大文字小文字を無視して判定する。
-      is_trial = subscription_detail['period_type'].to_s.casecmp?('TRIAL')
+      is_trial = PeriodType.trial?(subscription_detail['period_type'])
 
       {
         status: status_for(subscription_detail, effective_expires_at, is_trial),

--- a/app/services/revenue_cat/webhook_payload.rb
+++ b/app/services/revenue_cat/webhook_payload.rb
@@ -32,7 +32,7 @@ module RevenueCat
     end
 
     def trial?
-      period_type == 'TRIAL'
+      PeriodType.trial?(period_type)
     end
 
     def event_timestamp

--- a/spec/services/revenue_cat/period_type_spec.rb
+++ b/spec/services/revenue_cat/period_type_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe RevenueCat::PeriodType do
+  describe '.trial?' do
+    it 'Webhookペイロード形式の大文字"TRIAL"でtrueを返す' do
+      expect(described_class.trial?('TRIAL')).to be(true)
+    end
+
+    it 'REST API (GET /v1/subscribers) 形式の小文字"trial"でtrueを返す' do
+      expect(described_class.trial?('trial')).to be(true)
+    end
+
+    it '"NORMAL"でfalseを返す' do
+      expect(described_class.trial?('NORMAL')).to be(false)
+    end
+
+    it 'nilでfalseを返す' do
+      expect(described_class.trial?(nil)).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
## 概要

`ippei-shimizu/buzzbase#538` の対応。

`ippei-shimizu/buzzbase_back#342`（`period_type`の大文字小文字ゆれバグ修正）のレビューで指摘された設計上の懸念に対応する。

## 背景

`period_type`が、RevenueCatのWebhookペイロード（`WebhookPayload#trial?`）では大文字（`"TRIAL"`）、REST APIレスポンス（`SubscriberSync#attributes_for`が読む`GET /v1/subscribers`）では小文字（`"trial"`）という表記ゆれがあり、#342では`SubscriberSync`側だけを`casecmp?`で修正した。しかし`WebhookPayload#trial?`は`period_type == 'TRIAL'`という完全一致のまま残っており、「同じ概念に対する処理が2クラス間で防御レベルが不揃い」という構造上の再発リスクが残っていた。

## 変更内容

`RevenueCat::PeriodType.trial?`を新設し、`WebhookPayload#trial?` / `SubscriberSync#attributes_for`の両方から参照する形に一元化した。表記ゆれを吸収するロジックが1箇所に集約され、テストも1箇所で担保できる。

## 動作確認

- [x] `RevenueCat::PeriodType`単体のspecを新設（大文字/小文字/NORMAL/nilの4パターン）
- [x] `bundle exec rspec` 全件成功（1712 examples, 0 failures）
- [x] `bundle exec rubocop` 検出0件

## スコープ外

- `store`フィールドは`SubscriberSync`側で既に`.to_s.upcase`により吸収済みで、同様のリスクは無いことを確認済み（#342レビューで調査済み）
