### PR TITLE
Fix: Pro機能QA修正（バックエンド: 練習種別・目標指標・予定の終了時刻）

### DIFF
--- a/app/controllers/api/v2/plans_controller.rb
+++ b/app/controllers/api/v2/plans_controller.rb
@@ -47,7 +47,8 @@ module Api
           schedule_id: schedule.id,
           # 「日」表示のタイムラインで時刻軸に配置するため、time 型を保存 TZ に依存しない
           # "HH:MM" 文字列で返す。終日予定は nil。
-          scheduled_time: schedule.scheduled_time&.strftime('%H:%M')
+          scheduled_time: schedule.scheduled_time&.strftime('%H:%M'),
+          end_time: schedule.end_time&.strftime('%H:%M')
         }
       end
 

--- a/app/controllers/api/v2/practice_sessions_controller.rb
+++ b/app/controllers/api/v2/practice_sessions_controller.rb
@@ -42,6 +42,7 @@ module Api
           user: current_api_v1_user,
           logged_on: session_params[:logged_on],
           memo: session_params[:memo],
+          practice_type: session_params[:practice_type],
           improvement_theme_ids: session_params[:improvement_theme_ids],
           items: session_params[:items]&.map(&:to_h) || [],
           condition: session_params[:condition]&.to_h
