### PR TITLE
Fix: OAuthサインインの並行リクエストでRecordNotUniqueが500になる問題を修正

### DIFF
--- a/app/controllers/api/v1/auth/apple_controller.rb
+++ b/app/controllers/api/v1/auth/apple_controller.rb
@@ -9,7 +9,7 @@ module Api
 
           apple_data = AppleAuthService.verify(params[:identity_token], full_name: full_name_params)
 
-          user = find_or_create_user(apple_data)
+          user = resolve_user(apple_data)
 
           return render json: { errors: ['アカウントが停止されています'] }, status: :unauthorized if user.suspended_at.present?
           return render json: { errors: ['アカウントが削除されています'] }, status: :unauthorized if user.deleted_at.present?
@@ -24,33 +24,21 @@ module Api
         rescue AppleAuthService::InvalidToken => e
           Rails.logger.error "Apple Auth Error: #{e.message}"
           render json: { errors: [e.message] }, status: :unauthorized
+        rescue ::Users::OauthResolver::EmailMissing
+          render json: { errors: ['メールアドレスが取得できませんでした'] }, status: :unauthorized
         rescue ActiveRecord::RecordInvalid => e
           render json: { errors: e.record.errors.full_messages }, status: :unprocessable_entity
         end
 
         private
 
-        def find_or_create_user(apple_data)
-          user = User.find_by(provider: 'apple', uid: apple_data[:uid])
-          return user if user
-
-          raise AppleAuthService::InvalidToken, 'メールアドレスが取得できませんでした' if apple_data[:email].blank?
-
-          user = User.find_by(email: apple_data[:email])
-          if user
-            attrs = { provider: 'apple', uid: apple_data[:uid] }
-            attrs[:confirmed_at] = Time.current if user.confirmed_at.blank?
-            user.update!(attrs)
-            return user
-          end
-
-          User.create!(
-            email: apple_data[:email],
+        def resolve_user(apple_data)
+          ::Users::OauthResolver.new(
             provider: 'apple',
             uid: apple_data[:uid],
-            name: apple_data[:name],
-            confirmed_at: Time.current
-          )
+            email: apple_data[:email],
+            name: apple_data[:name]
+          ).call
         end
 
         def full_name_params

--- a/app/controllers/api/v1/auth/apple_controller.rb
+++ b/app/controllers/api/v1/auth/apple_controller.rb
@@ -25,7 +25,9 @@ module Api
           Rails.logger.error "Apple Auth Error: #{e.message}"
           render json: { errors: [e.message] }, status: :unauthorized
         rescue ::Users::OauthResolver::EmailMissing
-          render json: { errors: ['メールアドレスが取得できませんでした'] }, status: :unauthorized
+          message = 'メールアドレスが取得できませんでした'
+          Rails.logger.error "Apple Auth Error: #{message}"
+          render json: { errors: [message] }, status: :unauthorized
         rescue ActiveRecord::RecordInvalid => e
           render json: { errors: e.record.errors.full_messages }, status: :unprocessable_entity
         end

--- a/app/controllers/api/v1/auth/google_controller.rb
+++ b/app/controllers/api/v1/auth/google_controller.rb
@@ -9,7 +9,7 @@ module Api
 
           google_data = GoogleAuthService.verify(params[:id_token])
 
-          user = find_or_create_user(google_data)
+          user = resolve_user(google_data)
 
           return render json: { errors: ['アカウントが停止されています'] }, status: :unauthorized if user.suspended_at.present?
           return render json: { errors: ['アカウントが削除されています'] }, status: :unauthorized if user.deleted_at.present?
@@ -23,31 +23,21 @@ module Api
           }, status: :ok
         rescue GoogleAuthService::InvalidToken => e
           render json: { errors: [e.message] }, status: :unauthorized
+        rescue ::Users::OauthResolver::EmailMissing
+          render json: { errors: ['メールアドレスが取得できませんでした'] }, status: :unauthorized
         rescue ActiveRecord::RecordInvalid => e
           render json: { errors: e.record.errors.full_messages }, status: :unprocessable_entity
         end
 
         private
 
