### PR TITLE
Fix: issue #533 の事実ベース指摘に対応（シーズン削除ガード・目標値バリデーション・素振り同時実行・コンディションログupsert）

### DIFF
--- a/app/controllers/api/v1/seasons_controller.rb
+++ b/app/controllers/api/v1/seasons_controller.rb
@@ -37,8 +37,11 @@ module Api
       end
 
       def destroy
-        @season.destroy
-        render json: { message: 'シーズンを削除しました' }, status: :ok
+        if @season.destroy
+          render json: { message: 'シーズンを削除しました' }, status: :ok
+        else
+          render json: { errors: @season.errors.full_messages }, status: :unprocessable_entity
+        end
       end
 
       private

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -26,8 +26,8 @@ class Goal < ApplicationRecord
   validates :comparison_type, inclusion: { in: COMPARISON_TYPES }
   # 数値目標のみ指標必須（定性は達成/未達、自由指標は指標名で管理）。
   validates :metric_key, inclusion: { in: METRIC_KEYS }, if: :numeric?
-  # 数値・自由指標は目標値必須（定性目標のみ不要）。
-  validates :target_value, presence: true, unless: :qualitative?
+  # 数値・自由指標は目標値必須（定性目標のみ不要）。負の目標値は成立しない。
+  validates :target_value, presence: true, numericality: { greater_than_or_equal_to: 0 }, unless: :qualitative?
   # 自由指標（手動更新）は指標名必須。
   validates :custom_metric_label, presence: true, length: { maximum: 40 }, if: :manual?
   # 継続目標（メニュー継続日数）は対象メニュー必須。

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -1,6 +1,20 @@
 class Season < ApplicationRecord
   belongs_to :user
   has_many :game_results, dependent: :nullify
+  # シーズン目標は season_id が外れると集計期間を失うため、進行中のものが残っている間は削除を止める。
+  has_many :goals, dependent: :nullify
 
   validates :name, presence: true, length: { maximum: 50 }, uniqueness: { scope: :user_id }
+
+  # dependent: :nullify も before_destroy として登録されるため、prepend で必ずガードを先に走らせる。
+  before_destroy :guard_against_active_season_goals, prepend: true
+
+  private
+
+  def guard_against_active_season_goals
+    return unless goals.exists?(period_type: 'season', is_finalized: false)
+
+    errors.add(:base, '進行中のシーズン目標が紐づいているため削除できません')
+    throw(:abort)
+  end
 end

--- a/app/models/shadow_swing_session.rb
+++ b/app/models/shadow_swing_session.rb
@@ -51,15 +51,29 @@ class ShadowSwingSession < ApplicationRecord
       return log
     end
 
+    create_shadow_swing_log(swing_count)
+  end
+
+  # 当日まだログが無い状態で複数セッションが同時に完了すると、揃って find_by で
+  # nil を引き create! が競合しうる。一意インデックス（(user_id, logged_on) の
+  # shadow_swing 限定部分インデックス）違反をセーブポイント内で検知し、
+  # 先勝ちした行を取得して加算し直す。
+  def create_shadow_swing_log(swing_count)
     menu = linked_menu
-    user.practice_logs.create!(
-      practice_menu: menu,
-      logged_on:,
-      amount: swing_count,
-      menu_name: MENU_NAME,
-      unit_label: menu&.unit_label || UNIT_LABEL,
-      source: 'shadow_swing'
-    )
+    ActiveRecord::Base.transaction(requires_new: true) do
+      user.practice_logs.create!(
+        practice_menu: menu,
+        logged_on:,
+        amount: swing_count,
+        menu_name: MENU_NAME,
+        unit_label: menu&.unit_label || UNIT_LABEL,
+        source: 'shadow_swing'
+      )
+    end
+  rescue ActiveRecord::RecordNotUnique
+    log = user.practice_logs.find_by!(logged_on:, source: 'shadow_swing')
+    log.with_lock { log.update!(amount: log.amount.to_i + swing_count) }
+    log
   end
 
   def pro_settings_within_entitlements

--- a/app/models/shadow_swing_session.rb
+++ b/app/models/shadow_swing_session.rb
@@ -46,7 +46,8 @@ class ShadowSwingSession < ApplicationRecord
 
     log = user.practice_logs.find_by(logged_on:, source: 'shadow_swing')
     if log
