### PR TITLE
Refactor: Webhookジョブの恒久的エラーdiscard_onを共通マーカーで一元化

### DIFF
--- a/app/jobs/app/stripe/webhook_job.rb
+++ b/app/jobs/app/stripe/webhook_job.rb
@@ -10,8 +10,9 @@ module App
       # 設定漏れ由来の恒久的エラーはリトライしても回復しない。ActiveJob は後から登録した
       # ハンドラが優先されるため retry_on より後に置き、初回で discard させる。
       # 失敗の記録と Sentry 通知は WebhookProcessor#process 側で済んでいる。
-      discard_on App::Stripe::Handlers::CheckoutSessionCompletedHandler::MissingMetadataError,
-                 App::Stripe::Handlers::CheckoutSessionCompletedHandler::UnresolvedUserError
+      # 恒久的エラーは App::Stripe::PermanentWebhookError を継承させれば自動的に対象になるため、
+      # 新しい handler を追加する側がこの discard_on 自体を編集する必要はない。
+      discard_on App::Stripe::PermanentWebhookError
 
       # DB から webhook_event が消えていても落とさない（手動削除や DB 競合に備える）。
       def perform(webhook_event_id)

--- a/app/jobs/revenue_cat_webhook_job.rb
+++ b/app/jobs/revenue_cat_webhook_job.rb
@@ -8,8 +8,9 @@ class RevenueCatWebhookJob < ApplicationJob
   # 設定漏れ由来の恒久的エラーはリトライしても回復しない。ActiveJob は後から登録した
   # ハンドラが優先されるため retry_on より後に置き、初回で discard させる。
   # 失敗の記録と Sentry 通知は WebhookProcessor#process 側で済んでいる。
-  discard_on RevenueCat::UserResolver::UnresolvedUserError,
-             RevenueCat::Handlers::BaseHandler::UnknownProductError
+  # 恒久的エラーは RevenueCat::PermanentWebhookError を継承させれば自動的に対象になるため、
+  # 新しい handler を追加する側がこの discard_on 自体を編集する必要はない。
+  discard_on RevenueCat::PermanentWebhookError
 
   # DB から webhook_event が消えていても落とさない（手動削除や DB 競合に備える）。
   def perform(webhook_event_id)

--- a/app/services/app/stripe/handlers/checkout_session_completed_handler.rb
+++ b/app/services/app/stripe/handlers/checkout_session_completed_handler.rb
@@ -7,8 +7,8 @@ module App
         # metadata.user_idが欠落しているときに投げる。WebhookProcessorがこれをrescueして
         # webhook_eventをfailedにするため、決済は成立したのにSubscriptionへStripe IDが
         # 紐付かない状態がprocessed扱いのまま埋もれる（自動復旧できなくなる）のを防ぐ。
-        MissingMetadataError = Class.new(StandardError)
-        UnresolvedUserError = Class.new(StandardError)
+        MissingMetadataError = Class.new(PermanentWebhookError)
+        UnresolvedUserError = Class.new(PermanentWebhookError)
 
         def call
           user_id = payload.metadata[:user_id]

--- a/app/services/app/stripe/permanent_webhook_error.rb
+++ b/app/services/app/stripe/permanent_webhook_error.rb
@@ -4,6 +4,7 @@ module App
     # 各 handler の恒久的エラークラスはこれを継承する。App::Stripe::WebhookJob はこの1クラスだけを
     # discard_on すればよく、新しい恒久的エラーを追加する側が個別に job 側の登録を
     # 忘れるリスクを構造的に防ぐ。
+    # RevenueCat::PermanentWebhookError とは無関係な別クラスなので、RevenueCat側のhandlerからは継承しないこと。
     class PermanentWebhookError < StandardError; end
   end
 end