@@ -71,7 +72,7 @@ module Api
 
       def session_params
         params.require(:practice_session).permit(
-          :logged_on, :memo,
+          :logged_on, :memo, :practice_type,
           improvement_theme_ids: [],
           items: %i[practice_menu_id amount weight memo],
           condition: [:fatigue_level, :physical_level, :sleep_hours, :mood, :memo, { injuries: %i[part memo] }]

--- a/app/controllers/api/v2/schedules/week_copies_controller.rb
+++ b/app/controllers/api/v2/schedules/week_copies_controller.rb
@@ -43,7 +43,9 @@ module Api
             title: schedule.title,
             event_type: schedule.event_type,
             scheduled_time: schedule.scheduled_time,
+            end_time: schedule.end_time,
             planned_on: target_date,
+            note: schedule.note,
             notification_enabled: schedule.notification_enabled,
             notification_message: schedule.notification_message,
             menu_set_id: schedule.menu_set_id
@@ -60,6 +62,8 @@ module Api
           new_schedule
         end
 
+        # 判定キーに note / end_time は含めない。後から追加したカラムを条件に足すと、
+        # 追加前にコピー済みの週が「未コピー」と判定されて重複生成されるため。
         def already_copied?(schedule, target_date)
           current_api_v1_user.schedules.active.single.exists?(
             planned_on: target_date,

--- a/app/controllers/api/v2/schedules_controller.rb
+++ b/app/controllers/api/v2/schedules_controller.rb
@@ -59,7 +59,7 @@ module Api
       # menu_set_id は所有セットのみ許可する（IDOR 防止）。
       def schedule_params
         permitted = params.require(:schedule).permit(
-          :title, :days_of_week, :planned_on, :scheduled_time, :event_type, :menu_set_id,
+          :title, :days_of_week, :planned_on, :scheduled_time, :end_time, :event_type, :menu_set_id,
           :note, :notification_enabled, :active, :notification_message
         )
         permitted.delete(:notification_message) unless current_api_v1_user.has_entitlement?('custom_notification_messages')

--- a/app/jobs/finalize_goals_job.rb
+++ b/app/jobs/finalize_goals_job.rb
@@ -20,6 +20,10 @@ class FinalizeGoalsJob < ApplicationJob
         )
         award_badge(goal) if achieved
       end
+    rescue ActiveRecord::RecordInvalid => e
+      # 1件の不正データで全ユーザーの確定・バッジ付与が止まらないよう、その目標だけ飛ばす。
+      Rails.logger.error("FinalizeGoalsJob skipped goal_id=#{goal.id}: #{e.message}")
+      next
     end
   end
 

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -14,11 +14,17 @@ class Goal < ApplicationRecord
   COMPARISON_TYPES = %w[greater_than less_than].freeze
   KINDS = %w[numeric qualitative manual].freeze
   METRIC_KEYS = %w[
-    practice_days total_swing_count game_count menu_practice_days
+    practice_days self_practice_days total_swing_count game_count
+    menu_practice_days menu_practice_amount
     batting_average on_base_percentage slugging_percentage ops
     hits home_runs runs_batted_in runs_scored stolen_bases
     era whip strikeouts wins saves
   ].freeze
+  # 新規作成では選ばせないが、既存目標の進捗計算・確定を壊さないため METRIC_KEYS には残す。
+  DEPRECATED_METRIC_KEYS = %w[total_swing_count].freeze
+  SELECTABLE_METRIC_KEYS = (METRIC_KEYS - DEPRECATED_METRIC_KEYS).freeze
+  # 対象の練習メニュー指定が必須になる指標。
+  MENU_REQUIRED_METRIC_KEYS = %w[menu_practice_days menu_practice_amount].freeze
 
   validates :title, presence: true, length: { maximum: 60 }
   validates :period_type, inclusion: { in: PERIOD_TYPES }
@@ -26,12 +32,14 @@ class Goal < ApplicationRecord
   validates :comparison_type, inclusion: { in: COMPARISON_TYPES }
   # 数値目標のみ指標必須（定性は達成/未達、自由指標は指標名で管理）。
   validates :metric_key, inclusion: { in: METRIC_KEYS }, if: :numeric?
+  # 廃止指標は新規作成のみ禁止する。既存目標は編集も確定もできる状態を保つ。
+  validates :metric_key, inclusion: { in: SELECTABLE_METRIC_KEYS }, on: :create, if: :numeric?
   # 数値・自由指標は目標値必須（定性目標のみ不要）。負の目標値は成立しない。
   validates :target_value, presence: true, numericality: { greater_than_or_equal_to: 0 }, unless: :qualitative?
   # 自由指標（手動更新）は指標名必須。
   validates :custom_metric_label, presence: true, length: { maximum: 40 }, if: :manual?
-  # 継続目標（メニュー継続日数）は対象メニュー必須。
-  validates :practice_menu_id, presence: true, if: -> { metric_key == 'menu_practice_days' }
+  # メニュー単位の指標（継続日数・実施量）は対象メニュー必須。
+  validates :practice_menu_id, presence: true, if: -> { MENU_REQUIRED_METRIC_KEYS.include?(metric_key) }
   # 他ユーザーの練習メニューを指定できないようにする（IDOR / 名称漏洩防止）。
   validate :practice_menu_owned_by_user, if: -> { practice_menu_id.present? }
   # 他ユーザーのシーズンを指定できないようにする（IDOR / 集計混入防止）。

--- a/app/models/practice_log.rb
+++ b/app/models/practice_log.rb
@@ -23,7 +23,15 @@ class PracticeLog < ApplicationRecord
   def assign_practice_session
     return if practice_session_id.present? || logged_on.blank?
 
-    self.practice_session = PracticeSession.for(user, logged_on)
+    self.practice_session = PracticeSession.for(user, logged_on, practice_type: inferred_practice_type)
+  end
+
+  # 予定チェックから生まれたログは、その予定の種別でその日をチーム練習として起こす。
+  # nil を返した場合はカラム既定値（self_practice）に委ねる。
+  def inferred_practice_type
+    return nil if schedule.nil?
+
+    %w[practice game].include?(schedule.event_type) ? 'team_practice' : nil
   end
 
   def recalculate_activity

--- a/app/models/practice_session.rb
+++ b/app/models/practice_session.rb
@@ -1,4 +1,6 @@
 class PracticeSession < ApplicationRecord
+  PRACTICE_TYPES = %w[self_practice team_practice].freeze
+
   belongs_to :user
   # nullify だと after_commit（草・Streak 再計算）が発火せず集計が古いまま残るため destroy にする。
   has_many :practice_logs, dependent: :destroy
@@ -10,6 +12,7 @@ class PracticeSession < ApplicationRecord
 
   validates :logged_on, presence: true
   validates :user_id, uniqueness: { scope: :logged_on }
+  validates :practice_type, inclusion: { in: PRACTICE_TYPES }
 
   scope :ordered, -> { order(logged_on: :desc) }
 
@@ -18,8 +21,9 @@ class PracticeSession < ApplicationRecord
   #
   # @param user [User]
   # @param date [Date, String]
+  # @param practice_type [String, nil] 新規作成時のみ反映する練習種別（nil ならカラム既定値）
   # @return [PracticeSession]
-  def self.for(user, date)
+  def self.for(user, date, practice_type: nil)
     existing = user.practice_sessions.find_by(logged_on: date)
     return existing if existing
 
@@ -27,7 +31,7 @@ class PracticeSession < ApplicationRecord
     # ユニーク制約違反がトランザクション全体を abort させて rescue 節の復旧クエリまで
     # 道連れになる。セーブポイント内で INSERT させて影響をここに閉じ込める。
     ActiveRecord::Base.transaction(requires_new: true) do
-      user.practice_sessions.create!(logged_on: date)
+      user.practice_sessions.create!({ logged_on: date, practice_type: }.compact)
     end
   rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
     # 同時リクエストで find_by と INSERT の間に他方が作成した場合の復旧。

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -13,7 +13,8 @@ class Schedule < ApplicationRecord
   validates :title, length: { maximum: 50 }, allow_blank: true
   validates :title, presence: true, if: -> { menu_set_id.blank? }
   validates :event_type, inclusion: { in: EVENT_TYPES }
-  validate :note_within_limit
+  # 既存の超過データが「メモを触らない更新」まで弾いて修復不能にならないよう、変更時のみ検証する。
+  validate :note_within_limit, if: :note_changed?
   validate :exactly_one_of_recurrence_or_date
   validate :end_time_after_scheduled_time
 

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,5 +1,6 @@
 class Schedule < ApplicationRecord
   EVENT_TYPES = %w[self_practice practice game other].freeze
+  NOTE_MAX_LENGTH = 2000
 
   belongs_to :user
   belongs_to :menu_set, optional: true
@@ -12,7 +13,9 @@ class Schedule < ApplicationRecord
   validates :title, length: { maximum: 50 }, allow_blank: true
   validates :title, presence: true, if: -> { menu_set_id.blank? }
   validates :event_type, inclusion: { in: EVENT_TYPES }
+  validate :note_within_limit
   validate :exactly_one_of_recurrence_or_date
+  validate :end_time_after_scheduled_time
 
   scope :active, -> { where(active: true) }
   scope :recurring, -> { where.not(days_of_week: nil) }
@@ -61,6 +64,24 @@ class Schedule < ApplicationRecord
       errors.add(:base, '曜日または日付のいずれかを指定してください')
     elsif days_of_week.present? && planned_on.present?
       errors.add(:base, '曜日と日付は同時に指定できません')
+    end
+  end
+
+  # 属性名つきの既定メッセージは日本語ロケール未整備で壊れるため、:base に文言を持たせる。
+  def note_within_limit
+    return if note.blank? || note.length <= NOTE_MAX_LENGTH
+
+    errors.add(:base, "メモは#{NOTE_MAX_LENGTH}文字以内で入力してください")
+  end
+
+  # 日跨ぎの予定は扱わないため、終了時刻は同日内で開始時刻より後であること。
+  def end_time_after_scheduled_time
+    return if end_time.blank?
+
+    if scheduled_time.blank?
+      errors.add(:base, '終了時刻は開始時刻とセットで指定してください')
+    elsif end_time <= scheduled_time
+      errors.add(:base, '終了時刻は開始時刻より後にしてください')
     end
   end
 end

--- a/app/serializers/v2/goal_serializer.rb
+++ b/app/serializers/v2/goal_serializer.rb
@@ -2,6 +2,7 @@ module V2
   class GoalSerializer < ActiveModel::Serializer
     attributes :id, :title, :kind, :period_type, :season_id, :tournament_id, :month_start, :deadline,
                :metric_key, :target_value, :comparison_type, :practice_menu_id, :practice_menu_name,
+               :practice_menu_unit_label,
                :custom_metric_label, :custom_unit, :manual_current_value,
                :is_achieved, :is_finalized, :achieved_value,
                :current_value, :progress_percent, :days_remaining
@@ -16,6 +17,11 @@ module V2
 
     def practice_menu_name
       object.practice_menu&.name
+    end
+
+    # menu_practice_amount の単位はメニューごとに変わるため、指標固定の単位では表せない。
+    def practice_menu_unit_label
+      object.practice_menu&.unit_label
     end
 
     def days_remaining

--- a/app/serializers/v2/plan_serializer.rb
+++ b/app/serializers/v2/plan_serializer.rb
@@ -3,7 +3,7 @@ module V2
   # `done_menu_ids`（schedule_id => その日にログ済みの practice_menu_id 集合）を instance_options で受け取り、
   # 予定単位・メニュー単位の「済」判定に使う。同じメニューが複数の予定にあっても予定ごとに独立して判定する。
   class PlanSerializer < ActiveModel::Serializer
-    attributes :id, :title, :event_type, :scheduled_time, :recurring,
+    attributes :id, :title, :event_type, :scheduled_time, :end_time, :recurring,
                :menu_set_id, :game_result_id, :note, :menus, :done
 
     def title
@@ -12,6 +12,10 @@ module V2
 
     def scheduled_time
       object.scheduled_time&.strftime('%H:%M')
+    end
+
+    def end_time
+      object.end_time&.strftime('%H:%M')
     end
 
     def recurring

--- a/app/serializers/v2/practice_session_serializer.rb
+++ b/app/serializers/v2/practice_session_serializer.rb
@@ -3,7 +3,7 @@ module V2
   # `condition_logs_by_date`（logged_on => ConditionLog）を instance_options で受け取ると
   # それを使う（一覧表示での N+1 防止）。無ければ個別に 1 件取得する（show 等の単発表示用）。
   class PracticeSessionSerializer < ActiveModel::Serializer
-    attributes :id, :logged_on, :memo, :improvement_theme_ids, :created_at
+    attributes :id, :logged_on, :memo, :practice_type, :improvement_theme_ids, :created_at
 
     has_many :practice_logs, serializer: V2::PracticeLogSerializer
 

--- a/app/serializers/v2/schedule_serializer.rb
+++ b/app/serializers/v2/schedule_serializer.rb
@@ -1,6 +1,6 @@
 module V2
   class ScheduleSerializer < ActiveModel::Serializer
-    attributes :id, :title, :days_of_week, :planned_on, :scheduled_time, :event_type,
+    attributes :id, :title, :days_of_week, :planned_on, :scheduled_time, :end_time, :event_type,
                :recurring, :menu_set_id, :game_result_id, :note,
                :notification_enabled, :active, :notification_message, :menus,
                :logged_practice_menu_ids
@@ -17,6 +17,10 @@ module V2
 
     def scheduled_time
       object.scheduled_time&.strftime('%H:%M')
+    end
+
+    def end_time
+      object.end_time&.strftime('%H:%M')
     end
 
     def recurring

--- a/app/services/goals/metric_calculator.rb
+++ b/app/services/goals/metric_calculator.rb
@@ -1,13 +1,15 @@
 module Goals
   # 目標の指標を、その目標の対象期間で集計して現在値を返す。
   # 対応 metric は DISPATCH（Goal::METRIC_KEYS と対応）。自動集計できる打撃/投手/練習の値。
-  class MetricCalculator
+  class MetricCalculator # rubocop:disable Metrics/ClassLength
     # metric_key → 集計メソッド。Goal::METRIC_KEYS で検証済みの許可リスト。
     DISPATCH = {
       'practice_days' => :practice_days,
+      'self_practice_days' => :self_practice_days,
       'total_swing_count' => :total_swing_count,
       'game_count' => :game_count,
       'menu_practice_days' => :menu_practice_days,
+      'menu_practice_amount' => :menu_practice_amount,
       'batting_average' => :batting_average,
       'on_base_percentage' => :on_base_percentage,
       'slugging_percentage' => :slugging_percentage,
@@ -95,6 +97,15 @@ module Goals
            .where('intensity_level >= 1').count
     end
 
+    # 自主練習として記録した日のうち、実際に練習ログがある日を数える。
+    def self_practice_days(from, to)
+      @user.practice_sessions
+           .where(practice_type: 'self_practice', logged_on: from.to_date..to.to_date)
+           .joins(:practice_logs)
+           .distinct.count
+    end
+
+    # 新規作成は不可（Goal::DEPRECATED_METRIC_KEYS）。既存目標の集計のためだけに残す。
     def total_swing_count(from, to)
       @user.practice_logs.where(source: 'shadow_swing', logged_on: from.to_date..to.to_date).sum(:amount).to_i
     end
@@ -106,6 +117,16 @@ module Goals
       @user.practice_logs
            .where(practice_menu_id: @goal.practice_menu_id, logged_on: from.to_date..to.to_date)
            .distinct.count(:logged_on)
+    end
+
+    # メニュー回数: 対象メニューの実施量を期間内で合計する。単位はそのメニューの unit_label。
+    # 素振りメニューを選んだ場合は素振り自動ログ（source=shadow_swing）も対象に含む。
+    def menu_practice_amount(from, to)
+      return 0 if @goal.practice_menu_id.nil?
+
+      @user.practice_logs
+           .where(practice_menu_id: @goal.practice_menu_id, logged_on: from.to_date..to.to_date)
+           .sum(:amount).to_f.round(2)
     end
 
     def game_count(from, to)

--- a/app/services/practice_sessions/upsert.rb
+++ b/app/services/practice_sessions/upsert.rb
@@ -16,13 +16,15 @@ module PracticeSessions
     # @param user [User]
     # @param logged_on [Date, String]
     # @param memo [String, nil] その日の振り返りメモ
+    # @param practice_type [String, nil] 自主練習/チーム練習の種別（nil なら更新しない）
     # @param improvement_theme_ids [Array<Integer, String>, nil] 紐付ける課題テーマ群（nilならテーマ紐付けを更新しない）
     # @param items [Array<Hash>] [{ practice_menu_id:, amount:, memo: }]
     # @param condition [Hash, nil] コンディション入力（nil なら更新しない）
-    def initialize(user:, logged_on:, memo: nil, improvement_theme_ids: nil, items: [], condition: nil)
+    def initialize(user:, logged_on:, memo: nil, practice_type: nil, improvement_theme_ids: nil, items: [], condition: nil)
       @user = user
       @logged_on = logged_on
       @memo = memo
+      @practice_type = practice_type
       @improvement_theme_ids = improvement_theme_ids
       @items = items || []
       @condition = condition
@@ -32,8 +34,8 @@ module PracticeSessions
     def call
       session = nil
       ActiveRecord::Base.transaction do
-        session = PracticeSession.for(@user, @logged_on)
-        session.update!(memo: @memo) unless @memo.nil?
+        session = PracticeSession.for(@user, @logged_on, practice_type: @practice_type)
+        update_session_attributes(session)
         assign_themes(session) unless @improvement_theme_ids.nil?
         sync_items(session)
         upsert_condition if @condition.present?
@@ -42,6 +44,15 @@ module PracticeSessions
     end
 
     private
+
+    # memo と practice_type は片方だけ送られることがあるため、1回の update! にまとめて
+    # 送られなかった側を nil で潰さないようにする。
+    def update_session_attributes(session)
+      attributes = {}
+      attributes[:memo] = @memo unless @memo.nil?
+      attributes[:practice_type] = @practice_type unless @practice_type.nil?
+      session.update!(attributes) if attributes.any?
+    end
 
     # 自分の課題テーマのみ紐付ける（他ユーザーの課題は無視）。無料は1件まで、Proは複数件可。
     # Pro 解約後も既存の複数紐付けを維持・削減できるよう、既存件数を超えて新規に増やす場合のみ

--- a/db/migrate/20260811010001_add_practice_type_to_practice_sessions.rb
+++ b/db/migrate/20260811010001_add_practice_type_to_practice_sessions.rb
@@ -1,0 +1,6 @@
+class AddPracticeTypeToPracticeSessions < ActiveRecord::Migration[7.1]
+  def change
+    # 「自主練習日数」目標の集計軸。既存データは大半が個人記録なので self_practice を既定にする。
+    add_column :practice_sessions, :practice_type, :string, null: false, default: 'self_practice'
+  end
+end

--- a/db/migrate/20260811010002_backfill_practice_type_on_practice_sessions.rb
+++ b/db/migrate/20260811010002_backfill_practice_type_on_practice_sessions.rb
@@ -1,0 +1,19 @@
+class BackfillPracticeTypeOnPracticeSessions < ActiveRecord::Migration[7.1]
+  # 予定チェックから生まれたログを持つ日は、その予定の種別をその日の種別とみなす。
+  # PracticeLog#assign_practice_session の推論と同じルール。
+  def up
+    execute(<<-SQL.squish)
+      UPDATE practice_sessions SET practice_type = 'team_practice', updated_at = NOW()
+      WHERE EXISTS (
+        SELECT 1 FROM practice_logs
+        JOIN schedules ON schedules.id = practice_logs.schedule_id
+        WHERE practice_logs.practice_session_id = practice_sessions.id
+          AND schedules.event_type IN ('practice', 'game')
+      )
+    SQL
+  end
+
+  def down
+    # 変更前の練習種別を保持していないため書き戻せない。巻き戻しはカラム削除で行う。
+  end
+end

--- a/db/migrate/20260811020001_add_end_time_to_schedules.rb
+++ b/db/migrate/20260811020001_add_end_time_to_schedules.rb
@@ -1,0 +1,6 @@
+class AddEndTimeToSchedules < ActiveRecord::Migration[7.1]
+  def change
+    # 終日予定・開始時刻のみの予定を許容するため nullable。
+    add_column :schedules, :end_time, :time
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_10_000002) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_11_020001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -705,6 +705,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_10_000002) do
     t.text "memo"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "practice_type", default: "self_practice", null: false
     t.index ["user_id", "logged_on"], name: "index_practice_sessions_on_user_id_and_logged_on", unique: true
     t.index ["user_id"], name: "index_practice_sessions_on_user_id"
   end