-      log.update!(amount: log.amount.to_i + swing_count)
+      # 同日の複数セッションが同時完了しても加算が失われないよう、行ロック下で読み直して加算する。
+      log.with_lock { log.update!(amount: log.amount.to_i + swing_count) }
       return log
     end
 

--- a/app/services/goals/progress_calculator.rb
+++ b/app/services/goals/progress_calculator.rb
@@ -21,7 +21,8 @@ module Goals
       return @goal.is_achieved ? 100.0 : 0.0 if @goal.qualitative?
 
       target = @goal.target_value.to_f
-      return 0 if target.zero?
+      # 目標値 0 は除算できないため、achieved? と同じ判定に委ねて進捗率の矛盾を防ぐ。
+      return achieved? ? 100.0 : 0.0 if target.zero?
 
       percent =
         if @goal.comparison_type == 'less_than'

--- a/app/services/practice_sessions/upsert.rb
+++ b/app/services/practice_sessions/upsert.rb
@@ -89,8 +89,16 @@ module PracticeSessions
     def upsert_condition
       raise NotEntitled unless @user.has_entitlement?('detailed_condition_log')
 
-      log = @user.condition_logs.find_or_initialize_by(logged_on: @logged_on)
-      log.update!(@condition.merge(logged_on: @logged_on))
+      attributes = @condition.merge(logged_on: @logged_on)
+      # ユニーク制約違反は PostgreSQL では外側のトランザクションごと中断させるため、
+      # 復旧クエリを流せるようセーブポイント内で INSERT させる。
+      ActiveRecord::Base.transaction(requires_new: true) do
+        @user.condition_logs.find_or_initialize_by(logged_on: @logged_on).update!(attributes)
+      end
+    rescue ActiveRecord::RecordNotUnique
+      # 同時リクエストで find と INSERT の間に他方が作成した場合は、
+      # (user_id, logged_on) のユニークインデックスに任せて拾い直す。
+      @user.condition_logs.find_by!(logged_on: @logged_on).update!(attributes)
     end
 
     def item_menu_ids

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,6 +15,10 @@ ja:
               required: "カテゴリは必須です"
             prefecture:
               required: "都道府県は必須です"
+        goal:
+          attributes:
+            target_value:
+              greater_than_or_equal_to: "は0以上で入力してください"
         match_result:
           attributes:
             inning_format:

--- a/db/migrate/20260810000001_add_unique_index_to_shadow_swing_practice_logs.rb
+++ b/db/migrate/20260810000001_add_unique_index_to_shadow_swing_practice_logs.rb
@@ -1,0 +1,12 @@
+class AddUniqueIndexToShadowSwingPracticeLogs < ActiveRecord::Migration[7.1]
+  # shadow_swing 由来のログは同日1レコードへ集約する設計だが、DB制約が無く
+  # 初回セッションの同時完了で重複行がサイレントに作られうる。source ごとに
+  # 集約単位が異なる（manual は同日複数メニューを許容）ため、部分インデックスで
+  # shadow_swing のみ (user_id, logged_on) を一意にする。
+  def change
+    add_index :practice_logs, %i[user_id logged_on],
+              unique: true,
+              where: "source = 'shadow_swing'",
+              name: 'index_practice_logs_on_user_logged_on_shadow_swing'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_09_005516) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_10_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -668,6 +668,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_09_005516) do
     t.index ["practice_session_id"], name: "index_practice_logs_on_practice_session_id"
     t.index ["schedule_id"], name: "index_practice_logs_on_schedule_id"
     t.index ["user_id", "logged_on"], name: "index_practice_logs_on_user_id_and_logged_on"
+    t.index ["user_id", "logged_on"], name: "index_practice_logs_on_user_logged_on_shadow_swing", unique: true, where: "((source)::text = 'shadow_swing'::text)"
     t.index ["user_id"], name: "index_practice_logs_on_user_id"
   end
 