-        def find_or_create_user(google_data)
-          user = User.find_by(provider: 'google', uid: google_data[:uid])
-          return user if user
-
-          user = User.find_by(email: google_data[:email])
-          if user
-            attrs = { provider: 'google', uid: google_data[:uid] }
-            attrs[:confirmed_at] = Time.current if user.confirmed_at.blank?
-            user.update!(attrs)
-            return user
-          end
-
-          User.create!(
-            email: google_data[:email],
+        def resolve_user(google_data)
+          ::Users::OauthResolver.new(
             provider: 'google',
             uid: google_data[:uid],
-            name: google_data[:name],
-            confirmed_at: Time.current
-          )
+            email: google_data[:email],
+            name: google_data[:name]
+          ).call
         end
       end
     end

--- a/app/services/users/oauth_resolver.rb
+++ b/app/services/users/oauth_resolver.rb
@@ -1,6 +1,7 @@
 module Users
   # Google / Apple の検証済みペイロードから User を冪等に解決する。
-  # provider+uid 一致 -> email 一致（provider/uid をリンク）-> 新規作成 の順に解決する。
+  # provider+uid 一致 -> email 一致（provider/uid をリンク）-> 新規作成 の順に解決し、
+  # 並行リクエストによる一意制約違反は勝者を引き直して吸収する。
   class OauthResolver
     # Apple は2回目以降のサインインで email を返さないため、uid で既存ユーザーを
     # 引けなかった場合にだけ投げる。呼び出し側で provider 固有の文言に翻訳する。
@@ -25,8 +26,17 @@ module Users
 
       raise EmailMissing if @email.blank?
 
-      linked_user = find_by_email
-      linked_user ? link_provider!(linked_user) : create_user!
+      # 一意制約違反は外側のトランザクションごと中断させるため、復旧クエリを流せるよう
+      # セーブポイント内で書き込む。
+      ActiveRecord::Base.transaction(requires_new: true) do
+        linked_user = find_by_email
+        linked_user ? link_provider!(linked_user) : create_user!
+      end
+    rescue ActiveRecord::RecordNotUnique => e
+      # 同一 email / uid が並行到達したときの敗者側。勝者は必ず provider+uid を満たすため
+      # そこから引き直す。引けないなら email / uid 以外の制約違反なので握り潰さず投げ直す。
+      Rails.logger.warn("OAuth sign-in race recovered: provider=#{@provider}")
+      find_by_provider_uid || find_by_email || raise(e)
     end
 
     private

--- a/app/services/users/oauth_resolver.rb
+++ b/app/services/users/oauth_resolver.rb
@@ -46,7 +46,13 @@ module Users
     end
 
     def find_by_email
-      User.find_by(email: @email)
+      User.find_by(email: normalized_email)
+    end
+
+    # devise が保存時に strip + downcase する（case_insensitive_keys / strip_whitespace_keys）ため、
+    # 検索キーも同じ形に揃えないと既存ユーザーを取り逃して重複 INSERT になる。
+    def normalized_email
+      @email.to_s.strip.downcase
     end
 
     def link_provider!(user)