@@ -772,6 +773,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_10_000002) do
     t.string "event_type", default: "self_practice", null: false
     t.bigint "menu_set_id"
     t.bigint "game_result_id"
+    t.time "end_time"
     t.index ["game_result_id"], name: "index_schedules_on_game_result_id"
     t.index ["menu_set_id"], name: "index_schedules_on_menu_set_id"
     t.index ["user_id", "active"], name: "index_schedules_on_user_id_and_active"

--- a/spec/factories/practice_sessions.rb
+++ b/spec/factories/practice_sessions.rb
@@ -4,6 +4,10 @@ FactoryBot.define do
     logged_on { Time.find_zone('Asia/Tokyo').today }
     memo { nil }
 
+    trait :team_practice do
+      practice_type { 'team_practice' }
+    end
+
     transient do
       improvement_theme { nil }
     end

--- a/spec/models/goal_spec.rb
+++ b/spec/models/goal_spec.rb
@@ -28,4 +28,41 @@ RSpec.describe Goal, type: :model do
       expect(build(:goal, :qualitative, user:)).to be_valid
     end
   end
+
+  describe 'metric_key のバリデーション' do
+    it '廃止指標は新規作成できない' do
+      goal = build(:goal, user:, metric_key: 'total_swing_count')
+
+      expect(goal).not_to be_valid
+      expect(goal.errors[:metric_key]).to be_present
+    end
+
+    it '廃止指標の既存目標は編集して保存できる' do
+      goal = build(:goal, user:, metric_key: 'total_swing_count')
+      goal.save!(validate: false)
+
+      expect(goal.update(title: '編集後のタイトル')).to be(true)
+    end
+
+    it '許可リストに無い指標は無効' do
+      expect(build(:goal, user:, metric_key: 'unknown_metric')).not_to be_valid
+    end
+  end
+
+  describe 'メニュー単位指標の practice_menu_id' do
+    it 'メニュー回数(menu_practice_amount)は対象メニュー必須' do
+      goal = build(:goal, user:, metric_key: 'menu_practice_amount', practice_menu: nil)
+
+      expect(goal).not_to be_valid
+      expect(goal.errors[:practice_menu_id]).to be_present
+    end
+
+    it 'メニュー継続日数(menu_practice_days)は対象メニュー必須' do
+      expect(build(:goal, user:, metric_key: 'menu_practice_days', practice_menu: nil)).not_to be_valid
+    end
+
+    it '対象メニューを指定すれば有効' do
+      expect(build(:goal, user:, metric_key: 'menu_practice_amount', practice_menu: create(:practice_menu, user:))).to be_valid
+    end
+  end
 end