--- a/spec/models/goal_spec.rb
+++ b/spec/models/goal_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe Goal, type: :model do
+  let(:user) { create(:user) }
+
+  describe 'target_value のバリデーション' do
+    it '負の目標値は無効' do
+      goal = build(:goal, user:, target_value: -1)
+
+      aggregate_failures do
+        expect(goal).not_to be_valid
+        expect(goal.errors[:target_value]).to include('は0以上で入力してください')
+      end
+    end
+
+    it '0 は有効（達成済みを起点にする目標を許容する）' do
+      expect(build(:goal, user:, target_value: 0)).to be_valid
+    end
+
+    it '未入力は無効' do
+      goal = build(:goal, user:, target_value: nil)
+
+      expect(goal).not_to be_valid
+      expect(goal.errors[:target_value]).to be_present
+    end
+
+    it '定性目標は目標値を持たなくてよい' do
+      expect(build(:goal, :qualitative, user:)).to be_valid
+    end
+  end
+end

--- a/spec/models/season_spec.rb
+++ b/spec/models/season_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Season, type: :model do
   describe 'associations' do
     it { should belong_to(:user) }
     it { should have_many(:game_results).dependent(:nullify) }
+    it { should have_many(:goals).dependent(:nullify) }
   end
 
   describe 'validations' do
@@ -12,5 +13,37 @@ RSpec.describe Season, type: :model do
     it { should validate_presence_of(:name) }
     it { should validate_length_of(:name).is_at_most(50) }
     it { should validate_uniqueness_of(:name).scoped_to(:user_id) }
+  end
+
+  describe '#destroy' do
+    let(:user) { create(:user) }
+    let(:season) { create(:season, user:) }
+
+    def season_goal(user:, season:, is_finalized:)
+      create(:goal, user:, season:, period_type: 'season', month_start: nil, is_finalized:)
+    end
+
+    it '進行中のシーズン目標が紐づいている場合は削除できない' do
+      season_goal(user:, season:, is_finalized: false)
+
+      aggregate_failures do
+        expect(season.destroy).to be false
+        expect(season.errors.full_messages).to include('進行中のシーズン目標が紐づいているため削除できません')
+        expect(described_class.exists?(season.id)).to be true
+      end
+    end
+
+    it '確定済みのシーズン目標だけなら削除でき、目標の紐付けは外れる' do
+      goal = season_goal(user:, season:, is_finalized: true)
+
+      aggregate_failures do
+        expect(season.destroy).to be_truthy
+        expect(goal.reload.season_id).to be_nil
+      end
+    end
+
+    it 'シーズン目標が紐づいていなければ削除できる' do
+      expect(season.destroy).to be_truthy
+    end
   end
 end

--- a/spec/models/shadow_swing_session_spec.rb
+++ b/spec/models/shadow_swing_session_spec.rb
@@ -74,28 +74,46 @@ RSpec.describe ShadowSwingSession, type: :model do
 
     after { ActiveRecord::Base.connection.execute('TRUNCATE TABLE users CASCADE') }
 
-    it '同日の複数セッションが同時に完了しても本数が失われず合算される' do
-      create(:practice_menu, user:, name: '素振り', unit: 'count', unit_label: '本')
-      # 既存ログと当日の activity_logs を先に作り、加算の競合だけを見る状態にする。
-      create(:practice_log, :shadow_swing, user:, logged_on: today, amount: 100)
-      sessions = Array.new(4) { create(:shadow_swing_session, user:, logged_on: today) }
+    # sessions を同じタイミングで complete! させ、全スレッドの完了を待つ。
+    def complete_concurrently(sessions, swing_count:)
       ready = Queue.new
       start = Queue.new
-
       threads = sessions.map do |session|
         Thread.new do
           ActiveRecord::Base.connection_pool.with_connection do
             ready << true
             start.pop
-            session.complete!(swing_count: 10)
+            session.complete!(swing_count:)
           end
         end
       end
       sessions.size.times { ready.pop }
       sessions.size.times { start << true }
       threads.each(&:join)
+    end
+
+    it '同日の複数セッションが同時に完了しても本数が失われず合算される' do
+      create(:practice_menu, user:, name: '素振り', unit: 'count', unit_label: '本')
+      # 既存ログと当日の activity_logs を先に作り、加算の競合だけを見る状態にする。
+      create(:practice_log, :shadow_swing, user:, logged_on: today, amount: 100)
+      sessions = Array.new(4) { create(:shadow_swing_session, user:, logged_on: today) }
+
+      complete_concurrently(sessions, swing_count: 10)
 
       expect(user.practice_logs.where(source: 'shadow_swing').sum(:amount)).to eq(140)