--- a/app/services/app/stripe/permanent_webhook_error.rb
+++ b/app/services/app/stripe/permanent_webhook_error.rb
@@ -1,0 +1,9 @@
+module App
+  module Stripe
+    # Stripe webhook の設定漏れ等、リトライしても回復しない恒久的エラーの共通マーカー。
+    # 各 handler の恒久的エラークラスはこれを継承する。App::Stripe::WebhookJob はこの1クラスだけを
+    # discard_on すればよく、新しい恒久的エラーを追加する側が個別に job 側の登録を
+    # 忘れるリスクを構造的に防ぐ。
+    class PermanentWebhookError < StandardError; end
+  end
+end

--- a/app/services/revenue_cat/handlers/base_handler.rb
+++ b/app/services/revenue_cat/handlers/base_handler.rb
@@ -6,7 +6,7 @@ module RevenueCat
       # PlanCatalogに未登録のproduct_id/storeを受けたときに投げる。WebhookProcessorがこれを
       # rescueしてwebhook_eventをfailedにするため、課金・プラン変更は成立したのにentitlement
       # が付与されない状態がprocessed扱いのまま埋もれる（自動復旧できなくなる）のを防ぐ。
-      UnknownProductError = Class.new(StandardError)
+      UnknownProductError = Class.new(PermanentWebhookError)
 
       # stale_event? の比較対象。加入の有効／無効が往復しうるイベントだけを並べる。
       ORDERING_SENSITIVE_EVENT_TYPES = %w[cancelled uncancelled billing_issue renewed recovered expired refunded].freeze

--- a/app/services/revenue_cat/permanent_webhook_error.rb
+++ b/app/services/revenue_cat/permanent_webhook_error.rb
@@ -3,5 +3,6 @@ module RevenueCat
   # 各 handler の恒久的エラークラスはこれを継承する。RevenueCatWebhookJob はこの1クラスだけを
   # discard_on すればよく、新しい恒久的エラーを追加する側が個別に job 側の登録を
   # 忘れるリスクを構造的に防ぐ。
+  # App::Stripe::PermanentWebhookError とは無関係な別クラスなので、Stripe側のhandlerからは継承しないこと。
   class PermanentWebhookError < StandardError; end
 end

--- a/app/services/revenue_cat/permanent_webhook_error.rb
+++ b/app/services/revenue_cat/permanent_webhook_error.rb
@@ -1,0 +1,7 @@
+module RevenueCat
+  # RevenueCat webhook の設定漏れ等、リトライしても回復しない恒久的エラーの共通マーカー。
+  # 各 handler の恒久的エラークラスはこれを継承する。RevenueCatWebhookJob はこの1クラスだけを
+  # discard_on すればよく、新しい恒久的エラーを追加する側が個別に job 側の登録を
+  # 忘れるリスクを構造的に防ぐ。
+  class PermanentWebhookError < StandardError; end
+end

--- a/app/services/revenue_cat/user_resolver.rb
+++ b/app/services/revenue_cat/user_resolver.rb
@@ -6,7 +6,7 @@ module RevenueCat
     # 解決できない app_user_id を受けたときに投げる。WebhookProcessor がこれを rescue して
     # webhook_event を failed にするため、課金は成立したのに entitlement が付与されない状態が
     # processed 扱いのまま埋もれる（自動復旧できなくなる）のを防ぐ。
-    UnresolvedUserError = Class.new(StandardError)
+    UnresolvedUserError = Class.new(PermanentWebhookError)
 
     module_function
 

--- a/spec/jobs/app/stripe/webhook_job_spec.rb
+++ b/spec/jobs/app/stripe/webhook_job_spec.rb
@@ -47,6 +47,22 @@ RSpec.describe App::Stripe::WebhookJob, type: :job do
       end
     end
 
+    context 'App::Stripe::PermanentWebhookError を継承した未知のエラーのとき' do
+      # job 側は個別のエラークラスを列挙せず PermanentWebhookError だけを discard_on しているため、
+      # 将来 handler 側で新しい恒久的エラーを追加しても job 側の変更なしに discard される。
+      let(:error) { Class.new(App::Stripe::PermanentWebhookError) }
+
+      it 'リトライせず初回で discard される' do
+        perform_enqueued_jobs do
+          expect { described_class.perform_later(webhook_event.id) }.not_to raise_error
+        end
+
+        expect(Sentry).to have_received(:capture_exception).once
+        expect(enqueued_jobs).to be_empty
+        expect(webhook_event.reload).to be_failed
+      end
+    end
+
     context '一時的エラー（Stripe API 障害）のとき' do
       let(:error) { Stripe::APIConnectionError }
 