--- a/spec/models/practice_session_spec.rb
+++ b/spec/models/practice_session_spec.rb
@@ -65,6 +65,26 @@ RSpec.describe PracticeSession, type: :model do
     end
   end
 
+  describe 'practice_type' do
+    it '既定は自主練習' do
+      expect(described_class.for(user, today).practice_type).to eq('self_practice')
+    end
+
+    it '許可リストに無い種別は無効' do
+      expect(build(:practice_session, user:, practice_type: 'unknown')).not_to be_valid
+    end
+
+    it '新規作成時のみ指定した種別が入る' do
+      expect(described_class.for(user, today, practice_type: 'team_practice').practice_type).to eq('team_practice')
+    end
+
+    it '既存セッションがあれば種別を上書きしない' do
+      create(:practice_session, user:, logged_on: today)
+
+      expect(described_class.for(user, today, practice_type: 'team_practice').practice_type).to eq('self_practice')
+    end
+  end
+
   describe '練習ログの自動ぶら下げ' do
     let!(:menu) { create(:practice_menu, user:) }
 
@@ -72,6 +92,22 @@ RSpec.describe PracticeSession, type: :model do
       log = user.practice_logs.create!(practice_menu: menu, logged_on: today, amount: 100, menu_name: menu.name, source: 'manual')
       expect(log.practice_session).to be_present
       expect(log.practice_session.logged_on).to eq(today)
