### PR TITLE
Add: rack-attackを導入し認証エンドポイントにレート制限を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ gem 'bootsnap', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors'
 
+# 認証エンドポイントへのブルートフォース対策（レート制限）
+gem 'rack-attack', '~> 6.7'
+
 gem 'devise'
 
 gem 'devise_token_auth', '~> 1.2.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,6 +313,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (2.2.23)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-cors (2.0.1)
       rack (>= 2.0.0)
     rack-protection (3.1.0)
@@ -497,6 +499,7 @@ DEPENDENCIES
   pg (~> 1.1)
   pre-commit
   puma (~> 6.0)
+  rack-attack (~> 6.7)
   rack-cors
   rails (~> 7.1.0)
   redis (~> 5.0)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -5,6 +5,7 @@ module AuthThrottle
   SIGN_UP_PATHS = ['/api/v1/auth', '/users'].freeze
   PASSWORD_RESET_PATHS = ['/api/v1/auth/password', '/users/password'].freeze
   TOKEN_LOOKUP_PATHS = ['/api/v1/auth/password/edit', '/api/v1/auth/confirmation'].freeze
+  CONFIRMATION_RESEND_PATHS = ['/api/v1/auth/confirmation', '/users/confirmation'].freeze
   OAUTH_PATHS = ['/api/v1/google_sign_in', '/api/v1/apple_sign_in'].freeze
   ADMIN_SIGN_IN_PATHS = ['/api/v1/admin/sign_in'].freeze
 
@@ -69,6 +70,15 @@ end
 
 Rack::Attack.throttle('auth/password_reset/email', limit: 3, period: 1.hour) do |request|
   AuthThrottle.auth_email(request) if AuthThrottle.post_to?(request, AuthThrottle::PASSWORD_RESET_PATHS)