--- a/spec/jobs/revenue_cat_webhook_job_spec.rb
+++ b/spec/jobs/revenue_cat_webhook_job_spec.rb
@@ -59,6 +59,22 @@ RSpec.describe RevenueCatWebhookJob, type: :job do
       end
     end
 
+    context 'RevenueCat::PermanentWebhookError を継承した未知のエラーのとき' do
+      # job 側は個別のエラークラスを列挙せず PermanentWebhookError だけを discard_on しているため、
+      # 将来 handler 側で新しい恒久的エラーを追加しても job 側の変更なしに discard される。
+      let(:error) { Class.new(RevenueCat::PermanentWebhookError) }
+
+      it 'リトライせず初回で discard される' do
+        perform_enqueued_jobs do
+          expect { described_class.perform_later(webhook_event.id) }.not_to raise_error
+        end
+
+        expect(Sentry).to have_received(:capture_exception).once
+        expect(enqueued_jobs).to be_empty
+        expect(webhook_event.reload).to be_failed
+      end
+    end
+
     context '一時的エラー（RequestFailedError）のとき' do
       let(:error) { RevenueCat::SubscriberClient::RequestFailedError }
 


### PR DESCRIPTION
## 背景

`ippei-shimizu/buzzbase#544` 対応。`ippei-shimizu/buzzbase_back#346`（`ippei-shimizu/buzzbase#539`）のレビューで提案された、Webhookジョブの恒久的エラーdiscard_on対象を一元化するリファクタ。

## 問題

`RevenueCatWebhookJob` / `App::Stripe::WebhookJob`は、恒久的エラー（設定漏れ等でリトライしても回復しないエラー）を個別のクラス名で`discard_on`に列挙していた。RevenueCat側には`billing_issue_handler`・`cancellation_handler`・`expiration_handler`・`product_change_handler`・`refund_handler`・`renewal_handler`・`uncancellation_handler`など多数のhandlerが存在し、今後これらが新たに恒久的エラーを投げるようになっても、job側の`discard_on`への追加を忘れると、`#539`で直したはずの「最大5回リトライ×Sentry通知重複」がそのまま再発する構造だった。

## 対応

- `RevenueCat::PermanentWebhookError`（`app/services/revenue_cat/permanent_webhook_error.rb`）・`App::Stripe::PermanentWebhookError`（`app/services/app/stripe/permanent_webhook_error.rb`）という共通マーカーエラークラスを新設
- 既存の4つの恒久的エラークラス（`RevenueCat::UserResolver::UnresolvedUserError`・`RevenueCat::Handlers::BaseHandler::UnknownProductError`・`App::Stripe::Handlers::CheckoutSessionCompletedHandler::MissingMetadataError`・同`UnresolvedUserError`）を、それぞれのマーカーを継承する形に変更
- job側の`discard_on`を個別クラスの列挙から`discard_on RevenueCat::PermanentWebhookError` / `discard_on App::Stripe::PermanentWebhookError`の1行に集約

これにより、今後新しいhandlerが恒久的エラーを追加する際は該当するマーカーを継承するだけでよく、job側のdiscard_onを編集する必要がなくなる。

## テスト

既存の4ケース（個別エラークラスのdiscard確認）に加え、`RevenueCat::PermanentWebhookError` / `App::Stripe::PermanentWebhookError`を継承した**未知の**エラークラスでもjob側の変更なしにdiscardされることを検証するテストを追加した（このリファクタの目的そのものを担保するテスト）。

## 動作確認

```
docker compose exec back bundle exec rspec
=> 1744 examples, 0 failures

docker compose exec back bundle exec rubocop
=> 612 files inspected, no offenses detected
```

なお、このPRのマージはこちらで行います。