+    end
+
+    it 'チーム練習・試合の予定から作られたログはその日をチーム練習として起こす' do
+      schedule = create(:schedule, user:, event_type: 'practice')
+      log = user.practice_logs.create!(practice_menu: menu, schedule:, logged_on: today, amount: 100,
+                                       menu_name: menu.name, source: 'manual')
+
+      expect(log.practice_session.practice_type).to eq('team_practice')
+    end
+
+    it '自主練習の予定から作られたログは自主練習のままにする' do
+      schedule = create(:schedule, user:, event_type: 'self_practice')
+      log = user.practice_logs.create!(practice_menu: menu, schedule:, logged_on: today, amount: 100,
+                                       menu_name: menu.name, source: 'manual')
+
+      expect(log.practice_session.practice_type).to eq('self_practice')
     end
 
     it '同日の複数ログは同一セッションに束ねられる' do

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe Schedule, type: :model do
+  let(:user) { create(:user) }
+
+  describe 'メモの長さ' do
+    it '上限を超えるメモは保存できない' do
+      schedule = build(:schedule, user:, note: 'あ' * (described_class::NOTE_MAX_LENGTH + 1))
+
+      expect(schedule).not_to be_valid
+      expect(schedule.errors[:base]).to include("メモは#{described_class::NOTE_MAX_LENGTH}文字以内で入力してください")
+    end
+
+    # 上限を後から追加したため、既存の超過データがメモ以外の編集まで巻き込んで修復不能にならないようにする。
+    it '既に超過しているメモを触らない更新は通す' do
+      schedule = build(:schedule, user:, note: 'あ' * (described_class::NOTE_MAX_LENGTH + 1))
+      schedule.save!(validate: false)
+
+      expect(schedule.update(title: '編集後のタイトル')).to be(true)
+    end
+
+    it '既に超過しているメモをさらに超過した内容へ変えるのは弾く' do
+      schedule = build(:schedule, user:, note: 'あ' * (described_class::NOTE_MAX_LENGTH + 1))
+      schedule.save!(validate: false)
+
+      expect(schedule.update(note: 'い' * (described_class::NOTE_MAX_LENGTH + 1))).to be(false)
+    end
+  end
+
+  describe '終了時刻' do
+    it '開始時刻より後なら有効' do
+      expect(build(:schedule, user:, scheduled_time: '09:00', end_time: '12:30')).to be_valid
+    end
+
+    it '開始時刻が無いと指定できない' do
+      schedule = build(:schedule, user:, scheduled_time: nil, end_time: '12:30')
+
+      expect(schedule).not_to be_valid
+      expect(schedule.errors[:base]).to include('終了時刻は開始時刻とセットで指定してください')
+    end
+
+    it '開始時刻以前は指定できない' do
+      schedule = build(:schedule, user:, scheduled_time: '09:00', end_time: '09:00')
+
+      expect(schedule).not_to be_valid
+      expect(schedule.errors[:base]).to include('終了時刻は開始時刻より後にしてください')
+    end
+
+    it '未設定なら有効' do
+      expect(build(:schedule, user:, scheduled_time: '09:00', end_time: nil)).to be_valid
+    end
+  end
+end

