### PR TITLE
Fix: users.tokensがNULLのユーザーで認証系がNoMethodErrorで落ちる問題を修正

### DIFF
--- a/app/controllers/api/v1/auth/google_controller.rb
+++ b/app/controllers/api/v1/auth/google_controller.rb
@@ -35,8 +35,9 @@ module Api
 
           user = User.find_by(email: google_data[:email])
           if user
-            user.update!(provider: 'google', uid: google_data[:uid])
-            user.update!(confirmed_at: Time.current) if user.confirmed_at.blank?
+            attrs = { provider: 'google', uid: google_data[:uid] }
+            attrs[:confirmed_at] = Time.current if user.confirmed_at.blank?
+            user.update!(attrs)
             return user
           end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,11 +64,20 @@ class User < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
          :recoverable, :rememberable, :validatable, :confirmable
   include DeviseTokenAuth::Concerns::User
 
+  # gem 側 coder が持っていた「NULL は空ハッシュ」の読み替えを型で復活させる。reader を
+  # 上書きすると gem の in-place 更新 (`tokens[client] = ...`) が attribute に戻らず
+  # トークンが永続化されないため、必ず deserialize 側で吸収する。
+  class TokensType < ActiveRecord::Type::Json
+    def deserialize(value)
+      super || {}
+    end
+  end
+
   # devise_token_auth 1.2.6 + Rails 7.1 では `serialize :tokens, coder: TokensSerialization`
   # が json 型カラムに当たって二重シリアライズになり認証が壊れるため、明示的に json 型を当てて
   # coder を打ち消す。default は devise_token_auth が `tokens.fetch(...)` を呼ぶ前提のため
   # 空ハッシュにしておく。
-  attribute :tokens, ActiveRecord::Type::Json.new, default: -> { {} }
+  attribute :tokens, TokensType.new, default: -> { {} }
 
   # devise_token_auth 1.2.6 の clean_old_tokens は (1) `self.tokens = ...to_h` で Hash を
   # 全置換して attribute tracking と衝突し直前の create_token の代入を消す、(2)

--- a/db/migrate/20260818010001_backfill_and_require_users_tokens.rb
+++ b/db/migrate/20260818010001_backfill_and_require_users_tokens.rb
@@ -14,6 +14,8 @@ class BackfillAndRequireUsersTokens < ActiveRecord::Migration[7.1]
   end
 
   def down
+    execute "SET LOCAL lock_timeout = '5s'"
+
     change_column_null :users, :tokens, true
     change_column_default :users, :tokens, from: {}, to: nil
   end

--- a/db/migrate/20260818010001_backfill_and_require_users_tokens.rb
+++ b/db/migrate/20260818010001_backfill_and_require_users_tokens.rb
@@ -6,7 +6,9 @@ class BackfillAndRequireUsersTokens < ActiveRecord::Migration[7.1]
     # SET NOT NULL は ACCESS EXCLUSIVE を取るため、ロック待ちが長引いたらリリースごと失敗させる
     execute "SET LOCAL lock_timeout = '5s'"
 
-    execute "UPDATE users SET tokens = '{}' WHERE tokens IS NULL"
+    # json カラムでは SQL の NULL と JSON の null リテラルが別物で、後者は NOT NULL 制約も
+    # すり抜けるため、どちらも空ハッシュへ寄せる
+    execute "UPDATE users SET tokens = '{}' WHERE tokens IS NULL OR tokens::text = 'null'"
     change_column_default :users, :tokens, from: nil, to: {}
     change_column_null :users, :tokens, false
   end

--- a/db/migrate/20260818010001_backfill_and_require_users_tokens.rb
+++ b/db/migrate/20260818010001_backfill_and_require_users_tokens.rb
@@ -1,0 +1,18 @@
+class BackfillAndRequireUsersTokens < ActiveRecord::Migration[7.1]
+  # devise_token_auth は tokens を Hash 前提で in-place 更新するため、NULL のままだと
+  # ログイン・トークン検証が NoMethodError で 500 になる。既存の NULL を空ハッシュへ寄せ、
+  # 以降 NULL が入り込まないことを DB 側で保証する。
+  def up
+    # SET NOT NULL は ACCESS EXCLUSIVE を取るため、ロック待ちが長引いたらリリースごと失敗させる
+    execute "SET LOCAL lock_timeout = '5s'"
+
+    execute "UPDATE users SET tokens = '{}' WHERE tokens IS NULL"
+    change_column_default :users, :tokens, from: nil, to: {}
+    change_column_null :users, :tokens, false
+  end
+
+  def down
+    change_column_null :users, :tokens, true
+    change_column_default :users, :tokens, from: {}, to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_11_020001) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_18_010001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -1055,7 +1055,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_11_020001) do
     t.string "name"
     t.string "image"
     t.string "email"