+    end
+
+    it '当日のログが無い状態で複数セッションが同時に完了しても重複行を作らず合算される' do
+      create(:practice_menu, user:, name: '素振り', unit: 'count', unit_label: '本')
+      sessions = Array.new(4) { create(:shadow_swing_session, user:, logged_on: today) }
+
+      complete_concurrently(sessions, swing_count: 10)
+
+      logs = user.practice_logs.where(source: 'shadow_swing', logged_on: today)
+      aggregate_failures do
+        expect(logs.count).to eq(1)
+        expect(logs.first.amount).to eq(40)
+      end
     end
   end
 end

--- a/spec/models/shadow_swing_session_spec.rb
+++ b/spec/models/shadow_swing_session_spec.rb
@@ -65,4 +65,37 @@ RSpec.describe ShadowSwingSession, type: :model do
       expect(log.unit_label).to eq('本')
     end
   end
+
+  describe '#complete! の同時実行' do
+    # 別スレッドの実コネクションから同じ練習ログ行を奪い合わせるため、テスト用トランザクションを外す。
+    self.use_transactional_tests = false
+
+    let(:today) { Time.find_zone('Asia/Tokyo').today }
+
+    after { ActiveRecord::Base.connection.execute('TRUNCATE TABLE users CASCADE') }
+
+    it '同日の複数セッションが同時に完了しても本数が失われず合算される' do
+      create(:practice_menu, user:, name: '素振り', unit: 'count', unit_label: '本')
+      # 既存ログと当日の activity_logs を先に作り、加算の競合だけを見る状態にする。
+      create(:practice_log, :shadow_swing, user:, logged_on: today, amount: 100)
+      sessions = Array.new(4) { create(:shadow_swing_session, user:, logged_on: today) }
+      ready = Queue.new
+      start = Queue.new
+
+      threads = sessions.map do |session|
+        Thread.new do
+          ActiveRecord::Base.connection_pool.with_connection do
+            ready << true
+            start.pop
+            session.complete!(swing_count: 10)
+          end
+        end
+      end
+      sessions.size.times { ready.pop }
+      sessions.size.times { start << true }
+      threads.each(&:join)
+
+      expect(user.practice_logs.where(source: 'shadow_swing').sum(:amount)).to eq(140)
+    end
+  end
 end

--- a/spec/requests/api/v1/seasons_spec.rb
+++ b/spec/requests/api/v1/seasons_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Seasons', type: :request do
+  let(:user) { create(:user) }
+
+  describe 'DELETE /api/v1/seasons/:id' do
+    let!(:season) { create(:season, user:) }
+
+    context '未認証' do
+      it '401' do
+        delete "/api/v1/seasons/#{season.id}"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    it '紐づく進行中のシーズン目標が無ければ削除できる' do
+      delete "/api/v1/seasons/#{season.id}", headers: auth_headers_for(user)
+
+      aggregate_failures do
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['message']).to eq('シーズンを削除しました')
+        expect(Season.exists?(season.id)).to be false
+      end
+    end
+
+    it '進行中のシーズン目標が紐づいている場合は422とエラーメッセージを返す' do
+      create(:goal, user:, season:, period_type: 'season', month_start: nil, is_finalized: false)
+
+      delete "/api/v1/seasons/#{season.id}", headers: auth_headers_for(user)
+
+      aggregate_failures do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['errors']).to include('進行中のシーズン目標が紐づいているため削除できません')
+        expect(Season.exists?(season.id)).to be true
+      end
+    end
+  end
+end

--- a/spec/services/goals/progress_calculator_spec.rb
+++ b/spec/services/goals/progress_calculator_spec.rb
@@ -38,4 +38,37 @@ RSpec.describe Goals::ProgressCalculator do
       end
     end
   end