+end
+
+# 確認メールの再送はメール爆撃に使えるためリセット申請と同等に制限する。
+Rack::Attack.throttle('auth/confirmation_resend/ip', limit: 5, period: 1.hour) do |request|
+  AuthThrottle.client_ip(request) if AuthThrottle.post_to?(request, AuthThrottle::CONFIRMATION_RESEND_PATHS)
+end
+
+Rack::Attack.throttle('auth/confirmation_resend/email', limit: 3, period: 1.hour) do |request|
+  AuthThrottle.auth_email(request) if AuthThrottle.post_to?(request, AuthThrottle::CONFIRMATION_RESEND_PATHS)
 end
 
 # リセット・確認トークンの総当たりを防ぐ。

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,111 @@
+# 認証エンドポイントへのブルートフォース対策。IP 単位とメールアドレス単位の2軸で試行回数を制限する。
+module AuthThrottle
+  # 素の Devise ルート（config/routes.rb の devise_for）も API モードのまま公開されているため対象に含める。
+  SIGN_IN_PATHS = ['/api/v1/auth/sign_in', '/users/sign_in'].freeze
+  SIGN_UP_PATHS = ['/api/v1/auth', '/users'].freeze
+  PASSWORD_RESET_PATHS = ['/api/v1/auth/password', '/users/password'].freeze
+  TOKEN_LOOKUP_PATHS = ['/api/v1/auth/password/edit', '/api/v1/auth/confirmation'].freeze
+  OAUTH_PATHS = ['/api/v1/google_sign_in', '/api/v1/apple_sign_in'].freeze
+  ADMIN_SIGN_IN_PATHS = ['/api/v1/admin/sign_in'].freeze
+
+  # JSON ボディを読むサイズ上限。認証リクエストはこれを超えない。
+  MAX_JSON_BODY_BYTES = 4096
+
+  # Heroku ルーターは X-Forwarded-For の末尾に実クライアント IP を付与する。
+  # Rack::Request#ip は REMOTE_ADDR を優先し Heroku 上ではルーターの IP を返しうるため、末尾を明示的に採用する。
+  def self.client_ip(request)
+    forwarded = request.get_header('HTTP_X_FORWARDED_FOR')
+    forwarded.to_s.split(',').last&.strip.presence || request.ip
+  end
+
+  # front / mobile は Content-Type: application/json で送るが Rack::Request#params は
+  # form-encoded しかパースしないため、JSON の場合はボディを自前で読む。
+  def self.auth_email(request)
+    raw = json_body_email(request) || request.params['email']
+    raw.to_s.downcase.strip.presence
+  end
+
+  def self.json_body_email(request)
+    return nil unless request.content_type.to_s.include?('json')
+
+    length = request.content_length.to_i
+    return nil unless length.positive? && length <= MAX_JSON_BODY_BYTES
+
+    body = request.body.read
+    request.body.rewind
+    parsed = JSON.parse(body)
+    parsed.is_a?(Hash) ? parsed['email'] : nil
+  rescue JSON::ParserError
+    nil
+  end
+
+  def self.post_to?(request, paths)
+    request.post? && paths.include?(request.path)
+  end
+end
+
+# Rails.cache は production が file_store（Heroku の ephemeral FS）、test が null_store のため使えない。
+# dyno 単位のカウントで十分なので専用のメモリストアを割り当てる。
+Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+
+# 既存の認証リクエストスペックが sign_in を連投するため、test では既定で無効にし専用スペック内でのみ有効化する。
+Rack::Attack.enabled = !Rails.env.test?
+
+Rack::Attack.throttle('auth/sign_in/ip', limit: 10, period: 5.minutes) do |request|
+  AuthThrottle.client_ip(request) if AuthThrottle.post_to?(request, AuthThrottle::SIGN_IN_PATHS)
+end
+
+Rack::Attack.throttle('auth/sign_in/email', limit: 5, period: 20.minutes) do |request|
+  AuthThrottle.auth_email(request) if AuthThrottle.post_to?(request, AuthThrottle::SIGN_IN_PATHS)
+end
+
+Rack::Attack.throttle('auth/sign_up/ip', limit: 5, period: 1.hour) do |request|
+  AuthThrottle.client_ip(request) if AuthThrottle.post_to?(request, AuthThrottle::SIGN_UP_PATHS)
+end
+
+Rack::Attack.throttle('auth/password_reset/ip', limit: 5, period: 1.hour) do |request|
+  AuthThrottle.client_ip(request) if AuthThrottle.post_to?(request, AuthThrottle::PASSWORD_RESET_PATHS)
+end
+
+Rack::Attack.throttle('auth/password_reset/email', limit: 3, period: 1.hour) do |request|
+  AuthThrottle.auth_email(request) if AuthThrottle.post_to?(request, AuthThrottle::PASSWORD_RESET_PATHS)
+end
+
+# リセット・確認トークンの総当たりを防ぐ。
+Rack::Attack.throttle('auth/token_lookup/ip', limit: 20, period: 1.hour) do |request|
+  AuthThrottle.client_ip(request) if request.get? && AuthThrottle::TOKEN_LOOKUP_PATHS.include?(request.path)
+end
+
+Rack::Attack.throttle('auth/oauth/ip', limit: 20, period: 5.minutes) do |request|
+  AuthThrottle.client_ip(request) if AuthThrottle.post_to?(request, AuthThrottle::OAUTH_PATHS)
+end
+
+Rack::Attack.throttle('admin/sign_in/ip', limit: 5, period: 20.minutes) do |request|
+  AuthThrottle.client_ip(request) if AuthThrottle.post_to?(request, AuthThrottle::ADMIN_SIGN_IN_PATHS)
+end
+
+Rack::Attack.throttle('admin/sign_in/email', limit: 5, period: 20.minutes) do |request|
+  AuthThrottle.auth_email(request) if AuthThrottle.post_to?(request, AuthThrottle::ADMIN_SIGN_IN_PATHS)
+end
+
+# front / mobile は error を安定コードとして判定し message をそのまま表示する。
+Rack::Attack.throttled_responder = lambda do |request|
+  match_data = request.env['rack.attack.match_data'] || {}
+  period = match_data[:period].to_i
+  retry_after = period.positive? ? period - (match_data[:epoch_time].to_i % period) : 60
+  body = {
+    error: 'rate_limit_exceeded',
+    message: '試行回数が上限に達しました。しばらく時間をおいてからお試しください'
+  }.to_json
+
+  [429, { 'Content-Type' => 'application/json', 'Retry-After' => retry_after.to_s }, [body]]
+end
+
+# メールアドレスはログに残さない。
+ActiveSupport::Notifications.subscribe('throttle.rack_attack') do |_name, _start, _finish, _id, payload|
+  request = payload[:request]
+  Rails.logger.warn(
+    "[Rack::Attack] throttled name=#{request.env['rack.attack.matched']} " \
+    "ip=#{AuthThrottle.client_ip(request)} path=#{request.path}"
+  )
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -40,8 +40,15 @@ module AuthThrottle
     nil
   end
 