@@ -58,7 +64,7 @@ module Users
 
     def create_user!
       User.create!(
-        email: @email,
+        email: normalized_email,
         provider: @provider,
         uid: @uid,
         name: @name,

--- a/app/services/users/oauth_resolver.rb
+++ b/app/services/users/oauth_resolver.rb
@@ -1,0 +1,59 @@
+module Users
+  # Google / Apple の検証済みペイロードから User を冪等に解決する。
+  # provider+uid 一致 -> email 一致（provider/uid をリンク）-> 新規作成 の順に解決する。
+  class OauthResolver
+    # Apple は2回目以降のサインインで email を返さないため、uid で既存ユーザーを
+    # 引けなかった場合にだけ投げる。呼び出し側で provider 固有の文言に翻訳する。
+    class EmailMissing < StandardError; end
+
+    # @param provider [String] 'google' または 'apple'
+    # @param uid [String] IDトークンの sub
+    # @param email [String, nil]
+    # @param name [String, nil]
+    def initialize(provider:, uid:, email:, name: nil)
+      @provider = provider
+      @uid = uid
+      @email = email
+      @name = name
+    end
+
+    # @return [User] 既存・リンク済み・新規作成のいずれかのユーザー
+    # @raise [EmailMissing] uid で引けず email も無い場合
+    def call
+      existing_user = find_by_provider_uid
+      return existing_user if existing_user
+
+      raise EmailMissing if @email.blank?
+
+      linked_user = find_by_email
+      linked_user ? link_provider!(linked_user) : create_user!
+    end
+
+    private
+
+    def find_by_provider_uid
+      User.find_by(provider: @provider, uid: @uid)
+    end
+
+    def find_by_email
+      User.find_by(email: @email)
+    end
+
+    def link_provider!(user)
+      attributes = { provider: @provider, uid: @uid }
+      attributes[:confirmed_at] = Time.current if user.confirmed_at.blank?
+      user.update!(attributes)
+      user
+    end
+
+    def create_user!
+      User.create!(
+        email: @email,
+        provider: @provider,
+        uid: @uid,
+        name: @name,
+        confirmed_at: Time.current
+      )
+    end
+  end
+end

--- a/spec/requests/api/v1/auth/apple_spec.rb
+++ b/spec/requests/api/v1/auth/apple_spec.rb
@@ -157,5 +157,44 @@ RSpec.describe 'Api::V1::Auth::Apple', type: :request do
         expect(response).to have_http_status(:ok)
       end
     end
+
+    context '同一メールのリクエストが並行して一意制約に負けた場合' do
+      let!(:winner) { create(:user, :apple, uid: apple_uid, email:, user_id: 'yamada') }
+
+      before do
+        # SELECT の後・INSERT の前に勝者がコミットした敗者側を再現する。
+        allow(User).to receive(:find_by).and_call_original
+        allow(User).to receive(:find_by).with(provider: 'apple', uid: apple_uid).and_return(nil, winner)
+        allow(User).to receive(:find_by).with(email:).and_return(nil)
+        allow(User).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique)
+      end
+
+      it '500ではなく勝者のユーザーでサインインさせる' do
+        expect do
+          post '/api/v1/apple_sign_in', params: { identity_token: 'valid_token' }
+        end.not_to change(User, :count)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.headers['access-token']).to be_present
+        expect(winner.reload.tokens.keys).to include(response.headers['client'])
+      end
+    end
+
+    context 'メールに大文字・前後の空白が含まれる場合' do
+      let(:apple_data) { { uid: apple_uid, email: '  Apple-User@privaterelay.appleid.com  ', name: '山田 太郎' } }
+      let!(:existing_user) do
+        create(:user, provider: 'email', uid: 'apple-user@privaterelay.appleid.com',
+                      email: 'apple-user@privaterelay.appleid.com', user_id: 'yamada')
+      end
+
+      it '正規化して既存ユーザーにリンクする' do
+        expect do
+          post '/api/v1/apple_sign_in', params: { identity_token: 'valid_token' }
+        end.not_to change(User, :count)
+
+        expect(response).to have_http_status(:ok)
+        expect(existing_user.reload.provider).to eq('apple')
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/auth/apple_spec.rb
+++ b/spec/requests/api/v1/auth/apple_spec.rb
@@ -163,6 +163,7 @@ RSpec.describe 'Api::V1::Auth::Apple', type: :request do
 
       before do
         # SELECT の後・INSERT の前に勝者がコミットした敗者側を再現する。
+        # resolver が provider+uid を2回引く前提に依存しているため、解決順序を変えたらここも直す。
         allow(User).to receive(:find_by).and_call_original
         allow(User).to receive(:find_by).with(provider: 'apple', uid: apple_uid).and_return(nil, winner)
         allow(User).to receive(:find_by).with(email:).and_return(nil)

--- a/spec/requests/api/v1/auth/google_spec.rb
+++ b/spec/requests/api/v1/auth/google_spec.rb
@@ -121,6 +121,17 @@ RSpec.describe 'Api::V1::Auth::Google', type: :request do
       end
     end
 
+    context 'メールが取得できなかった場合' do
+      let(:google_data) { { uid: google_uid, email: nil, name: nil } }
+
+      it '401を返す' do
+        post '/api/v1/google_sign_in', params: { id_token: 'valid_token' }
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body['errors']).to include('メールアドレスが取得できませんでした')
+      end
+    end
+
     context '同一メールのリクエストが並行して一意制約に負けた場合' do
       let!(:winner) { create(:user, :google, uid: google_uid, email:, user_id: 'yamada') }
 