+
+  describe '目標値が0の場合の進捗・達成判定' do
+    it 'greater_than は達成扱いなので進捗100%' do
+      goal = create(:goal, user:, metric_key: 'practice_days', comparison_type: 'greater_than', target_value: 0)
+      calculator = described_class.new(goal)
+
+      aggregate_failures do
+        expect(calculator.achieved?).to be true
+        expect(calculator.progress_percent).to eq(100.0)
+      end
+    end
+
+    it 'less_than はデータなしなら未達成で進捗0%' do
+      goal = create(:goal, user:, metric_key: 'era', comparison_type: 'less_than', target_value: 0)
+      calculator = described_class.new(goal)
+
+      aggregate_failures do
+        expect(calculator.achieved?).to be false
+        expect(calculator.progress_percent).to eq(0.0)
+      end
+    end
+
+    it 'less_than は現在値0なら達成で進捗100%' do
+      pitching(innings_pitched: 7.0, earned_run: 0)
+      goal = create(:goal, user:, metric_key: 'era', comparison_type: 'less_than', target_value: 0)
+      calculator = described_class.new(goal)
+
+      aggregate_failures do
+        expect(calculator.achieved?).to be true
+        expect(calculator.progress_percent).to eq(100.0)
+      end
+    end
+  end
 end

--- a/spec/services/practice_sessions/upsert_spec.rb
+++ b/spec/services/practice_sessions/upsert_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe PracticeSessions::Upsert do
+  let(:user) { create(:user) }
+  let(:today) { Time.find_zone('Asia/Tokyo').today }
+  let(:condition) { { fatigue_level: 4, physical_level: 2, sleep_hours: 6.5, mood: '普通' } }
+
+  before { user.subscription.update!(status: 'active', expires_at: 1.month.from_now) }
+
+  def call_upsert
+    described_class.new(user:, logged_on: today, condition:).call
+  end
+
+  describe 'コンディションの upsert' do
+    it '未登録の日はコンディションを新規作成する' do
+      expect { call_upsert }.to change { user.condition_logs.count }.from(0).to(1)
+      expect(user.condition_logs.find_by(logged_on: today).fatigue_level).to eq(4)
+    end
+
+    it '登録済みの日はコンディションを更新する' do
+      create(:condition_log, user:, logged_on: today, fatigue_level: 1)
+
+      expect { call_upsert }.not_to(change { user.condition_logs.count })
+      expect(user.condition_logs.find_by(logged_on: today).fatigue_level).to eq(4)
+    end
+
+    context '同時リクエストがユニーク制約に競合したとき' do
+      # 相手方リクエストを別コネクションからコミットさせるため、テスト用トランザクションを外す。
+      self.use_transactional_tests = false
+
+      after { ActiveRecord::Base.connection.execute('TRUNCATE TABLE users CASCADE') }
+
+      it '例外にせず先勝ちしたレコードを更新して成功する' do
+        relation = user.condition_logs
+        loser = relation.new(logged_on: today)
+        allow(user).to receive(:condition_logs).and_return(relation)
+        allow(relation).to receive(:find_or_initialize_by).and_return(loser)
+        # 一意性バリデーションの SELECT を通過した直後に相手方が INSERT を確定させる、
+        # という同時到達の敗者側を再現する。
+        allow(loser).to receive(:valid?).and_wrap_original do |original, *args|
+          result = original.call(*args)
+          Thread.new do
+            ActiveRecord::Base.connection_pool.with_connection do
+              ConditionLog.create!(user_id: user.id, logged_on: today, fatigue_level: 1)
+            end
+          end.join
+          result
+        end
+
+        call_upsert
+
+        logs = ConditionLog.where(user_id: user.id, logged_on: today)
+        aggregate_failures do
+          expect(logs.count).to eq(1)
+          expect(logs.first.fatigue_level).to eq(4)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 背景

ippei-shimizu/buzzbase#533 で `release/pro-202605` 配下を多角的にレビューした結果検出された、事実ベースの不具合のうち back 側 5 件に対応する。

## 変更内容

### 1. シーズン削除時に紐づく進行中の目標が孤立する