-    t.json "tokens"
+    t.json "tokens", default: {}, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "user_id"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -369,6 +369,37 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe 'tokens カラム' do
+    # NOT NULL 制約を入れた後は本物の NULL 行を作れないため、DB から NULL が返ってきた
+    # 状態を instantiate で再現する
+    let(:persisted) { create(:user) }
+    let(:legacy) { described_class.instantiate(persisted.attributes.merge('tokens' => nil)) }
+
+    it 'DB に NULL が残っているレコードでも空ハッシュとして読める' do
+      expect(legacy.tokens).to eq({})
+    end
+
+    it 'DB に NULL が残っているレコードでもトークンを発行して永続化できる' do
+      headers = legacy.create_new_auth_token
+
+      expect(persisted.reload.tokens.keys).to include(headers['client'])
+    end
+
+    it 'nil を代入しても空ハッシュに正規化される' do
+      user = build(:user)
+      user.tokens = nil
+
+      expect(user.tokens).to eq({})
+    end
+
+    it 'DB 側でも NULL を許容せず空ハッシュがデフォルトになっている' do
+      column = described_class.columns_hash['tokens']
+
+      expect(column.null).to be false
+      expect(column.default).to eq('{}')
+    end
+  end
+
   describe '#create_new_auth_token' do
     let(:user) { create(:user) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -385,6 +385,12 @@ RSpec.describe User, type: :model do
       expect(persisted.reload.tokens.keys).to include(headers['client'])
     end
 
+    it 'NULL を読み込んだだけでは無関係な更新で tokens を書き込まない' do
+      legacy.update!(name: '新しい名前')
+
+      expect(legacy.saved_changes).not_to have_key('tokens')
+    end
+
     it 'nil を代入しても空ハッシュに正規化される' do
       user = build(:user)
       user.tokens = nil

--- a/spec/requests/api/v1/auth/google_spec.rb
+++ b/spec/requests/api/v1/auth/google_spec.rb
@@ -1,0 +1,124 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Auth::Google', type: :request do
+  let(:google_uid) { '110000000000000000001' }
+  let(:email) { 'google-user@example.com' }
+  let(:google_data) { { uid: google_uid, email:, name: '山田 太郎' } }
+
+  before do
+    allow(GoogleAuthService).to receive(:verify).and_return(google_data)
+  end
+
+  describe 'POST /api/v1/google_sign_in' do
+    context '新規ユーザーの場合' do
+      it 'ユーザーを作成してログインする' do
+        expect do
+          post '/api/v1/google_sign_in', params: { id_token: 'valid_token' }
+        end.to change(User, :count).by(1)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.headers['access-token']).to be_present
+        expect(response.headers['client']).to be_present
+        expect(response.headers['uid']).to be_present
+
+        expect(response.parsed_body['requires_username']).to be true
+      end
+
+      it 'provider: google で作成されトークンが保存される' do
+        post '/api/v1/google_sign_in', params: { id_token: 'valid_token' }
+
+        user = User.last
+        expect(user.provider).to eq('google')
+        expect(user.uid).to eq(google_uid)
+        expect(user.email).to eq(email)
+        expect(user.confirmed_at).to be_present
+        expect(user.tokens.keys).to include(response.headers['client'])
+      end
+    end
+
+    context '既存のGoogleユーザーの場合' do
+      let!(:existing_user) do
+        create(:user, :google, uid: google_uid, email:, user_id: 'yamada')
+      end
+
+      it '既存ユーザーでログインする' do
+        expect do
+          post '/api/v1/google_sign_in', params: { id_token: 'valid_token' }
+        end.not_to change(User, :count)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['requires_username']).to be false
+        expect(existing_user.reload.tokens.keys).to include(response.headers['client'])
+      end
+    end
+
+    context 'メール登録済みの未確認ユーザーが同じメールでログインする場合' do
+      let!(:existing_user) do
+        create(:user, :unconfirmed, provider: 'email', uid: email, email:, user_id: 'yamada')
+      end
+
+      it 'provider・uid・confirmed_at をまとめて更新しトークンを発行する' do
+        post '/api/v1/google_sign_in', params: { id_token: 'valid_token' }
+
+        expect(response).to have_http_status(:ok)
+
+        existing_user.reload
+        expect(existing_user.provider).to eq('google')
+        expect(existing_user.uid).to eq(google_uid)
+        expect(existing_user.confirmed_at).to be_present
+        expect(existing_user.tokens.keys).to include(response.headers['client'])
+      end
+    end
+
+    context 'id_tokenが未指定の場合' do
+      it '401を返す' do
+        post '/api/v1/google_sign_in', params: {}
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'トークンが無効な場合' do
+      before do
+        allow(GoogleAuthService).to receive(:verify).and_raise(
+          GoogleAuthService::InvalidToken, 'Google IDトークンの検証に失敗しました'
+        )
+      end
+
+      it '401を返す' do
+        post '/api/v1/google_sign_in', params: { id_token: 'invalid_token' }
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body['errors']).to include('Google IDトークンの検証に失敗しました')
+      end
+    end
+
+    context 'アカウントが停止されている場合' do
+      let!(:suspended_user) do
+        create(:user, :google, uid: google_uid, email:, suspended_at: Time.current)
+      end
+
+      it '401を返す' do
+        post '/api/v1/google_sign_in', params: { id_token: 'valid_token' }
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body['errors']).to include('アカウントが停止されています')
+        expect(suspended_user.reload.tokens).to be_empty
+      end
+    end
+
+    context 'アカウントが削除されている場合' do
+      let!(:deleted_user) do
+        create(:user, :google, uid: google_uid, email:, deleted_at: Time.current)
+      end
+
+      it '401を返す' do
+        post '/api/v1/google_sign_in', params: { id_token: 'valid_token' }
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body['errors']).to include('アカウントが削除されています')
+        expect(deleted_user.reload.tokens).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 関連Issue