--- a/spec/requests/api/v2/goals_spec.rb
+++ b/spec/requests/api/v2/goals_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe 'Api::V2::Goals', type: :request do
       it 'カスタム期間目標は無料は403' do
         params = { goal: { title: '大会前3週間', period_type: 'custom',
                            month_start: today, deadline: today + 21,
-                           metric_key: 'total_swing_count', target_value: 2000 } }
+                           metric_key: 'practice_days', target_value: 20 } }
         post '/api/v2/goals', params:, headers: auth_headers_for(user)
         expect(response).to have_http_status(:forbidden)
       end
@@ -133,7 +133,7 @@ RSpec.describe 'Api::V2::Goals', type: :request do
         make_pro(user)
         params = { goal: { title: '大会前3週間', period_type: 'custom',
                            month_start: today, deadline: today + 21,
-                           metric_key: 'total_swing_count', target_value: 2000 } }
+                           metric_key: 'practice_days', target_value: 20 } }
         post '/api/v2/goals', params:, headers: auth_headers_for(user)
         expect(response).to have_http_status(:created)
       end
@@ -305,6 +305,29 @@ RSpec.describe 'Api::V2::Goals', type: :request do
 
       FinalizeGoalsJob.new.perform
       expect(goal.reload.achieved_at).to be_within(1.second).of(achieved_at)
+    end
+
+    it '廃止指標の目標も確定できる' do
+      goal = build(:goal, user:, metric_key: 'total_swing_count', target_value: 100, deadline: today - 1,
+                          month_start: (today - 1).beginning_of_month)
+      goal.save!(validate: false)
+
+      FinalizeGoalsJob.new.perform
+      expect(goal.reload.is_finalized).to be(true)
+    end
+
+    it '保存に失敗する目標があっても他ユーザーの確定を止めない' do
+      # 許可リストから外れた指標が残っている状態を再現する。
+      broken = build(:goal, user:, metric_key: 'removed_metric', target_value: 1, deadline: today - 1,
+                            month_start: (today - 1).beginning_of_month)
+      broken.save!(validate: false)
+      other_user = create(:user)
+      healthy = create(:goal, user: other_user, metric_key: 'practice_days', target_value: 1, deadline: today - 1,
+                              month_start: (today - 1).beginning_of_month)
+
+      expect { FinalizeGoalsJob.new.perform }.not_to raise_error
+      expect(healthy.reload.is_finalized).to be(true)
+      expect(broken.reload.is_finalized).to be(false)
     end
   end
 end

--- a/spec/requests/api/v2/plans_spec.rb
+++ b/spec/requests/api/v2/plans_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe 'Api::V2::Plans', type: :request do
       expect(titles).to contain_exactly('朝練', '試合')
     end
 
+    it '終了時刻を返す' do
+      create(:schedule, user:, title: '全体練習', days_of_week: '1',
+                        scheduled_time: '09:00', end_time: '12:30')
+
+      get '/api/v2/plans/by_date', params: { date: '2026-07-06' }, headers: auth_headers_for(user)
+
+      plan = response.parsed_body.find { |item| item['title'] == '全体練習' }
+      expect(plan['end_time']).to eq('12:30')
+    end
+
     it '時刻順（未設定は末尾）で並ぶ' do
       create(:schedule, user:, title: '午後', days_of_week: '1', scheduled_time: '15:00')
       create(:schedule, user:, title: '朝', days_of_week: '1', scheduled_time: '06:00')
@@ -105,6 +115,19 @@ RSpec.describe 'Api::V2::Plans', type: :request do
       entries = response.parsed_body['entries'].index_by { |entry| entry['title'] }
       expect(entries['朝練']['scheduled_time']).to eq('06:00')
       expect(entries['終日']['scheduled_time']).to be_nil
+    end
+
+    it '終了時刻を "HH:MM" で返し、未設定なら nil を返す' do
+      make_pro(user)
+      create(:schedule, user:, title: '全体練習', days_of_week: nil, planned_on: '2026-07-08',
+                        scheduled_time: '09:00', end_time: '12:30')
+      create(:schedule, user:, title: '朝練', days_of_week: nil, planned_on: '2026-07-08', scheduled_time: '06:00')
+
+      get '/api/v2/plans/calendar', params: { from: '2026-07-08', to: '2026-07-08' }, headers: auth_headers_for(user)
+
+      entries = response.parsed_body['entries'].index_by { |entry| entry['title'] }
+      expect(entries['全体練習']['end_time']).to eq('12:30')
+      expect(entries['朝練']['end_time']).to be_nil
     end
 
     context '無料ユーザーの閲覧範囲(直近月中心)' do

--- a/spec/requests/api/v2/practice_sessions_spec.rb
+++ b/spec/requests/api/v2/practice_sessions_spec.rb
@@ -49,6 +49,49 @@ RSpec.describe 'Api::V2::PracticeSessions', type: :request do
       expect(session.practice_logs.find_by(practice_menu: batting_menu).amount.to_i).to eq(300)
     end
 