- 対象: `app/models/season.rb` / `app/controllers/api/v1/seasons_controller.rb`
- 問題: `goals` の FK は `on_delete: :nullify` のため、シーズンを削除すると進行中のシーズン目標が `season_id` を失い、集計期間を算出できないまま残っていた。さらに `destroy` の戻り値を見ずに常に 200 を返していた。
- 対応: `has_many :goals, dependent: :nullify` を追加したうえで、進行中（`period_type: 'season'` かつ `is_finalized: false`）の目標が残っている間は `before_destroy` で削除をガードする。`dependent: :nullify` も `before_destroy` として登録されるため `prepend: true` でガードを先行させている。コントローラーは削除失敗時に 422 とエラーメッセージを返すよう修正。

### 2. 目標の `target_value` に負数を許容してしまう

- 対象: `app/models/goal.rb` / `config/locales/ja.yml`
- 問題: `presence: true` のみで、負の目標値が保存でき進捗率が壊れる状態だった。
- 対応: `numericality: { greater_than_or_equal_to: 0 }` を追加。ja ロケールに `greater_than_or_equal_to` のメッセージを追加した。

### 3. `target_value = 0` のとき `progress_percent` と `achieved?` が矛盾する

- 対象: `app/services/goals/progress_calculator.rb`
- 問題: `achieved?` は `target_value = 0` で達成を返すのに、`progress_percent` は `return 0 if target.zero?` で無条件に 0% を返していた。
- 対応: `less_than_percent` が採るゼロ除算の分岐方針を踏襲し、目標値 0 のときは `achieved?` の判定に委ねて 100.0 / 0.0 を返す。

### 4. 素振り自動記録の同時完了でロストアップデートが起きる

- 対象: `app/models/shadow_swing_session.rb`
- 問題: `practice_log_for` の `log.update!(amount: log.amount.to_i + swing_count)` が行ロック無しの read-modify-write で、同日の複数セッションを同時に完了させると本数が失われていた。
- 対応: `log.with_lock` で該当の read-modify-write を排他する。

### 5. コンディションログの upsert で一意制約違反が未捕捉

- 対象: `app/services/practice_sessions/upsert.rb`
- 問題: `find_or_initialize_by` → `update!` の間に他リクエストが同じ `(user_id, logged_on)` を作成すると `ActiveRecord::RecordNotUnique` がそのまま外へ漏れていた。
- 対応: `PracticeSession.for` と同じく `rescue ActiveRecord::RecordNotUnique` で既存レコードを拾い直す。ただし PostgreSQL では一意制約違反が外側のトランザクションごと中断させ、素の rescue では復旧クエリが `PG::InFailedSqlTransaction` になることを実機で確認したため、INSERT を `transaction(requires_new: true)` のセーブポイント内で実行している。

## テスト

- `spec/models/season_spec.rb` — 進行中のシーズン目標がある場合の削除失敗 / 確定済みのみの場合の削除成功と nullify / 目標なしの削除成功
- `spec/requests/api/v1/seasons_spec.rb`（新規） — destroy の 200 / 422 / 401
- `spec/models/goal_spec.rb`（新規） — 負数の拒否 / 0 の許容 / 未入力の拒否 / 定性目標の除外
- `spec/services/goals/progress_calculator_spec.rb` — 目標値 0 での greater_than / less_than（データなし・現在値 0）
- `spec/models/shadow_swing_session_spec.rb` — 4 スレッドの同時 `complete!` で加算が合算されること（実コネクションを使うため当該 context のみ `use_transactional_tests = false`）
- `spec/services/practice_sessions/upsert_spec.rb`（新規） — 新規作成 / 更新 / 一意制約競合時の復旧

4 と 5 の並行性テストは、修正を戻した状態で確実に失敗すること（4: 140 期待に対し 110、5: `RecordNotUnique` 送出）を確認済み。

## 動作確認

- `docker compose exec back bundle exec rspec` — 1730 examples, 0 failures
- `docker compose exec back bundle exec rubocop` — 610 files inspected, no offenses detected

## 補足

`PracticeSession.for` の `rescue ActiveRecord::RecordNotUnique` も、`PracticeSessions::Upsert#call` のトランザクション内から呼ばれる経路ではセーブポイントが無いため同じ理由で復旧に失敗する。今回の指摘範囲外のため本 PR では変更していない。

Ref: ippei-shimizu/buzzbase#533
