### PR TITLE
Fix: グループ上限403に安定した機械可読エラーコードを追加

### DIFF
--- a/app/controllers/api/v1/group_invitations_controller.rb
+++ b/app/controllers/api/v1/group_invitations_controller.rb
@@ -9,7 +9,8 @@ module Api
         if invitation.nil?
           render json: { error: '招待状況が見つかりません' }, status: :not_found
         elsif !current_api_v1_user.can_create_or_join_group?
-          render json: { error: 'Pro プランでグループを無制限に作成・参加できます' }, status: :forbidden
+          render json: { error: 'group_limit_exceeded',
+                         message: 'Pro プランでグループを無制限に作成・参加できます' }, status: :forbidden
         else
           invitation.accepted!
           render json: { success: true }

--- a/app/controllers/api/v1/group_invite_links_controller.rb
+++ b/app/controllers/api/v1/group_invite_links_controller.rb
@@ -35,7 +35,10 @@ module Api
           return render json: { error: '既にこのグループのメンバーです' }, status: :unprocessable_entity
         end
 
-        return render json: { error: 'Pro プランでグループを無制限に作成・参加できます' }, status: :forbidden unless user.can_create_or_join_group?
+        unless user.can_create_or_join_group?
+          return render json: { error: 'group_limit_exceeded',
+                                message: 'Pro プランでグループを無制限に作成・参加できます' }, status: :forbidden
+        end
 
         ActiveRecord::Base.transaction do
           group.group_invitations.create!(user:, state: 'accepted', sent_at: Time.current)

--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -32,7 +32,10 @@ module Api
       end
 
       def create
-        return render json: { error: 'Pro プランでグループを無制限に作成・参加できます' }, status: :forbidden unless current_api_v1_user.can_create_or_join_group?
+        unless current_api_v1_user.can_create_or_join_group?
+          return render json: { error: 'group_limit_exceeded',
+                                message: 'Pro プランでグループを無制限に作成・参加できます' }, status: :forbidden
+        end
 
         group = current_api_v1_user.groups.build(group_params)
         if group.save

--- a/spec/requests/api/v1/group_invitations_spec.rb
+++ b/spec/requests/api/v1/group_invitations_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe 'Api::V1::GroupInvitations', type: :request do
         post "/api/v1/group_invitations/#{group.id}/accept_invitation", headers: auth_headers_for(user)
 
         expect(response).to have_http_status(:forbidden)
-        expect(response.parsed_body['error']).to eq('Pro プランでグループを無制限に作成・参加できます')
+        expect(response.parsed_body['error']).to eq('group_limit_exceeded')
+        expect(response.parsed_body['message']).to eq('Pro プランでグループを無制限に作成・参加できます')
         expect(invitation.reload.state).to eq('pending')
       end
     end

--- a/spec/requests/api/v1/group_invite_links_spec.rb
+++ b/spec/requests/api/v1/group_invite_links_spec.rb
@@ -152,7 +152,8 @@ RSpec.describe 'Api::V1::GroupInviteLinks', type: :request do
         end.not_to change(GroupInvitation, :count)
 
         expect(response).to have_http_status(:forbidden)
-        expect(response.parsed_body['error']).to eq('Pro プランでグループを無制限に作成・参加できます')
+        expect(response.parsed_body['error']).to eq('group_limit_exceeded')
+        expect(response.parsed_body['message']).to eq('Pro プランでグループを無制限に作成・参加できます')
       end
     end
   end

--- a/spec/requests/api/v1/groups_spec.rb
+++ b/spec/requests/api/v1/groups_spec.rb
@@ -116,7 +116,8 @@ RSpec.describe 'Api::V1::Groups', type: :request do
         end.not_to change(Group, :count)
 
         expect(response).to have_http_status(:forbidden)
-        expect(response.parsed_body['error']).to eq('Pro プランでグループを無制限に作成・参加できます')
+        expect(response.parsed_body['error']).to eq('group_limit_exceeded')
+        expect(response.parsed_body['message']).to eq('Pro プランでグループを無制限に作成・参加できます')
       end
     end
 


### PR DESCRIPTION
## 背景

`ippei-shimizu/buzzbase_front#449`（`ippei-shimizu/buzzbase#495`）のコードレビューで、front側の`isGroupLimitError`がステータスコード403のみで上限エラーを判定しており、対象3エンドポイントの`error`レスポンスが人間向け文言そのものだったため、front/mobileから安全に判定できないという指摘を受けた。

## 対応内容

グループ作成・招待コード参加・招待承認の3エンドポイントが返す403レスポンスを、`users#destroy`の`pro_active`と同じ形式（`error`に機械可読なコード、`message`に人間向け文言）に揃えた。

変更前: `{ "error": "Pro プランでグループを無制限に作成・参加できます" }`
変更後: `{ "error": "group_limit_exceeded", "message": "Pro プランでグループを無制限に作成・参加できます" }`

- `app/controllers/api/v1/groups_controller.rb#create`
- `app/controllers/api/v1/group_invitations_controller.rb#accept_invitation`
- `app/controllers/api/v1/group_invite_links_controller.rb#accept`

対応するspecの期待値も更新した。

## 影響範囲

front（`ippei-shimizu/buzzbase_front#449`）・mobile（`ippei-shimizu/buzzbase_mobile#180`）側で、この新しい`error`コードを見るように追随のコミットを行う（別途対応）。

## 動作確認

```
docker compose exec back bundle exec rspec
=> 1731 examples, 0 failures

docker compose exec back bundle exec rubocop
=> 6 files inspected, no offenses detected（変更ファイルのみ確認、フルスイートも別途0 offenses）
```

なお、このPRのマージはこちらで行います。