+    it '練習種別を保存して返す' do
+      post '/api/v2/practice_sessions',
+           params: { practice_session: { logged_on: today, practice_type: 'team_practice', items: } },
+           headers: auth_headers_for(user)
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body['practice_type']).to eq('team_practice')
+    end
+
+    it '練習種別の既定は自主練習' do
+      post '/api/v2/practice_sessions', params: { practice_session: { logged_on: today, items: } },
+                                        headers: auth_headers_for(user)
+      expect(response.parsed_body['practice_type']).to eq('self_practice')
+    end
+
+    it '練習種別だけを再 POST してもメモを消さない' do
+      post '/api/v2/practice_sessions', params: { practice_session: { logged_on: today, memo: '今日の振り返り', items: } },
+                                        headers: auth_headers_for(user)
+      post '/api/v2/practice_sessions',
+           params: { practice_session: { logged_on: today, practice_type: 'team_practice', items: } },
+           headers: auth_headers_for(user)
+
+      body = response.parsed_body
+      expect(body['memo']).to eq('今日の振り返り')
+      expect(body['practice_type']).to eq('team_practice')
+    end
+
+    it 'メモだけを再 POST しても練習種別を戻さない' do
+      post '/api/v2/practice_sessions',
+           params: { practice_session: { logged_on: today, practice_type: 'team_practice', items: } },
+           headers: auth_headers_for(user)
+      post '/api/v2/practice_sessions', params: { practice_session: { logged_on: today, memo: '追記', items: } },
+                                        headers: auth_headers_for(user)
+
+      expect(response.parsed_body['practice_type']).to eq('team_practice')
+    end
+
+    it '許可されない練習種別は422' do
+      post '/api/v2/practice_sessions',
+           params: { practice_session: { logged_on: today, practice_type: 'unknown', items: } },
+           headers: auth_headers_for(user)
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
     it '筋トレ（weight_reps）は重さと回数を保存する' do
       strength_menu = create(:practice_menu, user:, name: 'ベンチプレス', category: 'strength',
                                              unit: 'weight_reps', unit_label: '回')

--- a/spec/requests/api/v2/schedules/week_copies_spec.rb
+++ b/spec/requests/api/v2/schedules/week_copies_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe 'Api::V2::Schedules::WeekCopies', type: :request do
       expect(response.parsed_body.first['notification_message']).to eq('頑張れ')
     end
 
+    it '複製結果に終了時刻とメモを引き継ぐ' do
+      make_pro(user)
+      create(:schedule, user:, title: '全体練習', days_of_week: nil, planned_on: '2026-07-06',
+                        scheduled_time: '09:00', end_time: '12:30', note: '集合はグラウンド前')
+
+      post '/api/v2/schedules/week_copy', params: { week_start: '2026-07-06' }, headers: auth_headers_for(user)
+
+      copied = response.parsed_body.first
+      expect(copied['end_time']).to eq('12:30')
+      expect(copied['note']).to eq('集合はグラウンド前')
+    end
+
     it '無料ユーザーは403（Pro限定機能）' do
       create(:schedule, user:, title: '朝練', days_of_week: nil, planned_on: '2026-07-06', scheduled_time: '06:00')
       post '/api/v2/schedules/week_copy', params: { week_start: '2026-07-06' }, headers: auth_headers_for(user)

--- a/spec/requests/api/v2/schedules_spec.rb
+++ b/spec/requests/api/v2/schedules_spec.rb
@@ -60,6 +60,50 @@ RSpec.describe 'Api::V2::Schedules', type: :request do
       expect(response).to have_http_status(:created)
     end
 
+    context '終了時刻・メモ' do
+      it '終了時刻とメモを保存し "HH:MM" 形式で返す' do
+        post '/api/v2/schedules',
+             params: { schedule: { title: '全体練習', days_of_week: '1', scheduled_time: '09:00',
+                                   end_time: '12:30', note: '集合はグラウンド前' } },
+             headers: auth_headers_for(user)
+        expect(response).to have_http_status(:created)
+        body = response.parsed_body
+        expect(body['end_time']).to eq('12:30')
+        expect(body['note']).to eq('集合はグラウンド前')
+      end
+
+      it '終了時刻のみの指定は422' do
+        post '/api/v2/schedules',
+             params: { schedule: { title: 'x', days_of_week: '1', end_time: '12:30' } },
+             headers: auth_headers_for(user)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'メモが長すぎると読めるエラーを返す' do
+        post '/api/v2/schedules',
+             params: { schedule: { title: 'x', days_of_week: '1', note: 'あ' * 2001 } },
+             headers: auth_headers_for(user)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['errors']).to include('メモは2000文字以内で入力してください')
+      end
+
+      it '終了時刻が開始時刻以前だと422' do
+        post '/api/v2/schedules',
+             params: { schedule: { title: 'x', days_of_week: '1', scheduled_time: '09:00', end_time: '09:00' } },
+             headers: auth_headers_for(user)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['errors']).to include('終了時刻は開始時刻より後にしてください')
+      end
+
+      it '終了時刻なしでも作成できる' do
+        post '/api/v2/schedules',
+             params: { schedule: { title: 'x', days_of_week: '1', scheduled_time: '09:00' } },
+             headers: auth_headers_for(user)
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body['end_time']).to be_nil
+      end
+    end
+
     context 'カスタム通知文' do
       let(:custom_params) do
         { schedule: { title: 'x', days_of_week: '1', scheduled_time: '06:00', notification_message: '頑張れ' } }

--- a/spec/services/goals/metric_calculator_spec.rb
+++ b/spec/services/goals/metric_calculator_spec.rb
@@ -64,6 +64,38 @@ RSpec.describe Goals::MetricCalculator do
 
       expect(described_class.new(goal).current_value).to eq(2)
     end