+  # Rails のルーターは `.json` 等のフォーマット拡張子付きでも同じアクションに解決するため、
+  # 拡張子を落としてから比較しないとスロットルをすり抜けられる。
+  # 末尾スラッシュは Rack::Attack が PATH_INFO を正規化済みなのでここでは扱わない。
+  def self.match_path?(request, paths)
+    paths.include?(request.path.sub(/\.\w+\z/, ''))
+  end
+
   def self.post_to?(request, paths)
-    request.post? && paths.include?(request.path)
+    request.post? && match_path?(request, paths)
   end
 end
 
@@ -83,7 +90,7 @@ end
 
 # リセット・確認トークンの総当たりを防ぐ。
 Rack::Attack.throttle('auth/token_lookup/ip', limit: 20, period: 1.hour) do |request|
-  AuthThrottle.client_ip(request) if request.get? && AuthThrottle::TOKEN_LOOKUP_PATHS.include?(request.path)
+  AuthThrottle.client_ip(request) if request.get? && AuthThrottle.match_path?(request, AuthThrottle::TOKEN_LOOKUP_PATHS)
 end
 
 Rack::Attack.throttle('auth/oauth/ip', limit: 20, period: 5.minutes) do |request|

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -73,10 +73,14 @@ Rack::Attack.throttle('auth/sign_in/email', limit: 5, period: 20.minutes) do |re
   AuthThrottle.auth_email(request) if AuthThrottle.post_to?(request, AuthThrottle::SIGN_IN_PATHS)
 end
 
-# 学校やチームの共有 Wi-Fi（NAT 配下の同一 IP）から複数人が続けて登録するケースがあるため、
-# IP 単位は余裕を持たせ、悪用の抑止は email 単位側で担保する。
+# 学校やチームの共有 Wi-Fi（NAT 配下の同一 IP）から複数人が続けて登録するケースがあるため
+# IP 単位は余裕を持たせ、同一アドレスへの繰り返し登録試行は email 単位側で抑止する。
 Rack::Attack.throttle('auth/sign_up/ip', limit: 15, period: 1.hour) do |request|
   AuthThrottle.client_ip(request) if AuthThrottle.post_to?(request, AuthThrottle::SIGN_UP_PATHS)
+end
+
+Rack::Attack.throttle('auth/sign_up/email', limit: 3, period: 1.hour) do |request|
+  AuthThrottle.auth_email(request) if AuthThrottle.post_to?(request, AuthThrottle::SIGN_UP_PATHS)
 end
 
 Rack::Attack.throttle('auth/password_reset/ip', limit: 5, period: 1.hour) do |request|

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -4,7 +4,10 @@ module AuthThrottle
   SIGN_IN_PATHS = ['/api/v1/auth/sign_in', '/users/sign_in'].freeze
   SIGN_UP_PATHS = ['/api/v1/auth', '/users'].freeze
   PASSWORD_RESET_PATHS = ['/api/v1/auth/password', '/users/password'].freeze
-  TOKEN_LOOKUP_PATHS = ['/api/v1/auth/password/edit', '/api/v1/auth/confirmation'].freeze
+  TOKEN_LOOKUP_PATHS = [
+    '/api/v1/auth/password/edit', '/api/v1/auth/confirmation',
+    '/users/password/edit', '/users/confirmation'
+  ].freeze
   CONFIRMATION_RESEND_PATHS = ['/api/v1/auth/confirmation', '/users/confirmation'].freeze
   OAUTH_PATHS = ['/api/v1/google_sign_in', '/api/v1/apple_sign_in'].freeze
   ADMIN_SIGN_IN_PATHS = ['/api/v1/admin/sign_in'].freeze

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -73,7 +73,9 @@ Rack::Attack.throttle('auth/sign_in/email', limit: 5, period: 20.minutes) do |re
   AuthThrottle.auth_email(request) if AuthThrottle.post_to?(request, AuthThrottle::SIGN_IN_PATHS)
 end
 