--- a/spec/requests/api/v1/auth/google_spec.rb
+++ b/spec/requests/api/v1/auth/google_spec.rb
@@ -137,6 +137,7 @@ RSpec.describe 'Api::V1::Auth::Google', type: :request do
 
       before do
         # SELECT の後・INSERT の前に勝者がコミットした敗者側を再現する。
+        # resolver が provider+uid を2回引く前提に依存しているため、解決順序を変えたらここも直す。
         allow(User).to receive(:find_by).and_call_original
         allow(User).to receive(:find_by).with(provider: 'google', uid: google_uid).and_return(nil, winner)
         allow(User).to receive(:find_by).with(email:).and_return(nil)

--- a/spec/requests/api/v1/auth/google_spec.rb
+++ b/spec/requests/api/v1/auth/google_spec.rb
@@ -120,5 +120,41 @@ RSpec.describe 'Api::V1::Auth::Google', type: :request do
         expect(deleted_user.reload.tokens).to be_empty
       end
     end
+
+    context '同一メールのリクエストが並行して一意制約に負けた場合' do
+      let!(:winner) { create(:user, :google, uid: google_uid, email:, user_id: 'yamada') }
+
+      before do
+        # SELECT の後・INSERT の前に勝者がコミットした敗者側を再現する。
+        allow(User).to receive(:find_by).and_call_original
+        allow(User).to receive(:find_by).with(provider: 'google', uid: google_uid).and_return(nil, winner)
+        allow(User).to receive(:find_by).with(email:).and_return(nil)
+        allow(User).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique)
+      end
+
+      it '500ではなく勝者のユーザーでサインインさせる' do
+        expect do
+          post '/api/v1/google_sign_in', params: { id_token: 'valid_token' }
+        end.not_to change(User, :count)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.headers['access-token']).to be_present
+        expect(winner.reload.tokens.keys).to include(response.headers['client'])
+      end
+    end
+
+    context 'メールに大文字・前後の空白が含まれる場合' do
+      let(:google_data) { { uid: google_uid, email: '  Google-User@Example.COM  ', name: '山田 太郎' } }
+      let!(:existing_user) { create(:user, provider: 'email', uid: email, email:, user_id: 'yamada') }
+
+      it '正規化して既存ユーザーにリンクする' do
+        expect do
+          post '/api/v1/google_sign_in', params: { id_token: 'valid_token' }
+        end.not_to change(User, :count)
+
+        expect(response).to have_http_status(:ok)
+        expect(existing_user.reload.provider).to eq('google')
+      end
+    end
   end
 end