closes ippei-shimizu/buzzbase#535

## 概要

`users.tokens`（json型・DB default なし・NULL許容）が NULL のユーザーが本番に 215 件存在し、認証系エンドポイントが `NoMethodError: undefined method '[]=' for nil` で 500 になっていた。パスワードは正しいのにログインできないという実害が継続していたため、DB 側の制約と型レベルの二層で恒久的に解消する。

### 根本原因

devise_token_auth の `DeviseTokenAuth::Concerns::ActiveRecordSupport` は `serialize :tokens, DeviseTokenAuth::Concerns::TokensSerialization` を当てており、その `load` が `NilClass -> {}` に読み替えていた。そのため DB が NULL でも `user.tokens` は `{}` を返していた。

ところが `app/models/user.rb` で、json 型カラムに対する二重シリアライズを回避するため commit 1f489e4 (2026-05-18) で `attribute :tokens, ActiveRecord::Type::Json.new, default: -> { {} }` を追加し、この coder を打ち消した。`attribute` の `default:` は `User.new` された新規レコードにしか効かないため、DB から読み込んだ既存 NULL 行では nil がそのまま返るようになり、gem 側の `tokens[client] = ...` が落ちるようになった。

さらに `20231205151531_devise_token_auth_create_users.rb` が `t.json :tokens` のみで、DB default も NOT NULL 制約もなかった。

### NULL 行の発生経路（新規発生は 2026-05-19 以降ゼロ）

- (a) メール/パスワード登録で confirmable 未確認の間は `create_token` が呼ばれず tokens が一度も初期化されない（164 件）
- (b) 未確認アカウントに後日同じメールで Google/Apple ログインすると、`confirmed_at` だけ `update!` で確定した直後に `create_new_auth_token` が nil で落ち、中途半端な状態で止まる（51 件）

### 停止する Sentry Issue