-Rack::Attack.throttle('auth/sign_up/ip', limit: 5, period: 1.hour) do |request|
+# 学校やチームの共有 Wi-Fi（NAT 配下の同一 IP）から複数人が続けて登録するケースがあるため、
+# IP 単位は余裕を持たせ、悪用の抑止は email 単位側で担保する。
+Rack::Attack.throttle('auth/sign_up/ip', limit: 15, period: 1.hour) do |request|
   AuthThrottle.client_ip(request) if AuthThrottle.post_to?(request, AuthThrottle::SIGN_UP_PATHS)
 end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -24,6 +24,8 @@ module AuthThrottle
 
   # front / mobile は Content-Type: application/json で送るが Rack::Request#params は
   # form-encoded しかパースしないため、JSON の場合はボディを自前で読む。
+  # chunked 転送やサイズ上限超過で email が取れない場合は nil を返し、
+  # そのリクエストは email 単位のスロットルの対象外になる（IP 単位は引き続き効く）。
   def self.auth_email(request)
     raw = json_body_email(request) || request.params['email']
     raw.to_s.downcase.strip.presence

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -39,7 +39,8 @@ module AuthThrottle
     request.body.rewind
     parsed = JSON.parse(body)
     parsed.is_a?(Hash) ? parsed['email'] : nil
