### PR TITLE
Fix: Pro checkoutのkill switchガード・Webhookリトライ設計・一意制約リトライの信頼性向上

### DIFF
--- a/app/controllers/api/v1/pro/checkout_controller.rb
+++ b/app/controllers/api/v1/pro/checkout_controller.rb
@@ -4,10 +4,13 @@ module Api
       # POST /api/v1/pro/checkout
       # Web 加入用の Stripe Checkout Session を生成して checkout_url を返す。
       # 実際の状態遷移は Stripe → RevenueCat → Webhook 経由で行われるため、ここでは local 状態を触らない。
+      # Flipper :pro_features は新規販売の kill switch。無効時は Stripe を呼ばずに 403 で止める。
       class CheckoutController < ApplicationController
         before_action :authenticate_api_v1_user!
 
         def create
+          return render json: { error: 'feature_disabled' }, status: :forbidden unless Flipper.enabled?(:pro_features, current_api_v1_user)
+
           session = App::Stripe::CheckoutSessionBuilder.new(
             user: current_api_v1_user,
             plan: params[:plan],

--- a/app/jobs/app/stripe/webhook_job.rb
+++ b/app/jobs/app/stripe/webhook_job.rb
@@ -7,6 +7,12 @@ module App
       # 指数バックオフで最大 5 回リトライ。ApplicationJob の rescue_from で Sentry 通知される。
       retry_on StandardError, wait: :polynomially_longer, attempts: 5
 
+      # 設定漏れ由来の恒久的エラーはリトライしても回復しない。ActiveJob は後から登録した
+      # ハンドラが優先されるため retry_on より後に置き、初回で discard させる。
+      # 失敗の記録と Sentry 通知は WebhookProcessor#process 側で済んでいる。
+      discard_on App::Stripe::Handlers::CheckoutSessionCompletedHandler::MissingMetadataError,
+                 App::Stripe::Handlers::CheckoutSessionCompletedHandler::UnresolvedUserError
+
       # DB から webhook_event が消えていても落とさない（手動削除や DB 競合に備える）。
       def perform(webhook_event_id)
         webhook_event = WebhookEvent.find_by(id: webhook_event_id)

--- a/app/jobs/revenue_cat_webhook_job.rb
+++ b/app/jobs/revenue_cat_webhook_job.rb
@@ -5,6 +5,12 @@ class RevenueCatWebhookJob < ApplicationJob
   # 指数バックオフで最大 5 回リトライ。ApplicationJob の rescue_from で Sentry 通知される。
   retry_on StandardError, wait: :polynomially_longer, attempts: 5
 
+  # 設定漏れ由来の恒久的エラーはリトライしても回復しない。ActiveJob は後から登録した
+  # ハンドラが優先されるため retry_on より後に置き、初回で discard させる。
+  # 失敗の記録と Sentry 通知は WebhookProcessor#process 側で済んでいる。
+  discard_on RevenueCat::UserResolver::UnresolvedUserError,
+             RevenueCat::Handlers::BaseHandler::UnknownProductError
+
   # DB から webhook_event が消えていても落とさない（手動削除や DB 競合に備える）。
   def perform(webhook_event_id)
     webhook_event = WebhookEvent.find_by(id: webhook_event_id)

--- a/app/models/practice_session.rb
+++ b/app/models/practice_session.rb
@@ -29,10 +29,12 @@ class PracticeSession < ApplicationRecord
     ActiveRecord::Base.transaction(requires_new: true) do
       user.practice_sessions.create!(logged_on: date)
     end
-  rescue ActiveRecord::RecordNotUnique
-    # 同時リクエストで find と create の間に他方が作成した場合は、
-    # (user_id, logged_on) のユニークインデックスに任せて拾い直す。
-    user.practice_sessions.find_by!(logged_on: date)
+  rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+    # 同時リクエストで find_by と INSERT の間に他方が作成した場合の復旧。
+    # 相手方のコミットが一意性バリデーションの SELECT より前なら RecordInvalid、
+    # 後なら DB のユニークインデックス違反（RecordNotUnique）になるため両方から拾い直す。
+    # 行が見つからないなら別要因の検証エラーなので握り潰さず投げ直す。
+    user.practice_sessions.find_by(logged_on: date) || raise(e)
   end
 
   # その日のコンディションログ（1日1件・日付で一意）。

--- a/app/models/practice_session.rb
+++ b/app/models/practice_session.rb
@@ -20,7 +20,15 @@ class PracticeSession < ApplicationRecord
   # @param date [Date, String]
   # @return [PracticeSession]
   def self.for(user, date)
-    user.practice_sessions.find_or_create_by!(logged_on: date)
+    existing = user.practice_sessions.find_by(logged_on: date)
+    return existing if existing
+
+    # PracticeSessions::Upsert のような外側トランザクション内から呼ばれると、
+    # ユニーク制約違反がトランザクション全体を abort させて rescue 節の復旧クエリまで
+    # 道連れになる。セーブポイント内で INSERT させて影響をここに閉じ込める。
+    ActiveRecord::Base.transaction(requires_new: true) do
+      user.practice_sessions.create!(logged_on: date)
+    end
   rescue ActiveRecord::RecordNotUnique
     # 同時リクエストで find と create の間に他方が作成した場合は、
     # (user_id, logged_on) のユニークインデックスに任せて拾い直す。

--- a/app/models/shadow_swing_session.rb
+++ b/app/models/shadow_swing_session.rb
@@ -106,7 +106,7 @@ class ShadowSwingSession < ApplicationRecord
       user.practice_menus.create!(name: MENU_NAME, category: 'batting', unit: 'count', unit_label: UNIT_LABEL)
     end
   rescue ActiveRecord::RecordNotUnique
-    winner = user.practice_menus.find_by!(name: MENU_NAME)
-    winner.unit == 'count' ? winner : nil
+    # 一意インデックスは name / unit の両方で絞っているため、競合相手は必ず count 単位の行。
+    user.practice_menus.find_by!(name: MENU_NAME, unit: 'count')
   end
 end

--- a/app/models/shadow_swing_session.rb
+++ b/app/models/shadow_swing_session.rb
@@ -100,6 +100,13 @@ class ShadowSwingSession < ApplicationRecord
     return existing if existing&.unit == 'count'
     return nil if existing
 
-    user.practice_menus.create!(name: MENU_NAME, category: 'batting', unit: 'count', unit_label: UNIT_LABEL)
+    # 初回セッションの同時完了で create! が競合しうる。complete! のトランザクション内から
+    # 呼ばれるため、一意インデックス違反をセーブポイントに閉じ込めて先勝ちした行を拾い直す。
+    ActiveRecord::Base.transaction(requires_new: true) do
+      user.practice_menus.create!(name: MENU_NAME, category: 'batting', unit: 'count', unit_label: UNIT_LABEL)
+    end
+  rescue ActiveRecord::RecordNotUnique
+    winner = user.practice_menus.find_by!(name: MENU_NAME)
+    winner.unit == 'count' ? winner : nil
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -61,6 +61,9 @@ development:
 test:
   <<: *default
   database: app_test
+  # 同時実行テストはワーカー4スレッド + メインスレッドでデフォルトの5本を使い切るため、
+  # 他にコネクションが1本でも残っているとチェックアウト待ちでタイムアウトする。余裕を持たせる。
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 10 } %>
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/db/migrate/20260810000002_add_unique_index_to_shadow_swing_practice_menus.rb
+++ b/db/migrate/20260810000002_add_unique_index_to_shadow_swing_practice_menus.rb
@@ -1,0 +1,58 @@
+class AddUniqueIndexToShadowSwingPracticeMenus < ActiveRecord::Migration[7.1]
+  MENU_NAME = '素振り'.freeze
+  INDEX_NAME = 'index_practice_menus_on_user_id_and_shadow_swing_name'.freeze
+
+  # 素振りメニューは名前で既存行を探して無ければ作るため、初回セッションの同時完了で
+  # 同名メニューが重複作成されうる。ユーザーが任意の名前を重複させること自体は許容する仕様なので、
+  # 自動生成対象の '素振り' に限定した部分ユニークインデックスで競合を検知できるようにする。
+  def up
+    merge_duplicated_menus
+    add_index :practice_menus, %i[user_id name], unique: true, where: "name = '#{MENU_NAME}'", name: INDEX_NAME
+  end
+
+  def down
+    remove_index :practice_menus, name: INDEX_NAME
+  end
+
+  private
+
+  # 制約追加前に既存の重複を最古の1件へ寄せる。参照元を先に付け替えてから重複行を削除する。
+  def merge_duplicated_menus
+    # 同一 (user_id, input_type, metric) の組み合わせは一意制約があるため、
+    # 付け替えると keeper 側と衝突する敗者側の行だけ先に落とす。
+    execute(<<-SQL.squish)
+      DELETE FROM insight_combinations
+      USING (#{ranked_menus_sql}) AS ranked
+      WHERE insight_combinations.practice_menu_id = ranked.id
+        AND ranked.id <> ranked.keeper_id
+        AND EXISTS (
+          SELECT 1 FROM insight_combinations keeper_row
+          WHERE keeper_row.user_id = insight_combinations.user_id
+            AND keeper_row.input_type = insight_combinations.input_type
+            AND keeper_row.metric = insight_combinations.metric
+            AND keeper_row.practice_menu_id = ranked.keeper_id
+        )
+    SQL
+
+    %w[practice_logs goals menu_set_items schedule_menus insight_combinations].each do |table|
+      execute(<<-SQL.squish)
+        UPDATE #{table} SET practice_menu_id = ranked.keeper_id
+        FROM (#{ranked_menus_sql}) AS ranked
+        WHERE #{table}.practice_menu_id = ranked.id AND ranked.id <> ranked.keeper_id
+      SQL
+    end
+
+    execute(<<-SQL.squish)
+      DELETE FROM practice_menus
+      USING (#{ranked_menus_sql}) AS ranked
+      WHERE practice_menus.id = ranked.id AND ranked.id <> ranked.keeper_id
+    SQL
+  end
+
+  def ranked_menus_sql
+    <<-SQL.squish
+      SELECT id, FIRST_VALUE(id) OVER (PARTITION BY user_id ORDER BY id) AS keeper_id
+      FROM practice_menus WHERE name = '#{MENU_NAME}'
+    SQL
+  end
+end

--- a/db/migrate/20260810000002_add_unique_index_to_shadow_swing_practice_menus.rb
+++ b/db/migrate/20260810000002_add_unique_index_to_shadow_swing_practice_menus.rb
@@ -25,19 +25,21 @@ class AddUniqueIndexToShadowSwingPracticeMenus < ActiveRecord::Migration[7.1]
   # 制約追加前に既存の重複を最古の1件へ寄せる。参照元を先に付け替えてから重複行を削除する。
   def merge_duplicated_menus
     # 同一 (user_id, input_type, metric) の組み合わせは一意制約があるため、
-    # 付け替えると keeper 側と衝突する敗者側の行だけ先に落とす。
+    # 付け替え前に keeper 側だけでなく敗者行同士の重複も含めてグループ内で1件に絞る。
+    # 絞らずに付け替えると、敗者メニューが3件以上あり複数の敗者に同じ組み合わせが
+    # またがっているケースで UPDATE 自体が一意制約違反になりうる。
     execute(<<-SQL.squish)
       DELETE FROM insight_combinations
-      USING (#{ranked_menus_sql}) AS ranked
-      WHERE insight_combinations.practice_menu_id = ranked.id
-        AND ranked.id <> ranked.keeper_id
-        AND EXISTS (
-          SELECT 1 FROM insight_combinations keeper_row
-          WHERE keeper_row.user_id = insight_combinations.user_id
-            AND keeper_row.input_type = insight_combinations.input_type
-            AND keeper_row.metric = insight_combinations.metric
-            AND keeper_row.practice_menu_id = ranked.keeper_id
-        )
+      USING (
+        SELECT ic.id,
+               ROW_NUMBER() OVER (
+                 PARTITION BY ranked.keeper_id, ic.input_type, ic.metric
+                 ORDER BY ic.practice_menu_id
+               ) AS row_number
+        FROM insight_combinations ic
+        JOIN (#{ranked_menus_sql}) AS ranked ON ranked.id = ic.practice_menu_id
+      ) AS dedup
+      WHERE insight_combinations.id = dedup.id AND dedup.row_number > 1
     SQL
 
     %w[practice_logs goals menu_set_items schedule_menus insight_combinations].each do |table|

--- a/db/migrate/20260810000002_add_unique_index_to_shadow_swing_practice_menus.rb
+++ b/db/migrate/20260810000002_add_unique_index_to_shadow_swing_practice_menus.rb
@@ -1,13 +1,19 @@
 class AddUniqueIndexToShadowSwingPracticeMenus < ActiveRecord::Migration[7.1]
   MENU_NAME = '素振り'.freeze
+  MENU_UNIT = 'count'.freeze
   INDEX_NAME = 'index_practice_menus_on_user_id_and_shadow_swing_name'.freeze
+  TARGET_CONDITION = "name = '#{MENU_NAME}' AND unit = '#{MENU_UNIT}'".freeze
 
   # 素振りメニューは名前で既存行を探して無ければ作るため、初回セッションの同時完了で
   # 同名メニューが重複作成されうる。ユーザーが任意の名前を重複させること自体は許容する仕様なので、
-  # 自動生成対象の '素振り' に限定した部分ユニークインデックスで競合を検知できるようにする。
+  # 自動生成対象に絞った部分ユニークインデックスで競合を検知できるようにする。
+  #
+  # 対象は name = '素振り' かつ unit = 'count' のみ。ShadowSwingSession#linked_menu は
+  # count 単位のメニューだけを紐付け対象とし、それ以外の単位の同名メニューは
+  # 無関係なリソースとして素通りさせるため、制約もマージもその範囲に合わせる。
   def up
     merge_duplicated_menus
-    add_index :practice_menus, %i[user_id name], unique: true, where: "name = '#{MENU_NAME}'", name: INDEX_NAME
+    add_index :practice_menus, %i[user_id name], unique: true, where: TARGET_CONDITION, name: INDEX_NAME
   end
 
   def down
@@ -52,7 +58,7 @@ class AddUniqueIndexToShadowSwingPracticeMenus < ActiveRecord::Migration[7.1]
   def ranked_menus_sql
     <<-SQL.squish
       SELECT id, FIRST_VALUE(id) OVER (PARTITION BY user_id ORDER BY id) AS keeper_id
-      FROM practice_menus WHERE name = '#{MENU_NAME}'
+      FROM practice_menus WHERE #{TARGET_CONDITION}
     SQL
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -685,7 +685,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_10_000002) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id", "archived"], name: "index_practice_menus_on_user_id_and_archived"
-    t.index ["user_id", "name"], name: "index_practice_menus_on_user_id_and_shadow_swing_name", unique: true, where: "((name)::text = '素振り'::text)"
+    t.index ["user_id", "name"], name: "index_practice_menus_on_user_id_and_shadow_swing_name", unique: true, where: "(((name)::text = '素振り'::text) AND ((unit)::text = 'count'::text))"
     t.index ["user_id"], name: "index_practice_menus_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_10_000001) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_10_000002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -685,6 +685,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_10_000001) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id", "archived"], name: "index_practice_menus_on_user_id_and_archived"
+    t.index ["user_id", "name"], name: "index_practice_menus_on_user_id_and_shadow_swing_name", unique: true, where: "((name)::text = '素振り'::text)"
     t.index ["user_id"], name: "index_practice_menus_on_user_id"
   end
 

--- a/spec/jobs/app/stripe/webhook_job_spec.rb
+++ b/spec/jobs/app/stripe/webhook_job_spec.rb
@@ -19,6 +19,47 @@ RSpec.describe App::Stripe::WebhookJob, type: :job do
     end
   end
 
+  describe '恒久的エラーの discard' do
+    let(:handler) { instance_double(App::Stripe::Handlers::CheckoutSessionCompletedHandler) }
+
+    before do
+      allow(Sentry).to receive(:capture_exception)
+      allow(App::Stripe::EventDispatcher).to receive(:handler_for).and_return(handler)
+      allow(handler).to receive(:call).and_raise(error)
+    end
+
+    context '恒久的エラー（MissingMetadataError / UnresolvedUserError）のとき' do
+      [App::Stripe::Handlers::CheckoutSessionCompletedHandler::MissingMetadataError,
+       App::Stripe::Handlers::CheckoutSessionCompletedHandler::UnresolvedUserError].each do |error_class|
+        context error_class.name do
+          let(:error) { error_class }
+
+          it 'リトライせず初回で discard し、Sentry 通知も 1 回だけになる' do
+            perform_enqueued_jobs do
+              expect { described_class.perform_later(webhook_event.id) }.not_to raise_error
+            end
+
+            expect(Sentry).to have_received(:capture_exception).once
+            expect(enqueued_jobs).to be_empty
+            expect(webhook_event.reload).to be_failed
+          end
+        end
+      end
+    end
+
+    context '一時的エラー（Stripe API 障害）のとき' do
+      let(:error) { Stripe::APIConnectionError }
+
+      it '従来通り最大 5 回までリトライされる' do
+        perform_enqueued_jobs do
+          expect { described_class.perform_later(webhook_event.id) }.to raise_error(error)
+        end
+
+        expect(Sentry).to have_received(:capture_exception).exactly(5).times
+      end
+    end
+  end
+
   describe 'retry / queue 設定' do
     it 'StandardError で exponential backoff のリトライ設定がある' do
       handlers = described_class.rescue_handlers

--- a/spec/jobs/revenue_cat_webhook_job_spec.rb
+++ b/spec/jobs/revenue_cat_webhook_job_spec.rb
@@ -31,6 +31,47 @@ RSpec.describe RevenueCatWebhookJob, type: :job do
     end
   end
 
+  describe '恒久的エラーの discard' do
+    let(:handler) { instance_double(RevenueCat::Handlers::InitialPurchaseHandler) }
+
+    before do
+      allow(Sentry).to receive(:capture_exception)
+      allow(RevenueCat::EventDispatcher).to receive(:handler_for).and_return(handler)
+      allow(handler).to receive(:call).and_raise(error)
+    end
+
+    context '恒久的エラー（UnresolvedUserError / UnknownProductError）のとき' do
+      [RevenueCat::UserResolver::UnresolvedUserError,
+       RevenueCat::Handlers::BaseHandler::UnknownProductError].each do |error_class|
+        context error_class.name do
+          let(:error) { error_class }
+
+          it 'リトライせず初回で discard し、Sentry 通知も 1 回だけになる' do
+            perform_enqueued_jobs do
+              expect { described_class.perform_later(webhook_event.id) }.not_to raise_error
+            end
+
+            expect(Sentry).to have_received(:capture_exception).once
+            expect(enqueued_jobs).to be_empty
+            expect(webhook_event.reload).to be_failed
+          end
+        end
+      end
+    end
+
+    context '一時的エラー（RequestFailedError）のとき' do
+      let(:error) { RevenueCat::SubscriberClient::RequestFailedError }
+
+      it '従来通り最大 5 回までリトライされる' do
+        perform_enqueued_jobs do
+          expect { described_class.perform_later(webhook_event.id) }.to raise_error(error)
+        end
+
+        expect(Sentry).to have_received(:capture_exception).exactly(5).times
+      end
+    end
+  end
+
   describe 'queue' do
     it 'default キューに enqueue される' do
       expect(described_class.new.queue_name).to eq('default')

--- a/spec/models/practice_session_spec.rb
+++ b/spec/models/practice_session_spec.rb
@@ -11,6 +11,20 @@ RSpec.describe PracticeSession, type: :model do
       expect(described_class.for(user, today)).to eq(first)
     end
 
+    it 'find_by が見逃した行を一意性バリデーションが検知した場合も既存セッションを返す' do
+      winner = create(:practice_session, user:, logged_on: today)
+      relation = user.practice_sessions
+      allow(user).to receive(:practice_sessions).and_return(relation)
+      # 相手方のコミットが find_by の後・バリデーションの前に入った同時到達を再現する。
+      allow(relation).to receive(:find_by).and_return(nil, winner)
+
+      expect(described_class.for(user, today)).to eq(winner)
+    end
+
+    it '一意制約と無関係な検証エラーは握り潰さずそのまま投げる' do
+      expect { described_class.for(user, nil) }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
     context 'PracticeSessions::Upsert の外側トランザクション内から同時に呼ばれたとき' do
       # 別スレッドの実コネクションから同じ日次セッション行を奪い合わせるため、テスト用トランザクションを外す。
       self.use_transactional_tests = false
@@ -36,14 +50,15 @@ RSpec.describe PracticeSession, type: :model do
         count.times { ready.pop }
         count.times { start << true }
         threads.each(&:join)
-        errors
+        Array.new(errors.size) { errors.pop }
       end
 
       it '一意制約の競合から復旧し、セッションを1件だけ作って全リクエストが成功する' do
         errors = upsert_concurrently(4)
 
         aggregate_failures do
-          expect(errors.size).to eq(0)
+          # 失敗時に原因を追えるよう、件数ではなく例外の内容を突き合わせる。
+          expect(errors.map { |e| "#{e.class}: #{e.message}" }).to be_empty
           expect(described_class.where(user_id: user.id, logged_on: today).count).to eq(1)
         end
       end

--- a/spec/models/practice_session_spec.rb
+++ b/spec/models/practice_session_spec.rb
@@ -17,26 +17,30 @@ RSpec.describe PracticeSession, type: :model do
 
       after { ActiveRecord::Base.connection.execute('TRUNCATE TABLE users CASCADE') }
 
-      it '一意制約の競合から復旧し、セッションを1件だけ作って全リクエストが成功する' do
+      # 同じ日付への Upsert を同じタイミングで走らせ、発生した例外を集めて返す。
+      def upsert_concurrently(count)
         errors = Queue.new
         ready = Queue.new
         start = Queue.new
-        threads = Array.new(4) do |index|
+        threads = Array.new(count) do |index|
           Thread.new do
             ActiveRecord::Base.connection_pool.with_connection do
               ready << true
               start.pop
-              begin
-                PracticeSessions::Upsert.new(user:, logged_on: today, memo: "振り返り#{index}").call
-              rescue StandardError => e
-                errors << e
-              end
+              PracticeSessions::Upsert.new(user:, logged_on: today, memo: "振り返り#{index}").call
+            rescue StandardError => e
+              errors << e
             end
           end
         end
-        threads.size.times { ready.pop }
-        threads.size.times { start << true }
+        count.times { ready.pop }
+        count.times { start << true }
         threads.each(&:join)
+        errors
+      end
+
+      it '一意制約の競合から復旧し、セッションを1件だけ作って全リクエストが成功する' do
+        errors = upsert_concurrently(4)
 
         aggregate_failures do
           expect(errors.size).to eq(0)

--- a/spec/models/practice_session_spec.rb
+++ b/spec/models/practice_session_spec.rb
@@ -10,6 +10,40 @@ RSpec.describe PracticeSession, type: :model do
       expect { described_class.for(user, today) }.not_to change(described_class, :count)
       expect(described_class.for(user, today)).to eq(first)
     end
+
+    context 'PracticeSessions::Upsert の外側トランザクション内から同時に呼ばれたとき' do
+      # 別スレッドの実コネクションから同じ日次セッション行を奪い合わせるため、テスト用トランザクションを外す。
+      self.use_transactional_tests = false
+
+      after { ActiveRecord::Base.connection.execute('TRUNCATE TABLE users CASCADE') }
+
+      it '一意制約の競合から復旧し、セッションを1件だけ作って全リクエストが成功する' do
+        errors = Queue.new
+        ready = Queue.new
+        start = Queue.new
+        threads = Array.new(4) do |index|
+          Thread.new do
+            ActiveRecord::Base.connection_pool.with_connection do
+              ready << true
+              start.pop
+              begin
+                PracticeSessions::Upsert.new(user:, logged_on: today, memo: "振り返り#{index}").call
+              rescue StandardError => e
+                errors << e
+              end
+            end
+          end
+        end
+        threads.size.times { ready.pop }
+        threads.size.times { start << true }
+        threads.each(&:join)
+
+        aggregate_failures do
+          expect(errors.size).to eq(0)
+          expect(described_class.where(user_id: user.id, logged_on: today).count).to eq(1)
+        end
+      end
+    end
   end
 
   describe '練習ログの自動ぶら下げ' do

--- a/spec/models/shadow_swing_session_spec.rb
+++ b/spec/models/shadow_swing_session_spec.rb
@@ -115,5 +115,19 @@ RSpec.describe ShadowSwingSession, type: :model do
         expect(logs.first.amount).to eq(40)
       end
     end
+
+    it '素振りメニューが未作成の状態で複数セッションが同時に完了してもメニューは1件しか作られない' do
+      sessions = Array.new(4) { create(:shadow_swing_session, user:, logged_on: today) }
+
+      complete_concurrently(sessions, swing_count: 10)
+
+      menus = user.practice_menus.where(name: described_class::MENU_NAME)
+      log = user.practice_logs.find_by(source: 'shadow_swing', logged_on: today)
+      aggregate_failures do
+        expect(menus.count).to eq(1)
+        expect(log.practice_menu_id).to eq(menus.first.id)
+        expect(log.amount).to eq(40)
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/pro/checkout_spec.rb
+++ b/spec/requests/api/v1/pro/checkout_spec.rb
@@ -11,10 +11,31 @@ RSpec.describe 'Api::V1::Pro::Checkout', type: :request do
   end
 
   describe 'POST /api/v1/pro/checkout' do
+    before { Flipper.enable_actor(:pro_features, user) }
+
+    after { Flipper.disable(:pro_features) }
+
     context '未認証のとき' do
       it '401 を返す' do
         post '/api/v1/pro/checkout', params:, as: :json
         expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'Flipper :pro_features が無効のとき' do
+      let(:builder) { instance_double(App::Stripe::CheckoutSessionBuilder) }
+
+      before do
+        Flipper.disable(:pro_features)
+        allow(App::Stripe::CheckoutSessionBuilder).to receive(:new).and_return(builder)
+      end
+
+      it '403 + error: feature_disabled を返し、Stripe を呼ばない' do
+        post '/api/v1/pro/checkout', params:, headers: auth_headers_for(user), as: :json
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response.parsed_body['error']).to eq('feature_disabled')
+        expect(App::Stripe::CheckoutSessionBuilder).not_to have_received(:new)
       end
     end
 


### PR DESCRIPTION
## 概要

back 側のフォローアップ 4 件をまとめて対応する。

- ippei-shimizu/buzzbase#507 Pro checkout が `pro_features` フラグでガードされていない
- ippei-shimizu/buzzbase#539 Webhook ジョブの恒久的エラーで無駄なリトライ・Sentry 通知が発生する
- ippei-shimizu/buzzbase#541 `PracticeSession.for` の一意制約違反リトライがネストしたトランザクション内で機能しない
- ippei-shimizu/buzzbase#542 素振りメニューの初回同時作成で重複しうる

コミットは issue ごとに分割している。

---

## ippei-shimizu/buzzbase#507 Pro checkout の kill switch ガード

### 問題

`app/controllers/api/v1/pro/checkout_controller.rb` が `Flipper.enabled?(:pro_features, ...)` を一切見ておらず、kill switch を有効にしても API を直接叩けば Stripe Checkout Session が作成できてしまう。Web の販売経路を止める実質的なゲートが front の `startProCheckout()` だけになっていた。

### 対応

`CheckoutController#create` の先頭で `Flipper.enabled?(:pro_features, current_api_v1_user)` を判定し、無効なら Stripe を呼ばずに `403 { "error": "feature_disabled" }` を返す。

エラーコード名は front の `StartProCheckoutResult` が持つ `feature_disabled` に合わせた。なお front 側は現状 `invalid_plan` / `stripe_api_error` しか body から拾っておらず、back の `feature_disabled` は `unknown` に落ちる。front は API 呼び出し前にフラグを見て弾いているため実際には到達しない経路であり、front の変更は本 PR のスコープ外としている（マッピング追加は任意のフォローアップ）。

### `SubscriptionController#update`（プラン変更）にガードを入れなかった理由

`pro_features` は「新規販売を止める」ための kill switch であり、既存課金ユーザーの契約操作を止めるものではないと判断した。月額↔年額のプラン変更まで 403 にすると、販売停止中に既存顧客が自分の契約を調整する手段を失う。解約（`#destroy`）を止めてはならないのと同じ理由で、`#update` もガード対象外としている。新規課金が発生するのは checkout 経路のみなので、kill switch の目的は checkout のガードだけで達成できる。

`Webhooks::StripeController` は既に成立した決済の後処理のためガード不要（issue 記載の通り）。

### テスト

`spec/requests/api/v1/pro/checkout_spec.rb`

- `pro_features` 無効時に 403 + `feature_disabled` を返し、`CheckoutSessionBuilder` を呼ばないこと
- 既存の 200 / 409 / 422 / 502 ケースはフラグ有効前提に更新

---

## ippei-shimizu/buzzbase#539 Webhook ジョブの恒久的エラーを discard する

### 問題

`RevenueCatWebhookJob` / `App::Stripe::WebhookJob` はどちらも `retry_on StandardError, attempts: 5` を持つため、設定漏れ由来の恒久的エラーでもリトライが 5 回走る。`WebhookProcessor#process` は例外のたびに `mark_failed!` + `Sentry.capture_exception` を呼ぶため、回復しないエラーで Sentry に 5 件同一通知が積まれる。

### 対応

各ジョブに `discard_on` を `retry_on` より **後** に登録した。ActiveJob（`ActiveSupport::Rescuable`）は後から登録したハンドラを優先するため、対象クラスだけが初回で discard される。

- `RevenueCatWebhookJob`: `RevenueCat::UserResolver::UnresolvedUserError` / `RevenueCat::Handlers::BaseHandler::UnknownProductError`
- `App::Stripe::WebhookJob`: `App::Stripe::Handlers::CheckoutSessionCompletedHandler::MissingMetadataError` / `...::UnresolvedUserError`

失敗の記録（`mark_failed!`）と Sentry 通知は `WebhookProcessor#process` 側で初回に済むため、discard しても調査に必要な情報は失われない。

### 補足（実測して分かったこと）

issue には「`ApplicationJob` の `rescue_from` との二重通知」とあったが、実測では `rescue_from` は発火していなかった。`rescue_with_handler` は後勝ちでハンドラを選ぶため、サブクラスの `retry_on` が親の `rescue_from StandardError` より優先される。実際に起きていたのは「通知 1 回 × リトライ 5 回 = 5 件」であり、本対応でこれが 1 件になる。テストでもこの差分（恒久的エラー 1 回 / 一時的エラー 5 回）を検証している。

### テスト

`spec/jobs/revenue_cat_webhook_job_spec.rb` / `spec/jobs/app/stripe/webhook_job_spec.rb`

- 恒久的エラー時: リトライされず（`enqueued_jobs` が空）例外も伝播せず、`Sentry.capture_exception` が 1 回だけ、`webhook_event` は `failed`
- 一時的エラー時: 従来通り 5 回リトライされ、`Sentry.capture_exception` が 5 回呼ばれる

---

## ippei-shimizu/buzzbase#541 `PracticeSession.for` のセーブポイント化

### 問題

`PracticeSession.for` は `find_or_create_by!` + `rescue ActiveRecord::RecordNotUnique` で復旧する実装だが、`PracticeSessions::Upsert#call` の外側トランザクション内から呼ばれると、一意制約違反が PostgreSQL のトランザクション全体を abort させ、`rescue` 節の復旧クエリまで `PG::InFailedSqlTransaction` で失敗するリスクがある。

### 対応

`PracticeSessions::Upsert#upsert_condition` で確立済みのパターンに揃え、`find_by` → 無ければ `ActiveRecord::Base.transaction(requires_new: true)` のセーブポイント内で `create!` する形にした。制約違反の影響がセーブポイント内に閉じ、`rescue` 節の `find_by!` が確実に流せる。

### 補足（正直な検証結果）

修正前の実装に対して**必ず失敗する再現テストは作れなかった**。実際に SQL ログを取って確認したところ、アプリが通る経路では `record.save!` の内側で `SAVEPOINT active_record_1` が張られており、`ROLLBACK TO SAVEPOINT` で外側トランザクションが救われていた。一方で、素の `rails runner` で外側トランザクション内に直接 `RecordNotUnique` を起こすと復旧クエリは `PG::InFailedSqlTransaction` で失敗する（＝ issue の指摘する失敗モード自体は実在する）。

したがって本変更は「実証済みバグの修正」ではなく、**Rails 内部の暗黙のセーブポイントに依存せず、復旧が savepoint 内に閉じることを実装として明示する hardening** として入れている。既存の `upsert_condition` / `create_shadow_swing_log` と同じ書き方に揃う点でも読み手のコストが下がる。

### テスト

`spec/models/practice_session_spec.rb`

- `PracticeSessions::Upsert` を 4 スレッドから同時実行し、例外ゼロ・セッションが 1 件だけ作られることを検証（`use_transactional_tests = false` + 別コネクション）

---

## ippei-shimizu/buzzbase#542 素振りメニューの重複作成防止

### 問題

`ShadowSwingSession#linked_menu` は `find_by(name: '素振り')` → 無ければ `create!` するが、`practice_menus` に一意制約が無いため、初回の素振りセッション 2 つがほぼ同時に完了すると「素振り」メニューが重複作成される。

### 対応

ippei-shimizu/buzzbase_back#345 で `practice_logs` に入れた「部分ユニークインデックス + rescue」パターンを踏襲した。

1. マイグレーション `20260810000002_add_unique_index_to_shadow_swing_practice_menus.rb`
   - `practice_menus (user_id, name)` に **`WHERE name = '素振り' AND unit = 'count'` の部分ユニークインデックス**を追加
   - `PracticeMenu` には name の一意性バリデーションが無く、ユーザーが任意の名前を重複させること自体は仕様上許容されている。そのため全メニュー名を一意にはせず、アプリが自動生成する範囲だけに絞った
2. `linked_menu` を `transaction(requires_new: true)` のセーブポイントで囲み、`RecordNotUnique` を rescue して先勝ち行を拾い直す
   - `complete!` のトランザクション内から呼ばれるためセーブポイントが必須
   - 一意インデックスが name / unit の両方で絞られているため、競合相手は必ず count 単位の行になる

### 対象を `unit = 'count'` に限定している理由

`linked_menu` は `existing&.unit == 'count'` のときだけ紐付け、それ以外の単位の同名メニューは `nil` を返して素通りさせる（＝ shadow_swing 機能から見て無関係な別リソースとして扱う）設計になっている。

`PracticeMenu` に name の一意性バリデーションが無い以上、ユーザーがメニュー管理画面から手動で「素振り」という名前・`unit = '分'` 等のメニューを作っているケースはありえる。制約とマージの対象を name だけで決めると、この手動作成メニューのログ・目標・スケジュール紐付けを、自動生成された count 単位のメニューへ誤って統合してしまう。そのため**インデックスの `where` 条件とマイグレーションのマージ対象の両方**に `unit = 'count'` を入れ、単位違いの「素振り」メニューは一意制約からもマージからも完全に除外している。

### レビューしてほしい点: マイグレーションが既存データを更新・削除する

部分インデックス追加前に、既に重複している `'素振り'`（count 単位）メニューを最古の 1 件へマージする処理を入れている（重複があるとインデックス作成自体が失敗するため）。

- `practice_logs` / `goals` / `menu_set_items` / `schedule_menus` / `insight_combinations` の `practice_menu_id` を keeper へ付け替え
- `insight_combinations` は `(user_id, input_type, practice_menu_id, metric)` に一意制約があるため、付け替えると keeper と衝突する敗者側の行のみ先に削除
- 付け替え後に重複メニュー行を削除

本番に重複が存在する可能性は低い想定だが、**行の削除を伴う**ため適用前に確認してほしい。

### テスト

`spec/models/shadow_swing_session_spec.rb`

- 素振りメニュー未作成の状態で 4 セッションを同時完了させ、メニューが 1 件だけ作られ、練習ログがそのメニューに紐付き、本数が合算されることを検証
- 修正前（インデックス削除 + rescue 無し）でこのテストが落ちることも確認済み

---

## 動作確認

```
docker compose exec back bundle exec rspec
=> 1740 examples, 0 failures

docker compose exec back bundle exec rubocop
=> 610 files inspected, no offenses detected

docker compose exec back bundle exec rails db:migrate
=> 20260810000002 AddUniqueIndexToShadowSwingPracticeMenus: migrated
```