| Sentry Issue | 落ちる箇所 | 件数 |
| --- | --- | --- |
| BUZZBASE-BACKEND-1E / 1D | `ApplicationController#set_sentry_context` -> `valid_token?` の `tokens[client]` | 180 |
| BUZZBASE-BACKEND-T | `GoogleController#create` -> `create_new_auth_token` の `tokens.fetch` | 91 |
| BUZZBASE-BACKEND-12 | `SessionsController#create` -> `update_auth_header` の `tokens[@token.client]` | 16 |
| BUZZBASE-BACKEND-1G | `SessionsController#create` -> `create_token` の `tokens[token.client]` | 1 |

## 変更内容

- `db/migrate/20260818010001_backfill_and_require_users_tokens.rb` を追加。既存の NULL 行を `{}` にバックフィルし、`default: {}` / `NOT NULL` を付与する
- `User::TokensType`（`ActiveRecord::Type::Json` のサブクラス）を定義し、gem の coder が持っていた「NULL は空ハッシュ」の読み替えを `deserialize` で復活させる
- `GoogleController#find_or_create_user` の 2 回に分かれた `update!` を 1 回に統合し、Apple 側と同形にする
- `spec/models/user_spec.rb` に tokens カラムの NULL 耐性とスキーマ制約のテストを追加
- `spec/requests/api/v1/auth/google_spec.rb` を新規追加（これまで Google の request spec が存在しなかった）

### 設計上の判断

reader override（`def tokens = super || {}`）は採用していない。`super` はメモ化済みの nil を返し `|| {}` が毎回使い捨ての Hash を作るため、gem の in-place 更新（`tokens[client] = ...`）が attribute store に戻らず `changed_in_place?` が false になり、トークンが永続化されなくなる。`deserialize` を上書きすれば attribute の値そのものが `{}` になるので in-place 更新が正しく検知・保存される。`spec/models/user_spec.rb` の「DB に NULL が残っているレコードでもトークンを発行して永続化できる」がこの回帰テスト。

`cast` の上書きは不要。`ActiveModel::Type::Helpers::Mutable#cast` は `deserialize(serialize(value))` を経由するため、`cast(nil)` は自動的に `{}` になる（この経路依存は spec で固定している）。

## マイグレーション

- [x] マイグレーションあり -> `bundle exec rails db:migrate`
- [ ] マイグレーションなし

`db/schema.rb` の差分:

```diff
-    t.json "tokens"
+    t.json "tokens", default: {}, null: false
```

`default:` が `{}`（Hash）であって `"{}"`（String）でないことを確認済み。String になると JSON 文字列スカラーとして保存され、二重エンコード問題が再発する。

### ロック影響とデプロイタイミング

- `UPDATE`（215 行）は ROW EXCLUSIVE で無視できるコスト
- `SET DEFAULT` はカタログのみの変更で瞬時
- `SET NOT NULL` は ACCESS EXCLUSIVE + 全行スキャンだが users は数千件規模なので瞬時。`SET LOCAL lock_timeout = '5s'` を入れているため、ロック待ちが長引いた場合はトランザクションごとロールバックしてリリースが中断されるだけで済む（冪等なので再実行可能）
- `Procfile` の `release: bundle exec rails db:migrate` により、旧コード稼働中のリリースフェーズでマイグレーションが走る。この時点で NULL が消えるため旧コードのままでも 500 が止まる。旧コードも `attribute ... default: -> { {} }` を持つので INSERT が NOT NULL 違反になることはなく、デプロイ順序の制約はない

被害を受けていた 215 名は再ログインで復旧するため、コード変更以外のリカバリ作業は不要。

## 確認手順

1. `docker compose exec back bundle exec rails db:migrate` を実行し、`db/schema.rb` が `t.json "tokens", default: {}, null: false` になることを確認
2. `docker compose exec back bundle exec rails db:rollback` で `down` が通ることを確認
3. `docker compose exec back bundle exec rspec spec/models/user_spec.rb spec/requests/api/v1/auth/` が green であることを確認
4. 本番デプロイ後、`SELECT count(*) FROM users WHERE tokens IS NULL;` が 0 になること、上表の Sentry Issue が新規発生しなくなることを 24〜48h 監視して手動 Resolve する

## チェックリスト

- [x] テストが通る (`bundle exec rspec` 1795 examples / 0 failures)
- [x] `bundle exec rubocop` 614 files / no offenses
- [x] 動作確認済み（マイグレーション適用・rollback・再適用、NULL 行の読み出しとトークン発行の永続化を rails runner で確認）