+
+    it 'メニュー回数(menu_practice_amount)は対象メニューの実施量を期間内で合計する' do
+      menu = create(:practice_menu, user:)
+      month = Time.find_zone('Asia/Tokyo').today.beginning_of_month
+      create(:practice_log, user:, practice_menu: menu, logged_on: month + 5, amount: 200)
+      create(:practice_log, user:, practice_menu: menu, logged_on: month + 6, amount: 150)
+      create(:practice_log, user:, practice_menu: create(:practice_menu, user:), logged_on: month + 5, amount: 999)
+      goal = create(:goal, user:, metric_key: 'menu_practice_amount', practice_menu: menu, target_value: 1000)
+
+      expect(described_class.new(goal).current_value).to eq(350.0)
+    end
+
+    it '自主練習日数(self_practice_days)は自主練習かつ練習ログのある日だけを数える' do
+      month = Time.find_zone('Asia/Tokyo').today.beginning_of_month
+      create(:practice_log, user:, logged_on: month + 5)
+      create(:practice_log, user:, logged_on: month + 6)
+      user.practice_sessions.find_by(logged_on: month + 6).update!(practice_type: 'team_practice')
+      # ログの無い自主練習日はカウントしない。
+      create(:practice_session, user:, logged_on: month + 7)
+      goal = create(:goal, user:, metric_key: 'self_practice_days', target_value: 20)
+
+      expect(described_class.new(goal).current_value).to eq(1)
+    end
+
+    it '素振り本数(total_swing_count)は新規作成できないが既存目標の集計は続く' do
+      month = Time.find_zone('Asia/Tokyo').today.beginning_of_month
+      create(:practice_log, user:, source: 'shadow_swing', logged_on: month + 5, amount: 300)
+      goal = build(:goal, user:, metric_key: 'total_swing_count', target_value: 2000)
+      goal.save!(validate: false)
+
+      expect(described_class.new(goal).current_value).to eq(300)
+    end
   end
 
   describe 'シーズン目標の集計' do


### PR DESCRIPTION
## 概要

ippei-shimizu/buzzbase#545 のQA修正のうち、バックエンド側の対応です。

front / mobile の対応PRと合わせてリリースします。

## 変更内容

### 1. 練習記録に自主練習/チーム練習の種別を追加

「自主練習日数」目標を集計するための基盤です。自主練とチーム練を区別するカラムが `schedules.event_type` にしか無かったため、練習記録側（日単位）に持たせました。

- `practice_sessions.practice_type`（`self_practice` / `team_practice`、NOT NULL・既定 `self_practice`）を追加
- 既存行は、予定経由のログを持ち `event_type ∈ {practice, game}` の日だけ `team_practice` へバックフィル
- `PracticeLog#assign_practice_session` が予定の種別から推論して当日のセッションを起こす（バックフィルと同じルール）
- `PracticeSessions::Upsert` は `memo` と `practice_type` を1回の `update!` にまとめる。片方だけ送られたときに、もう片方を `nil` で潰さないため

### 2. 目標指標の入れ替え

- 追加: `self_practice_days`（自主練習日数）、`menu_practice_amount`（メニュー回数 / 対象メニューの実施量を合計）
- `total_swing_count`（素振り本数）は **新規作成のみ禁止**（`SELECTABLE_METRIC_KEYS`）にし、`METRIC_KEYS` からは削除していません
- `GoalSerializer` に `practice_menu_unit_label` を追加（メニュー回数の単位はメニューごとに変わるため）
- `FinalizeGoalsJob` に目標単位の `rescue ActiveRecord::RecordInvalid` を追加

#### 素振り本数を削除しなかった理由

`METRIC_KEYS` から外すと、既存の素振り本数目標が `FinalizeGoalsJob` の `goal.update!` で `RecordInvalid` を投げます。同ジョブには `rescue` が無く、`find_each` の途中で例外が上がると **全ユーザーの目標確定とバッジ付与が止まります**。

さらに `goals_controller` の `update_params` は `metric_key` を更新対象から外しているため、影響を受けたユーザーは自力で修復できず、タイトルや期限の編集まで 422 になります。確定済み履歴も `GoalSerializer` → `MetricCalculator` を通るため、dispatch を消すと過去の達成値が 0 に書き換わって見えます。

QAの要望である「指標リストから素振り本数を削除」は、クライアント側の選択肢（`GOAL_METRIC_CATEGORIES`）から外すことで満たしています。あわせて、1件の不正データがバッチ全体を止める構造自体も `rescue` で解消しました。

### 3. 予定に終了時刻を追加・メモを週コピーへ引き継ぎ

- `schedules.end_time`（`time`, nullable）を追加
- 開始時刻とセットでのみ指定可、開始より後であることをバリデーション（日跨ぎは非対応）
- `note` に長さ上限（2000文字）を追加
- permit / `ScheduleSerializer` / `PlanSerializer` / `plans_controller#calendar_entry` / 週コピーの **5箇所** を同時に対応
- 週コピーで `note` が引き継がれていなかった既存の積み残しも修正

週コピーの重複判定キー（`already_copied?`）は **変更していません**。後から追加したカラムを判定に足すと、追加前にコピー済みの週がコピー先の新カラムNULLゆえ「未コピー」と誤判定され、重複生成されるためです。

## マイグレーション

```
20260811010001  practice_sessions に practice_type を追加
20260811010002  practice_type のバックフィル（生SQL・down は空）
20260811020001  schedules に end_time を追加
```

バックフィルは `down` で書き戻せません（変更前の種別を保持していないため）。巻き戻す場合はカラム削除で対応します。

## テスト

`1773 examples, 0 failures` / `rubocop` 違反なし

追加した観点:
- 廃止指標が create で弾かれ update では通ること、確定ジョブが完走すること
- 不正な目標が1件あってもバッチ全体が止まらないこと
- `practice_type` のみ / `memo` のみを再POSTしても、もう片方が消えないこと
- 終了時刻の形式・バリデーション（開始時刻なし / 開始時刻以前で422）
- 週コピーで `note` / `end_time` が引き継がれ、2回実行しても重複しないこと

## リリース前に確認をお願いしたいこと

本番の Rails console で以下を確認してください（Heroku へのアクセスはこちらでは行っていません）。

- `Schedule.where('length(note) > 2000').count` が 0 であること（`note` に長さ上限を追加したため）
- `Goal.where(metric_key: 'total_swing_count').count` — 既存件数の把握

## 補足

既存ユーザーの練習日はほぼすべて `self_practice` にバックフィルされるため、`self_practice_days` は過去分が実態より多めに出ます。今後の記録は記録画面で選んだ種別が入ります。