--- a/spec/services/users/oauth_resolver_spec.rb
+++ b/spec/services/users/oauth_resolver_spec.rb
@@ -1,0 +1,165 @@
+require 'rails_helper'
+
+RSpec.describe Users::OauthResolver do
+  let(:uid) { '110000000000000000001' }
+  let(:email) { 'google-user@example.com' }
+
+  describe '#call' do
+    context 'provider と uid が一致する既存ユーザーがいる場合' do
+      let!(:existing_user) { create(:user, :google, uid:, email:) }
+
+      it '既存ユーザーを返し新規作成しない' do
+        expect do
+          expect(described_class.new(provider: 'google', uid:, email:, name: '山田 太郎').call).to eq(existing_user)
+        end.not_to change(User, :count)
+      end
+    end
+
+    context 'email が一致する既存ユーザーがいる場合' do
+      it 'provider と uid をリンクして返す' do
+        existing_user = create(:user, provider: 'email', uid: email, email:)
+
+        expect do
+          described_class.new(provider: 'google', uid:, email:, name: '山田 太郎').call
+        end.not_to change(User, :count)
+
+        expect(existing_user.reload).to have_attributes(provider: 'google', uid:)
+      end
+
+      it '未確認ユーザーなら confirmed_at を埋める' do
+        existing_user = create(:user, :unconfirmed, provider: 'email', uid: email, email:)
+
+        described_class.new(provider: 'google', uid:, email:, name: '山田 太郎').call
+
+        expect(existing_user.reload.confirmed_at).to be_present
+      end
+
+      it '確認済みユーザーの confirmed_at は上書きしない' do
+        confirmed_at = 3.days.ago
+        existing_user = create(:user, provider: 'email', uid: email, email:, confirmed_at:)
+
+        described_class.new(provider: 'google', uid:, email:, name: '山田 太郎').call
+
+        expect(existing_user.reload.confirmed_at).to be_within(1.second).of(confirmed_at)
+      end
+    end
+
+    context '該当するユーザーがいない場合' do
+      it 'confirmed_at 付きで新規作成する' do
+        expect do
+          described_class.new(provider: 'google', uid:, email:, name: '山田 太郎').call
+        end.to change(User, :count).by(1)
+
+        expect(User.last).to have_attributes(provider: 'google', uid:, email:, name: '山田 太郎')
+        expect(User.last.confirmed_at).to be_present
+      end
+
+      it 'apple でも同じ経路で作成される' do
+        described_class.new(provider: 'apple', uid:, email:, name: '山田 太郎').call
+
+        expect(User.last).to have_attributes(provider: 'apple', uid:)
+      end
+    end
+
+    context 'email に大文字・前後の空白が含まれる場合' do
+      it '正規化して既存ユーザーを引き当てる' do
+        existing_user = create(:user, provider: 'email', uid: email, email:)
+
+        expect do
+          described_class.new(provider: 'google', uid:, email: '  Google-User@Example.COM  ', name: '山田 太郎').call
+        end.not_to change(User, :count)
+
+        expect(existing_user.reload.provider).to eq('google')
+      end
+
+      it '新規作成時は正規化した email で保存する' do
+        described_class.new(provider: 'google', uid:, email: '  Google-User@Example.COM  ', name: '山田 太郎').call
+
+        expect(User.last.email).to eq(email)
+      end
+    end
+
+    context 'email が空の場合' do
+      it 'uid でも引けなければ EmailMissing を投げる' do
+        expect do
+          described_class.new(provider: 'apple', uid:, email: nil, name: nil).call
+        end.to raise_error(described_class::EmailMissing)
+      end
+
+      it 'uid で引ければ既存ユーザーを返す' do
+        existing_user = create(:user, :apple, uid:, email:)
+
+        expect(described_class.new(provider: 'apple', uid:, email: nil, name: nil).call).to eq(existing_user)
+      end
+    end
+
+    context '同一 email が並行到達して一意制約に負けた場合' do
+      it 'INSERT が競合しても勝者のユーザーを返す' do
+        winner = create(:user, :google, uid:, email:)
+        # SELECT の後・INSERT の前に勝者がコミットした敗者側を再現する。
+        allow(User).to receive(:find_by).and_return(nil, nil, winner)
+        allow(User).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique)
+
+        expect(described_class.new(provider: 'google', uid:, email:, name: '山田 太郎').call).to eq(winner)
+      end
+
+      it 'リンクの UPDATE が競合しても勝者のユーザーを返す' do
+        # 勝者が先に provider+uid を確保し、こちらは別レコードへのリンクに失敗する状況。
+        winner = create(:user, :google, uid:, email: 'winner@example.com')
+        linked_user = create(:user, provider: 'email', uid: email, email:)
+        allow(User).to receive(:find_by).and_return(nil, linked_user, winner)
+        allow(linked_user).to receive(:update!).and_raise(ActiveRecord::RecordNotUnique)
+
+        expect(described_class.new(provider: 'google', uid:, email:, name: '山田 太郎').call).to eq(winner)
+      end
+
+      it '勝者を引き直せない場合は例外をそのまま投げる' do
+        allow(User).to receive(:find_by).and_return(nil)
+        allow(User).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique)
+
+        expect do
+          described_class.new(provider: 'google', uid:, email:, name: '山田 太郎').call
+        end.to raise_error(ActiveRecord::RecordNotUnique)
+      end
+    end
+
+    context '同一ユーザーのサインインが実際に同時実行されたとき' do
+      # 別スレッドの実コネクションから同じ email 行を奪い合わせるため、テスト用トランザクションを外す。
+      self.use_transactional_tests = false
+
+      after { ActiveRecord::Base.connection.execute('TRUNCATE TABLE users CASCADE') }
+
+      # 同じ provider / uid / email の解決を同じタイミングで走らせ、発生した例外を集めて返す。
+      def resolve_concurrently(count, uid:, email:)
+        errors = Queue.new
+        ready = Queue.new
+        start = Queue.new
+        threads = Array.new(count) do
+          Thread.new do
+            ActiveRecord::Base.connection_pool.with_connection do
+              ready << true
+              start.pop
+              described_class.new(provider: 'google', uid:, email:, name: '山田 太郎').call
+            rescue StandardError => e
+              errors << e
+            end
+          end
+        end
+        count.times { ready.pop }
+        count.times { start << true }
+        threads.each(&:join)
+        Array.new(errors.size) { errors.pop }
+      end
+
+      it '一意制約の競合から復旧し、ユーザーを1件だけ作って全リクエストが成功する' do
+        errors = resolve_concurrently(4, uid:, email:)
+
+        aggregate_failures do
+          # 失敗時に原因を追えるよう、件数ではなく例外の内容を突き合わせる。
+          expect(errors.map { |e| "#{e.class}: #{e.message}" }).to be_empty
+          expect(User.where(email:).count).to eq(1)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