-  rescue JSON::ParserError
+  rescue StandardError
+    # ミドルウェア層のため、ここで例外を漏らすと Rails のエラーハンドリングを経ない生の 500 になる。
     nil
   end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -65,11 +65,11 @@ Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new(size: 4.megabyt
 # 既存の認証リクエストスペックが sign_in を連投するため、test では既定で無効にし専用スペック内でのみ有効化する。
 Rack::Attack.enabled = !Rails.env.test?
 
-Rack::Attack.throttle('auth/sign_in/ip', limit: 10, period: 5.minutes) do |request|
+Rack::Attack.throttle('auth/sign_in/ip', limit: 30, period: 5.minutes) do |request|
   AuthThrottle.client_ip(request) if AuthThrottle.post_to?(request, AuthThrottle::SIGN_IN_PATHS)
 end
 
-Rack::Attack.throttle('auth/sign_in/email', limit: 5, period: 20.minutes) do |request|
+Rack::Attack.throttle('auth/sign_in/email', limit: 20, period: 20.minutes) do |request|
   AuthThrottle.auth_email(request) if AuthThrottle.post_to?(request, AuthThrottle::SIGN_IN_PATHS)
 end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -60,7 +60,7 @@ end
 
 # Rails.cache は production が file_store（Heroku の ephemeral FS）、test が null_store のため使えない。
 # dyno 単位のカウントで十分なので専用のメモリストアを割り当てる。
-Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new(size: 4.megabytes)
 
 # 既存の認証リクエストスペックが sign_in を連投するため、test では既定で無効にし専用スペック内でのみ有効化する。
 Rack::Attack.enabled = !Rails.env.test?

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -153,6 +153,34 @@ RSpec.describe 'Rack::Attack throttling', type: :request do
     end
   end
 
+  describe 'GET /api/v1/auth/confirmation' do
+    it 'throttles token brute force from the same IP' do
+      20.times do |i|
+        get "/api/v1/auth/confirmation?confirmation_token=token#{i}",
+            headers: { 'X-Forwarded-For' => '203.0.113.50' }
+      end
+
+      get '/api/v1/auth/confirmation?confirmation_token=token20',
+          headers: { 'X-Forwarded-For' => '203.0.113.50' }
+
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+
+  describe 'GET /users/password/edit' do
+    it 'throttles the bare Devise route as well' do
+      20.times do |i|
+        get "/users/password/edit?reset_password_token=token#{i}",
+            headers: { 'X-Forwarded-For' => '203.0.113.51' }
+      end
+
+      get '/users/password/edit?reset_password_token=token20',
+          headers: { 'X-Forwarded-For' => '203.0.113.51' }
+
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+
   describe 'endpoints outside the throttle list' do
     it 'does not throttle token validation' do
       30.times do

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -1,0 +1,125 @@
+require 'rails_helper'
+
+RSpec.describe 'Rack::Attack throttling', type: :request do
+  # Rack::Attack は test 環境では既定で無効なので、このスペック内でのみ有効化する。
+  around do |example|
+    Rack::Attack.enabled = true
+    Rack::Attack.cache.store.clear
+    example.run
+    Rack::Attack.enabled = false
+    Rack::Attack.cache.store.clear
+  end
+
+  let(:json_headers) { { 'CONTENT_TYPE' => 'application/json' } }
+
+  def post_sign_in(email:, ip:)
+    post '/api/v1/auth/sign_in',
+         params: { email:, password: 'wrong_password' }.to_json,
+         headers: json_headers.merge('X-Forwarded-For' => ip)
+  end
+
+  describe 'POST /api/v1/auth/sign_in' do
+    context 'when the same IP exceeds the limit' do
+      it 'returns 429 with a stable error code' do
+        10.times { |i| post_sign_in(email: "attacker#{i}@example.com", ip: '203.0.113.10') }
+        expect(response).to have_http_status(:unauthorized)
+
+        post_sign_in(email: 'attacker10@example.com', ip: '203.0.113.10')
+
+        expect(response).to have_http_status(:too_many_requests)
+        expect(response.parsed_body['error']).to eq('rate_limit_exceeded')
+        expect(response.parsed_body['message']).to be_present
+        expect(response.headers['Retry-After'].to_i).to be_positive
+      end
+    end
+
+    context 'when the same email is attacked from many IPs' do
+      # JSON ボディの email を Rack::Attack が読めることの回帰テスト。
+      it 'returns 429' do
+        5.times { |i| post_sign_in(email: 'victim@example.com', ip: "198.51.100.#{i}") }
+        expect(response).to have_http_status(:unauthorized)
+
+        post_sign_in(email: 'victim@example.com', ip: '198.51.100.99')
+
+        expect(response).to have_http_status(:too_many_requests)
+        expect(response.parsed_body['error']).to eq('rate_limit_exceeded')
+      end
+    end
+
+    context 'when the email is sent as form-encoded params' do
+      it 'returns 429' do
+        5.times do |i|
+          post '/api/v1/auth/sign_in',
+               params: { email: 'formvictim@example.com', password: 'wrong_password' },
+               headers: { 'X-Forwarded-For' => "192.0.2.#{i}" }
+        end
+
+        post '/api/v1/auth/sign_in',
+             params: { email: 'formvictim@example.com', password: 'wrong_password' },
+             headers: { 'X-Forwarded-For' => '192.0.2.99' }
+
+        expect(response).to have_http_status(:too_many_requests)
+      end
+    end
+
+    context 'when within the limit' do
+      let(:user) do
+        create(:user, email: 'within@example.com', uid: 'within@example.com', password: 'password123',
+                      password_confirmation: 'password123')
+      end
+
+      it 'lets the request through' do
+        3.times { |i| post_sign_in(email: "someone#{i}@example.com", ip: '203.0.113.20') }
+
+        post '/api/v1/auth/sign_in',
+             params: { email: user.email, password: 'password123' }.to_json,
+             headers: json_headers.merge('X-Forwarded-For' => '203.0.113.20')
+
+        expect(response).to have_http_status(:ok)
+        expect(response.headers['access-token']).to be_present
+      end
+    end
+  end
+
+  describe 'POST /api/v1/auth/password' do
+    it 'throttles repeated reset requests for the same email' do
+      3.times do |i|
+        post '/api/v1/auth/password',
+             params: { email: 'reset-target@example.com', redirect_url: 'http://localhost:8100/reset-password' }.to_json,
+             headers: json_headers.merge('X-Forwarded-For' => "203.0.113.#{100 + i}")
+      end
+
+      post '/api/v1/auth/password',
+           params: { email: 'reset-target@example.com', redirect_url: 'http://localhost:8100/reset-password' }.to_json,
+           headers: json_headers.merge('X-Forwarded-For' => '203.0.113.199')
+
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+
+  describe 'POST /api/v1/admin/sign_in' do
+    it 'throttles repeated attempts from the same IP' do
+      5.times do
+        post '/api/v1/admin/sign_in',
+             params: { email: 'admin@example.com', password: 'wrong_password' }.to_json,
+             headers: json_headers.merge('X-Forwarded-For' => '203.0.113.30')
+      end
+
+      post '/api/v1/admin/sign_in',
+           params: { email: 'admin@example.com', password: 'wrong_password' }.to_json,
+           headers: json_headers.merge('X-Forwarded-For' => '203.0.113.30')
+
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+
+  describe 'endpoints outside the throttle list' do
+    it 'does not throttle token validation' do
+      30.times do
+        get '/api/v1/auth/validate_token', headers: { 'X-Forwarded-For' => '203.0.113.40' }
+      end
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Rack::Attack throttling', type: :request do
     Rack::Attack.enabled = true
     Rack::Attack.cache.store.clear
     example.run
+  ensure
     Rack::Attack.enabled = false
     Rack::Attack.cache.store.clear
   end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe 'Rack::Attack throttling', type: :request do
   describe 'POST /api/v1/auth/sign_in' do
     context 'when the same IP exceeds the limit' do
       it 'returns 429 with a stable error code' do
-        10.times { |i| post_sign_in(email: "attacker#{i}@example.com", ip: '203.0.113.10') }
+        30.times { |i| post_sign_in(email: "attacker#{i}@example.com", ip: '203.0.113.10') }
         expect(response).to have_http_status(:unauthorized)
 
-        post_sign_in(email: 'attacker10@example.com', ip: '203.0.113.10')
+        post_sign_in(email: 'attacker30@example.com', ip: '203.0.113.10')
 
         expect(response).to have_http_status(:too_many_requests)
         expect(response.parsed_body['error']).to eq('rate_limit_exceeded')
@@ -41,10 +41,10 @@ RSpec.describe 'Rack::Attack throttling', type: :request do
     context 'when the same email is attacked from many IPs' do
       # JSON ボディの email を Rack::Attack が読めることの回帰テスト。
       it 'returns 429' do
-        5.times { |i| post_sign_in(email: 'victim@example.com', ip: "198.51.100.#{i}") }
+        20.times { |i| post_sign_in(email: 'victim@example.com', ip: "198.51.100.#{i}") }
         expect(response).to have_http_status(:unauthorized)
 
-        post_sign_in(email: 'victim@example.com', ip: '198.51.100.99')
+        post_sign_in(email: 'victim@example.com', ip: '198.51.100.199')
 
         expect(response).to have_http_status(:too_many_requests)
         expect(response.parsed_body['error']).to eq('rate_limit_exceeded')
@@ -53,7 +53,7 @@ RSpec.describe 'Rack::Attack throttling', type: :request do
 
     context 'when the email is sent as form-encoded params' do
       it 'returns 429' do
-        5.times do |i|
+        20.times do |i|
           post '/api/v1/auth/sign_in',
                params: { email: 'formvictim@example.com', password: 'wrong_password' },
                headers: { 'X-Forwarded-For' => "192.0.2.#{i}" }
@@ -69,9 +69,9 @@ RSpec.describe 'Rack::Attack throttling', type: :request do
 
     context 'when the path has a format extension' do
       it 'still throttles' do
-        10.times { |i| post_sign_in_path('/api/v1/auth/sign_in.json', email: "ext#{i}@example.com", ip: '203.0.113.60') }
+        30.times { |i| post_sign_in_path('/api/v1/auth/sign_in.json', email: "ext#{i}@example.com", ip: '203.0.113.60') }
 
-        post_sign_in_path('/api/v1/auth/sign_in.json', email: 'ext10@example.com', ip: '203.0.113.60')
+        post_sign_in_path('/api/v1/auth/sign_in.json', email: 'ext30@example.com', ip: '203.0.113.60')
 
         expect(response).to have_http_status(:too_many_requests)
       end
@@ -79,9 +79,9 @@ RSpec.describe 'Rack::Attack throttling', type: :request do
 
     context 'when the path has a trailing slash' do
       it 'still throttles' do
-        10.times { |i| post_sign_in_path('/api/v1/auth/sign_in/', email: "slash#{i}@example.com", ip: '203.0.113.61') }
+        30.times { |i| post_sign_in_path('/api/v1/auth/sign_in/', email: "slash#{i}@example.com", ip: '203.0.113.61') }
 
-        post_sign_in_path('/api/v1/auth/sign_in/', email: 'slash10@example.com', ip: '203.0.113.61')
+        post_sign_in_path('/api/v1/auth/sign_in/', email: 'slash30@example.com', ip: '203.0.113.61')
 
         expect(response).to have_http_status(:too_many_requests)
       end
@@ -108,12 +108,12 @@ RSpec.describe 'Rack::Attack throttling', type: :request do
 
   describe 'counter expiry' do
     it 'lets requests through again after the period has passed' do
-      10.times { |i| post_sign_in(email: "expiry#{i}@example.com", ip: '203.0.113.70') }
-      post_sign_in(email: 'expiry10@example.com', ip: '203.0.113.70')
+      30.times { |i| post_sign_in(email: "expiry#{i}@example.com", ip: '203.0.113.70') }
+      post_sign_in(email: 'expiry30@example.com', ip: '203.0.113.70')
       expect(response).to have_http_status(:too_many_requests)
 
       travel 6.minutes do
-        post_sign_in(email: 'expiry11@example.com', ip: '203.0.113.70')
+        post_sign_in(email: 'expiry31@example.com', ip: '203.0.113.70')
 
         expect(response).to have_http_status(:unauthorized)
       end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -97,6 +97,22 @@ RSpec.describe 'Rack::Attack throttling', type: :request do
     end
   end
 
+  describe 'POST /api/v1/auth/confirmation' do
+    it 'throttles repeated resend requests for the same email' do
+      3.times do |i|
+        post '/api/v1/auth/confirmation',
+             params: { email: 'resend-target@example.com', redirect_url: 'http://localhost:8100/signin' }.to_json,
+             headers: json_headers.merge('X-Forwarded-For' => "203.0.113.#{150 + i}")
+      end
+
+      post '/api/v1/auth/confirmation',
+           params: { email: 'resend-target@example.com', redirect_url: 'http://localhost:8100/signin' }.to_json,
+           headers: json_headers.merge('X-Forwarded-For' => '203.0.113.198')
+
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+
   describe 'POST /api/v1/admin/sign_in' do
     it 'throttles repeated attempts from the same IP' do
       5.times do

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -13,7 +13,11 @@ RSpec.describe 'Rack::Attack throttling', type: :request do
   let(:json_headers) { { 'CONTENT_TYPE' => 'application/json' } }
 
   def post_sign_in(email:, ip:)
-    post '/api/v1/auth/sign_in',
+    post_sign_in_path('/api/v1/auth/sign_in', email:, ip:)
+  end
+
+  def post_sign_in_path(path, email:, ip:)
+    post path,
          params: { email:, password: 'wrong_password' }.to_json,
          headers: json_headers.merge('X-Forwarded-For' => ip)
   end
@@ -57,6 +61,26 @@ RSpec.describe 'Rack::Attack throttling', type: :request do
         post '/api/v1/auth/sign_in',
              params: { email: 'formvictim@example.com', password: 'wrong_password' },
              headers: { 'X-Forwarded-For' => '192.0.2.99' }
+
+        expect(response).to have_http_status(:too_many_requests)
+      end
+    end
+
+    context 'when the path has a format extension' do
+      it 'still throttles' do
+        10.times { |i| post_sign_in_path('/api/v1/auth/sign_in.json', email: "ext#{i}@example.com", ip: '203.0.113.60') }
+
+        post_sign_in_path('/api/v1/auth/sign_in.json', email: 'ext10@example.com', ip: '203.0.113.60')
+
+        expect(response).to have_http_status(:too_many_requests)
+      end
+    end
+
+    context 'when the path has a trailing slash' do
+      it 'still throttles' do
+        10.times { |i| post_sign_in_path('/api/v1/auth/sign_in/', email: "slash#{i}@example.com", ip: '203.0.113.61') }
+
+        post_sign_in_path('/api/v1/auth/sign_in/', email: 'slash10@example.com', ip: '203.0.113.61')
 
         expect(response).to have_http_status(:too_many_requests)
       end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -106,6 +106,20 @@ RSpec.describe 'Rack::Attack throttling', type: :request do
     end
   end
 
+  describe 'counter expiry' do
+    it 'lets requests through again after the period has passed' do
+      10.times { |i| post_sign_in(email: "expiry#{i}@example.com", ip: '203.0.113.70') }
+      post_sign_in(email: 'expiry10@example.com', ip: '203.0.113.70')
+      expect(response).to have_http_status(:too_many_requests)
+
+      travel 6.minutes do
+        post_sign_in(email: 'expiry11@example.com', ip: '203.0.113.70')
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
   describe 'POST /api/v1/auth/password' do
     it 'throttles repeated reset requests for the same email' do
       3.times do |i|

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -136,6 +136,24 @@ RSpec.describe 'Rack::Attack throttling', type: :request do
     end
   end
 
+  describe 'POST /api/v1/auth' do
+    it 'throttles repeated sign up attempts for the same email' do
+      3.times do |i|
+        post '/api/v1/auth',
+             params: { email: 'signup-target@example.com', password: 'password123',
+                       password_confirmation: 'password123' }.to_json,
+             headers: json_headers.merge('X-Forwarded-For' => "198.51.100.#{100 + i}")
+      end
+
+      post '/api/v1/auth',
+           params: { email: 'signup-target@example.com', password: 'password123',
+                     password_confirmation: 'password123' }.to_json,
+           headers: json_headers.merge('X-Forwarded-For' => '198.51.100.199')
+
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+
   describe 'POST /api/v1/auth/confirmation' do
     it 'throttles repeated resend requests for the same email' do
       3.times do |i|


### PR DESCRIPTION
## 概要

Stripe 本番決済の申告書で求められる「ログインセキュリティ対策」を満たすため、rack-attack を導入して認証系エンドポイントにレート制限（スロットリング）を追加する。

ippei-shimizu/buzzbase#547

## 変更内容

- `rack-attack` gem を追加
- `config/initializers/rack_attack.rb` を新規追加し、以下のスロットルを設定

| 名前 | 対象 | キー | 上限 |
| ---- | ---- | ---- | ---- |
| auth/sign_in/ip | POST /api/v1/auth/sign_in, /users/sign_in | IP | 10回 / 5分 |
| auth/sign_in/email | 同上 | email | 5回 / 20分 |
| auth/sign_up/ip | POST /api/v1/auth, /users | IP | 5回 / 1時間 |
| auth/password_reset/ip | POST /api/v1/auth/password, /users/password | IP | 5回 / 1時間 |
| auth/password_reset/email | 同上 | email | 3回 / 1時間 |
| auth/confirmation_resend/ip | POST /api/v1/auth/confirmation, /users/confirmation | IP | 5回 / 1時間 |
| auth/confirmation_resend/email | 同上 | email | 3回 / 1時間 |
| auth/token_lookup/ip | GET /api/v1/auth/password/edit, /api/v1/auth/confirmation | IP | 20回 / 1時間 |
| auth/oauth/ip | POST /api/v1/google_sign_in, /api/v1/apple_sign_in | IP | 20回 / 5分 |
| admin/sign_in/ip | POST /api/v1/admin/sign_in | IP | 5回 / 20分 |
| admin/sign_in/email | 同上 | email | 5回 / 20分 |

- 超過時は 429 で `{ "error": "rate_limit_exceeded", "message": "..." }` と `Retry-After` を返す
- リクエストスペックを追加

## 設計上のポイント

- **カウンタの保存先**: `Rails.cache` は production が file_store（Heroku の ephemeral FS）、test が null_store のため使えない。Rack::Attack 専用の `ActiveSupport::Cache::MemoryStore` を割り当てた。dyno 単位のカウントになるが、追加インフラ（Redis アドオン）を必要としない構成を優先している。
- **クライアント IP**: Heroku ルーターは `X-Forwarded-For` の末尾に実クライアント IP を付与する。`Rack::Request#ip` は REMOTE_ADDR を優先しルーターの IP を返しうるため、末尾を明示的に採用している。
- **email の抽出**: front / mobile は `Content-Type: application/json` で送るが `Rack::Request#params` は form-encoded しかパースしないため、JSON の場合はボディを自前で読んで `rewind` している（4KB のサイズガードあり）。この挙動はスペックで回帰テストしている。
- **test 環境**: 既存の認証リクエストスペックが sign_in を連投するため、test では既定で無効にし専用スペック内でのみ有効化している。
- **エラー形式**: front / mobile が原因判定に使えるよう、既存の `group_limit_exceeded` と同じく安定コード（`error`）と表示文言（`message`）を分離している。

## 既存機能への影響

- Rack::Cors はミドルウェアスタックの先頭（`insert_before 0`）にあるため、429 レスポンスにも CORS ヘッダが付く
- 対象外のエンドポイント（`validate_token` 等）は連投しても制限されないことをスペックで確認済み
- 既存の認証リクエストスペック 50 件がすべてパスすることを確認済み

## 確認方法

```bash
docker compose exec back bundle exec rspec spec/requests/rack_attack_spec.rb
docker compose exec back bundle exec rspec spec/requests/api/v1/auth/
docker compose exec back bundle exec rubocop
```

## 関連 PR

- front: ippei-shimizu/buzzbase_front#458（429 の文言表示）
- mobile: ippei-shimizu/buzzbase_mobile#184（429 の文言表示）