本番 Sentry `BUZZBASE-BACKEND-1J` で `POST /api/v1/google_sign_in` が `ActiveRecord::RecordNotUnique (PG::UniqueViolation: index_users_on_email)` により 500 を返した問題を修正する。

モバイルの axios timeout(15秒)でユーザーが再タップし、同一 email のサインインリクエストが並行到達すると、`find_by` -> `create!` の間に相手方の INSERT がコミットされて一意制約に衝突する。devise_token_auth 1.2.2 が `will_save_change_to_email?` を常に false に上書きしているため devise の `validates_uniqueness_of :email` は走らず（開発環境で実測確認済み）、重複は必ず DB 制約で `RecordNotUnique` になり、`rescue ActiveRecord::RecordInvalid` にも ApplicationController の `rescue_from` にも該当せず 500 になっていた。

Fixes ippei-shimizu/buzzbase#551

## 変更内容

- `app/services/users/oauth_resolver.rb` を新設し、Google / Apple で重複していた `find_or_create_user` を移設した
  - 書き込みをセーブポイント（`transaction(requires_new: true)`）に閉じ込め、`RecordNotUnique` を rescue して勝者を provider+uid から引き直す
  - 引き直せない場合は元の例外を再送出するので、`user_id` / `confirmation_token` など別の一意制約違反は従来どおり 500 + Sentry で検知できる
  - `find_by(email:)` を保存時の devise 正規化（strip + downcase）に揃え、大文字混じり email で既存ユーザーを取り逃す経路を塞いだ
- `google_controller.rb` / `apple_controller.rb` は resolver を呼ぶだけにした
- 競合復旧・email 正規化のスペックを追加した（実スレッドで4並列サインインさせる回帰テストを含む）

## 挙動の変更点

- **Google で email が取得できなかった場合のレスポンスが 422 から 401 に変わる**。従来は `create!` が devise の presence 検証で落ちて 422 だった。Google は email スコープ必須のため実発生しないが、Apple と同じ「メールアドレスが取得できませんでした」の 401 に統一した
- あわせて、従来 Google 側で email が nil のとき `find_by(email: nil)` が `WHERE email IS NULL` にマッチして無関係なユーザーを引く可能性があったが、`EmailMissing` ガードで塞がれた
- email 正規化により、以前は新規作成されていた大文字混じり email が既存ユーザーにマッチするようになる。対象が削除済み / 停止中ユーザーだった場合は 200 ではなく 401 になる（より正しい挙動）

## 動作確認

- `docker compose exec back bundle exec rspec` -> 1828 examples, 0 failures
- `docker compose exec back bundle exec rspec spec/requests/api/v1/auth spec/services/users` -> 68 examples, 0 failures
- `docker compose exec back bundle exec rubocop app/services/users app/controllers/api/v1/auth spec/services/users spec/requests/api/v1/auth` -> no offenses
- 既存の `google_spec.rb` / `apple_spec.rb` は 1 行も書き換えず（追記のみ）にパスすることを回帰の合格条件とした

## スコープ外

- バックエンドの遅延そのもの（Heroku dyno / DB）の調査・改善
- mobile 側の連打抑止・タイムアウト値の見直し
